### PR TITLE
feat: 添加 prepare 脚本

### DIFF
--- a/packages/cssinjs/package.json
+++ b/packages/cssinjs/package.json
@@ -34,6 +34,7 @@
     "test:watch": "vitest watch",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "prepare": "pnpm build",
     "prepublish": "pnpm build",
     "build": "tsdown",
     "dev": "tsdown --watch",


### PR DESCRIPTION
在 fork 仓库之后，pnpm i 安装依赖，不会自动构建 cssinjs 包，代码中的许多导入类似于 import type { CSSObject } from '@antdv-next/cssinjs' 会报出 ts 错误。
如果这个添加是多余的，请关闭这个 pr