### PR TITLE
feat: add AntdvNextResolver for unplugin-vue-components

### DIFF
--- a/packages/auto-import-resolver/README.md
+++ b/packages/auto-import-resolver/README.md
@@ -1,0 +1,127 @@
+# Antdv-next Auto Import Resolver
+
+English | [简体中文](./README.zh-CN.md)
+
+`@antdv-next/auto-import-resolver` is a resolver for [unplugin-vue-components](https://github.com/unplugin/unplugin-vue-components) that enables on-demand importing of Antdv-next components.
+
+### Features
+
+- Supports `Vite`, `Webpack`, `Rspack`, `Vue CLI`, `Rollup`, `esbuild`, and more.
+- Automatically imports the corresponding CSS styles for the components.
+- Supports SSR (Server-Side Rendering).
+
+### Installation
+
+```shell
+# via npm
+npm i @antdv-next/auto-import-resolver unplugin-vue-components unplugin-auto-import -D
+
+# via yarn
+yarn add @antdv-next/auto-import-resolver unplugin-vue-components unplugin-auto-import -D
+
+# via pnpm
+pnpm add @antdv-next/auto-import-resolver unplugin-vue-components unplugin-auto-import -D
+
+# via Bun
+bun add @antdv-next/auto-import-resolver unplugin-vue-components unplugin-auto-import -D
+```
+
+## Usage
+
+### Vite
+
+```ts
+// vite.config.ts
+import Components from 'unplugin-vue-components/vite';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+export default defineConfig({
+  plugins: [
+    Components({
+      resolvers: [AntdvNextResolver()],
+    }),
+  ],
+});
+```
+
+### Rollup
+
+```ts
+// rollup.config.js
+import Components from 'unplugin-vue-components/rollup';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+export default {
+  plugins: [
+    Components({
+      resolvers: [AntdvNextResolver()],
+    }),
+  ],
+};
+```
+
+### Webpack
+
+```ts
+// webpack.config.js
+import Components from 'unplugin-vue-components/webpack';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+module.exports = {
+  plugins: [
+    Components({
+      resolvers: [AntdvNextResolver()],
+    }),
+  ],
+};
+```
+
+### Rspack
+
+```ts
+// rspack.config.js
+import Components from 'unplugin-vue-components/rspack';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+module.exports = {
+  plugins: [
+    Components({
+      resolvers: [AntdvNextResolver()],
+    }),
+  ],
+};
+```
+
+### Vue CLI
+
+```ts
+// vue.config.js
+import Components from 'unplugin-vue-components/webpack';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+module.exports = {
+  configureWebpack: {
+    plugins: [
+      Components({
+        resolvers: [AntdvNextResolver()],
+      }),
+    ],
+  },
+};
+```
+
+### esbuild
+
+```ts
+// esbuild.config.js
+import Components from 'unplugin-vue-components/esbuild';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+build({
+  plugins: [
+    Components({
+      resolvers: [AntdvNextResolver()],
+    }),
+  ],
+});
+```

--- a/packages/auto-import-resolver/README.zh-CN.md
+++ b/packages/auto-import-resolver/README.zh-CN.md
@@ -1,0 +1,128 @@
+# Antdv-next Auto Import Resolver
+
+[English](./README.md) | 简体中文
+
+`@antdv-next/auto-import-resolver` 是 [unplugin-vue-components](https://github.com/unplugin/unplugin-vue-components) 的一个解析器，用于实现 Antdv-next 按需引入。
+
+### 特性
+
+- 支持 `Vite`, `Webpack`, `Rspack`, `Vue CLI`, `Rollup`, `esbuild` 等
+- 支持自动引入组件对应的 CSS 样式
+- 支持 SSR（服务端渲染）
+
+### 安装
+
+```shell
+# via npm
+npm i @antdv-next/auto-import-resolver unplugin-vue-components unplugin-auto-import -D
+
+# via yarn
+yarn add @antdv-next/auto-import-resolver unplugin-vue-components unplugin-auto-import -D
+
+# via pnpm
+pnpm add @antdv-next/auto-import-resolver unplugin-vue-components unplugin-auto-import -D
+
+# via Bun
+bun add @antdv-next/auto-import-resolver unplugin-vue-components unplugin-auto-import -D
+```
+
+## 使用
+
+### Vite
+
+```ts
+// vite.config.ts
+import Components from 'unplugin-vue-components/vite';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+export default defineConfig({
+  plugins: [
+    Components({
+      resolvers: [AntdvNextResolver()],
+    }),
+  ],
+});
+```
+
+### Rollup
+
+```ts
+// rollup.config.js
+import Components from 'unplugin-vue-components/rollup';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+export default {
+  plugins: [
+    Components({
+      resolvers: [AntdvNextResolver()],
+    }),
+  ],
+};
+```
+
+### Webpack
+
+```ts
+// webpack.config.js
+import Components from 'unplugin-vue-components/webpack';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+module.exports = {
+  plugins: [
+    Components({
+      resolvers: [AntdvNextResolver()],
+    }),
+  ],
+};
+```
+
+### Rspack
+
+```ts
+// rspack.config.js
+import Components from 'unplugin-vue-components/rspack';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+module.exports = {
+  plugins: [
+    Components({
+      resolvers: [AntdvNextResolver()],
+    }),
+  ],
+};
+```
+
+### Vue CLI
+
+```ts
+// vue.config.js
+import Components from 'unplugin-vue-components/webpack';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+module.exports = {
+  configureWebpack: {
+    plugins: [
+      Components({
+        resolvers: [AntdvNextResolver()],
+      }),
+    ],
+  },
+};
+```
+
+### esbuild
+
+```ts
+// esbuild.config.js
+import Components from 'unplugin-vue-components/esbuild';
+import { AntdvNextResolver } from '@antdv-next/auto-import-resolver';
+
+build({
+  plugins: [
+    Components({
+      resolvers: [AntdvNextResolver()],
+    }),
+  ],
+});
+```
+

--- a/packages/auto-import-resolver/package.json
+++ b/packages/auto-import-resolver/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@antdv-next/auto-import-resolver",
+  "type": "module",
+  "version": "1.0.0-beta.2",
+  "description": "antdv-next auto import resolver based on unplugin-vue-components",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antdv-next/antdv-next.git"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown"
+  },
+  "devDependencies": {
+    "@vue/tsconfig": "^0.8.1",
+    "tsdown": "^0.20.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/auto-import-resolver/src/index.ts
+++ b/packages/auto-import-resolver/src/index.ts
@@ -1,0 +1,55 @@
+export interface AntdvNextResolverOptions {
+  /**
+   * exclude components that do not require automatic import
+   *
+   * @default []
+   */
+  exclude?: string[]
+  /**
+   * resolve `antdv-next' icons
+   *
+   * requires package `@antdv-next/icons`
+   *
+   * @default false
+   */
+  resolveIcons?: boolean
+  /**
+   * rename package
+   *
+   * @default 'antdv-next'
+   */
+  packageName?: string
+  /**
+   * customize prefix of component
+   * @default 'A'
+   */
+  prefix?: string
+}
+/**
+ * Resolver for Ant Design Vue
+ */
+export function AntdvNextResolver(options: AntdvNextResolverOptions = {}) {
+  const originPrefix = options.prefix ?? 'A'
+  return {
+    type: 'component' as const,
+    resolve: (name: string) => {
+      if (options.resolveIcons && name.match(/(Outlined|Filled|TwoTone)$/)) {
+        return {
+          name,
+          from: '@antdv-next/icons',
+        }
+      }
+
+      const [compName, prefix] = [name.slice(originPrefix.length), name.slice(0, originPrefix.length)]
+      if (prefix === originPrefix && !options?.exclude?.includes(compName)) {
+        const { packageName = 'antdv-next' } = options
+        const path = `${packageName}`
+        return {
+          name: compName,
+          from: path,
+          sideEffects: '',
+        }
+      }
+    },
+  }
+}

--- a/packages/auto-import-resolver/tsconfig.json
+++ b/packages/auto-import-resolver/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "compilerOptions": {
+    /* Linting */
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/auto-import-resolver/tsdown.config.ts
+++ b/packages/auto-import-resolver/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  dts: true,
+  format: 'es',
+  entry: [
+    'src/index.ts',
+  ],
+  external: [
+    'unocss',
+  ],
+})


### PR DESCRIPTION
unplugin-vue-components no longer accept new resolvers，we should create a package to publish own resolvers.
https://github.com/unplugin/unplugin-vue-components/blob/main/src/core/resolvers/_READ_BEFORE_CONTRIBUTE.md