### PR TITLE
docs(drawer): fix markdown syntax for closable prop in API section

### DIFF
--- a/playground/src/pages/components/drawer/index.en-US.md
+++ b/playground/src/pages/components/drawer/index.en-US.md
@@ -49,7 +49,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | --- | --- | --- | --- | --- |
 | afterOpenChange | Callback after the animation ends when switching drawers | (open: boolean) => void | - | - |
 | classes | Customize class for each semantic structure inside the Drawer component. Supports object or function. | DrawerClassNamesType | - | - |
-| closable | Whether to show a close button. The position can be configured with `placement` | boolean \| { closeIcon?: VueNode; disabled?: boolean; placement?: 'start' \| 'end' } | true | - |
+| closable | Whether to show a close button. The position can be configured with `placement` | boolean \| \{ closeIcon?: VueNode, disabled?: boolean, placement?: 'start' \| 'end' \} | true | - |
 | closeIcon | Custom close icon | VueNode | - | - |
 | ~~destroyOnClose~~ | Whether to unmount child components on closing drawer or not | boolean | false | - |
 | destroyOnHidden | Whether to unmount child components on closing drawer or not | boolean | false | - |

--- a/playground/src/pages/components/drawer/index.zh-CN.md
+++ b/playground/src/pages/components/drawer/index.zh-CN.md
@@ -50,7 +50,7 @@ demo:
 | --- | --- | --- | --- | --- |
 | afterOpenChange | 切换抽屉时动画结束后的回调 | (open: boolean) => void | - | - |
 | classes | 用于自定义 Drawer 组件内部各语义化结构的 class，支持对象或函数 | DrawerClassNamesType | - | - |
-| closable | 是否展示关闭按钮，可通过 `placement` 设置位置 | boolean \| { closeIcon?: VueNode; disabled?: boolean; placement?: 'start' \| 'end' } | true | - |
+| closable | 是否展示关闭按钮，可通过 `placement` 设置位置 | boolean \| \{ closeIcon?: VueNode, disabled?: boolean, placement?: 'start' \| 'end' \} | true | - |
 | closeIcon | 自定义关闭图标 | VueNode | - | - |
 | ~~destroyOnClose~~ | 关闭时销毁 Drawer 里的子元素 | boolean | false | - |
 | destroyOnHidden | 关闭时销毁 Drawer 里的子元素 | boolean | false | - |


### PR DESCRIPTION
fix markdown syntax for closable prop in API section.