### PR TITLE
docs: direction switching

### DIFF
--- a/playground/src/composables/local-store.ts
+++ b/playground/src/composables/local-store.ts
@@ -5,3 +5,5 @@ export const localeStore = useStorage<'zh-CN' | 'en-US'>('locale', 'zh-CN')
 export const darkModeStore = useStorage<boolean>('dark-mode', false)
 
 export const compactModeStore = useStorage<boolean>('compact-mode', false)
+
+export const directionStore = useStorage<'ltr' | 'rtl'>('direction', 'ltr')

--- a/playground/src/layouts/base/header.vue
+++ b/playground/src/layouts/base/header.vue
@@ -14,7 +14,7 @@ import { useAppStore } from '@/stores/app.ts'
 
 const route = useRoute()
 const appStore = useAppStore()
-const { headerKey, locale } = storeToRefs(appStore)
+const { headerKey, locale, direction } = storeToRefs(appStore)
 const versions = ref([
   {
     label: version,
@@ -88,6 +88,14 @@ function changeLocale(value: 1 | 2) {
 const localeValue = computed(() => {
   return locale.value === 'zh-CN' ? 1 : 2
 })
+
+const directionValue = computed(() => {
+  return direction.value === 'ltr' ? 1 : 2
+})
+
+function changeDirection(value: 1 | 2) {
+  appStore.toggleDirection(value === 1 ? 'ltr' : 'rtl')
+}
 </script>
 
 <template>
@@ -106,8 +114,8 @@ const localeValue = computed(() => {
         </h1>
       </a-col>
       <a-col :xxl="20" :xl="19" :lg="18" :md="18" :sm="0" :xs="0">
-        <div class="ant-doc-header-right flex items-center pr-[var(--ant-padding)] gap-sm h-full">
-          <div class="b-l-1 b-l-solid b-l-black/6 flex items-center m-0" style="flex: auto">
+        <div class="ant-doc-header-right flex items-center gap-sm h-full" :class="[direction === 'ltr' ? 'pr-(--ant-padding)' : 'pl-(--ant-padding)']">
+          <div class="flex items-center m-0" :class="[direction === 'ltr' ? 'b-l-1 b-l-solid b-l-black/6' : 'b-r-1 b-r-solid b-r-black/6']" style="flex: auto">
             <SearchIcon class="ant-doc-search-bar-svg" />
             <input v-model="searchValue" class="ant-doc-search-bar-input" placeholder="输入关键字搜索...">
           </div>
@@ -148,11 +156,12 @@ const localeValue = computed(() => {
             </SwitchBtn>
             <SwitchBtn
               key="direction"
-              :value="1"
+              :value="directionValue"
               tooltip1="LTR"
               tooltip2="RTL"
               pure
               aria-label="RTL Switch Button"
+              @click="changeDirection"
             >
               <template #label1>
                 <DirectionIcon class="w-20px" direction="ltr" />

--- a/playground/src/layouts/base/index.vue
+++ b/playground/src/layouts/base/index.vue
@@ -10,7 +10,7 @@ import 'dayjs/locale/zh-cn'
 import 'dayjs/locale/en'
 
 const appStore = useAppStore()
-const { locale, darkMode, compactMode } = storeToRefs(appStore)
+const { locale, darkMode, compactMode, direction } = storeToRefs(appStore)
 
 const antdLocale = shallowRef(cn)
 watch(
@@ -43,6 +43,7 @@ const zeroRuntime = import.meta.env.PROD === true
   <a-style-provider>
     <a-config-provider
       :locale="antdLocale"
+      :direction="direction"
       :theme="{
         algorithm,
         zeroRuntime,

--- a/playground/src/layouts/base/main.vue
+++ b/playground/src/layouts/base/main.vue
@@ -8,7 +8,7 @@ import { useAppStore } from '@/stores/app'
 
 const { isMobile } = useMobile()
 const appStore = useAppStore()
-const { siderMenus, siderKey, siderOpenKeys, siderLocales, locale } = storeToRefs(appStore)
+const { siderMenus, siderKey, siderOpenKeys, siderLocales, locale, direction } = storeToRefs(appStore)
 const { anchorItems } = useDocPage()
 const router = useRouter()
 const handleChangeMenu: MenuEmits['click'] = (info) => {
@@ -56,7 +56,7 @@ const handleChangeMenu: MenuEmits['click'] = (info) => {
       <section class="ant-doc-main-section">
         <a-anchor :items="anchorItems" class="ant-doc-main-sider-anchor" :offset-top="70" :affix="false" />
       </section>
-      <article class="pl-48px pr-164px pb-32px mt--16px">
+      <article class="pb-32px mt--16px" :class="[direction === 'ltr' ? 'pl-48px pr-164px' : 'pr-48px pl-164px']">
         <slot />
       </article>
     </a-col>

--- a/playground/src/stores/app.ts
+++ b/playground/src/stores/app.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { compactModeStore, darkModeStore, localeStore } from '@/composables/local-store'
+import { compactModeStore, darkModeStore, directionStore, localeStore } from '@/composables/local-store'
 import { menusMap } from '@/config/menu'
 
 export interface AppState {
@@ -9,6 +9,7 @@ export interface AppState {
   locale: 'zh-CN' | 'en-US'
   darkMode: boolean
   compactMode: boolean
+  direction: 'ltr' | 'rtl'
 }
 
 export const useAppStore = defineStore('app', {
@@ -20,6 +21,7 @@ export const useAppStore = defineStore('app', {
       locale: localeStore.value,
       darkMode: darkModeStore.value ?? false,
       compactMode: compactModeStore.value ?? false,
+      direction: directionStore.value ?? 'ltr',
     }
   },
   actions: {
@@ -43,6 +45,10 @@ export const useAppStore = defineStore('app', {
     toggleCompactMode(compactMode?: boolean) {
       this.compactMode = compactMode || !this.compactMode
       compactModeStore.value = this.compactMode
+    },
+    toggleDirection(direction?: 'ltr' | 'rtl') {
+      this.direction = direction || (this.direction === 'ltr' ? 'rtl' : 'ltr')
+      directionStore.value = this.direction
     },
   },
   getters: {


### PR DESCRIPTION
<img width="2559" height="1347" alt="image" src="https://github.com/user-attachments/assets/967ea236-6028-46c7-970c-b237d495a24b" />

添加文档方向切换(右侧布局极丑，并且难以阅读，不知道为什么antd会有这样的功能)