### PR TITLE
test(breadcrumb): add unit tests and semantic DOM tests for Breadcrumb

### DIFF
--- a/packages/antdv-next/src/breadcrumb/tests/Breadcrumb.semantic.test.tsx
+++ b/packages/antdv-next/src/breadcrumb/tests/Breadcrumb.semantic.test.tsx
@@ -1,0 +1,76 @@
+import type { BreadcrumbProps } from '..'
+import { describe, expect, it, vi } from 'vitest'
+import Breadcrumb from '..'
+import { mount } from '../../../../../tests/utils'
+
+describe('breadcrumb.Semantic', () => {
+  it('should support classNames and styles', () => {
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        items: [
+          { title: 'Home' },
+          { title: 'Current' },
+        ],
+        classes: { root: 'custom-root', item: 'custom-item', separator: 'custom-separator' },
+        styles: { root: { margin: '10px' }, item: { padding: '5px' }, separator: { color: 'red' } },
+      },
+    })
+
+    const rootElement = wrapper.find('.ant-breadcrumb')
+    expect(rootElement.classes()).toContain('custom-root')
+    expect(rootElement.attributes('style')).toContain('margin: 10px')
+
+    const itemElement = wrapper.find('.ant-breadcrumb-item')
+    expect(itemElement.classes()).toContain('custom-item')
+    expect(itemElement.attributes('style')).toContain('padding: 5px')
+
+    const separatorElement = wrapper.find('.ant-breadcrumb-separator')
+    expect(separatorElement.classes()).toContain('custom-separator')
+    expect(separatorElement.attributes('style')).toContain('color: red')
+  })
+
+  it('should support classNames and styles as functions', async () => {
+    const classNamesFn = vi.fn((info: { props: BreadcrumbProps }) => {
+      if (info.props.separator === '>') {
+        return { root: 'arrow-breadcrumb', separator: 'arrow-separator' }
+      }
+      return { root: 'default-breadcrumb', separator: 'default-separator' }
+    })
+
+    const stylesFn = vi.fn((info: { props: BreadcrumbProps }) => {
+      if (info.props.separator === '>') {
+        return { root: { backgroundColor: '#f0f0f0' } }
+      }
+      return { root: { backgroundColor: '#ffffff' } }
+    })
+
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        items: [
+          { title: 'Home' },
+          { title: 'Current' },
+        ],
+        separator: '>',
+        classes: classNamesFn,
+        styles: stylesFn,
+      },
+    })
+
+    expect(classNamesFn).toHaveBeenCalled()
+    expect(stylesFn).toHaveBeenCalled()
+
+    const rootElement = wrapper.find('.ant-breadcrumb')
+    expect(rootElement.classes()).toContain('arrow-breadcrumb')
+
+    const separatorElement = wrapper.find('.ant-breadcrumb-separator')
+    expect(separatorElement.classes()).toContain('arrow-separator')
+
+    await wrapper.setProps({ separator: '/' })
+
+    const updatedRootElement = wrapper.find('.ant-breadcrumb')
+    expect(updatedRootElement.classes()).toContain('default-breadcrumb')
+
+    const updatedSeparatorElement = wrapper.find('.ant-breadcrumb-separator')
+    expect(updatedSeparatorElement.classes()).toContain('default-separator')
+  })
+})

--- a/packages/antdv-next/src/breadcrumb/tests/Breadcrumb.test.tsx
+++ b/packages/antdv-next/src/breadcrumb/tests/Breadcrumb.test.tsx
@@ -1,0 +1,196 @@
+import { HomeOutlined } from '@antdv-next/icons'
+import { describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import Breadcrumb from '..'
+import rtlTest from '../../../../../tests/shared/rtlTest'
+import { mount } from '../../../../../tests/utils'
+
+describe('breadcrumb', () => {
+  rtlTest(() => h(Breadcrumb, { items: [{ title: 'Home' }, { title: 'Current' }] }))
+
+  it('should render basic items', () => {
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        items: [
+          { title: 'Home' },
+          { title: 'Application' },
+          { title: 'Current' },
+        ],
+      },
+    })
+    expect(wrapper.find('.ant-breadcrumb').exists()).toBe(true)
+    expect(wrapper.findAll('.ant-breadcrumb-link').length).toBe(3)
+  })
+
+  it('should render separator', () => {
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        items: [
+          { title: 'Home' },
+          { title: 'Current' },
+        ],
+      },
+    })
+    expect(wrapper.find('.ant-breadcrumb-separator').exists()).toBe(true)
+    expect(wrapper.find('.ant-breadcrumb-separator').text()).toBe('/')
+  })
+
+  it('should render custom separator', () => {
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        separator: '>',
+        items: [
+          { title: 'Home' },
+          { title: 'Current' },
+        ],
+      },
+    })
+    expect(wrapper.find('.ant-breadcrumb-separator').text()).toBe('>')
+  })
+
+  it('should render item with href as link', () => {
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        items: [
+          { title: 'Home', href: '/' },
+          { title: 'Current' },
+        ],
+      },
+    })
+    const link = wrapper.find('a')
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toBe('/')
+  })
+
+  it('should render item with path', () => {
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        items: [
+          { title: 'Home', path: '/home' },
+          { title: 'Detail', path: '/detail' },
+        ],
+      },
+    })
+    const links = wrapper.findAll('a')
+    expect(links.length).toBe(2)
+    expect(links[0].attributes('href')).toBe('#/home')
+    expect(links[1].attributes('href')).toBe('#/home/detail')
+  })
+
+  it('should support onClick on items', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        items: [
+          { title: 'Home', onClick },
+          { title: 'Current' },
+        ],
+      },
+    })
+    await wrapper.find('.ant-breadcrumb-link').trigger('click')
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('should render with BreadcrumbItem children', () => {
+    const wrapper = mount(() => (
+      <Breadcrumb>
+        <Breadcrumb.Item>Home</Breadcrumb.Item>
+        <Breadcrumb.Item>Application</Breadcrumb.Item>
+      </Breadcrumb>
+    ))
+    expect(wrapper.find('.ant-breadcrumb').exists()).toBe(true)
+  })
+
+  it('should render with custom BreadcrumbSeparator', () => {
+    const wrapper = mount(() => (
+      <Breadcrumb>
+        <Breadcrumb.Item>Home</Breadcrumb.Item>
+        <Breadcrumb.Separator>-</Breadcrumb.Separator>
+        <Breadcrumb.Item>Current</Breadcrumb.Item>
+      </Breadcrumb>
+    ))
+    expect(wrapper.text()).toContain('-')
+  })
+
+  it('should render with icon in title', () => {
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        items: [
+          { title: h(HomeOutlined) },
+          { title: 'Current' },
+        ],
+      },
+    })
+    expect(wrapper.find('.anticon-home').exists()).toBe(true)
+  })
+
+  it('should support itemRender', () => {
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        items: [
+          { title: 'Home', href: '/' },
+          { title: 'Current' },
+        ],
+        itemRender: ({ title, href }: any) => {
+          return href ? h('a', { href, class: 'custom-link' }, title) : h('span', title)
+        },
+      },
+    })
+    expect(wrapper.find('.custom-link').exists()).toBe(true)
+  })
+
+  it('should render item with menu dropdown', () => {
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        items: [
+          { title: 'Home' },
+          {
+            title: 'Application',
+            menu: {
+              items: [
+                { key: '1', label: 'App1' },
+                { key: '2', label: 'App2' },
+              ],
+            },
+          },
+          { title: 'Current' },
+        ],
+      },
+    })
+    expect(wrapper.find('.ant-breadcrumb').exists()).toBe(true)
+    expect(wrapper.findAll('.ant-breadcrumb-link').length).toBe(3)
+  })
+
+  it('should support data attributes', () => {
+    const wrapper = mount(() => (
+      <Breadcrumb data-test="breadcrumb-test" items={[{ title: 'Home' }]} />
+    ))
+    expect(wrapper.find('[data-test="breadcrumb-test"]').exists()).toBe(true)
+  })
+
+  it('should match snapshot', () => {
+    const wrapper = mount(() => (
+      <Breadcrumb
+        items={[
+          { title: 'Home', href: '/' },
+          { title: 'Application', href: '/app' },
+          { title: 'Current' },
+        ]}
+      />
+    ))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('should match separator snapshot', () => {
+    const wrapper = mount(() => (
+      <Breadcrumb
+        separator=">"
+        items={[
+          { title: 'Home' },
+          { title: 'Current' },
+        ]}
+      />
+    ))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/packages/antdv-next/src/breadcrumb/tests/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/antdv-next/src/breadcrumb/tests/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1,0 +1,62 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`breadcrumb > rtl render > component should be rendered correctly in RTL direction 1`] = `
+<div
+  data-v-app=""
+>
+  <nav
+    class="ant-breadcrumb [object Object]-rtl css-var-root"
+  >
+    <ol>
+      <li
+        class="ant-breadcrumb-item"
+      >
+        <span
+          class="ant-breadcrumb-link"
+        >
+          Home
+        </span>
+      </li>
+      <li
+        class="ant-breadcrumb-separator"
+      >
+        /
+      </li>
+      <li
+        class="ant-breadcrumb-item"
+      >
+        <span
+          class="ant-breadcrumb-link"
+        >
+          Current
+        </span>
+      </li>
+      <!---->
+    </ol>
+  </nav>
+</div>
+`;
+
+exports[`breadcrumb > should match separator snapshot 1`] = `
+"<nav class="ant-breadcrumb css-var-root">
+  <ol>
+    <li class="ant-breadcrumb-item"><span class="ant-breadcrumb-link">Home</span></li>
+    <li class="ant-breadcrumb-separator">&gt;</li>
+    <li class="ant-breadcrumb-item"><span class="ant-breadcrumb-link">Current</span></li>
+    <!---->
+  </ol>
+</nav>"
+`;
+
+exports[`breadcrumb > should match snapshot 1`] = `
+"<nav class="ant-breadcrumb css-var-root">
+  <ol>
+    <li class="ant-breadcrumb-item"><a class="ant-breadcrumb-link" href="/">Home</a></li>
+    <li class="ant-breadcrumb-separator">/</li>
+    <li class="ant-breadcrumb-item"><a class="ant-breadcrumb-link" href="/app">Application</a></li>
+    <li class="ant-breadcrumb-separator">/</li>
+    <li class="ant-breadcrumb-item"><span class="ant-breadcrumb-link">Current</span></li>
+    <!---->
+  </ol>
+</nav>"
+`;

--- a/packages/antdv-next/src/breadcrumb/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/breadcrumb/tests/__snapshots__/demo.test.tsx.snap
@@ -1,0 +1,1188 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`breadcrumb demo > renders _semantic correctly 1`] = `
+<div
+  class="semantic-preview-container"
+  data-v-0e8f6da1=""
+>
+  <div
+    class="ant-row css-var-root semantic-preview-row"
+    data-v-0e8f6da1=""
+  >
+    <div
+      class="ant-col ant-col-16 css-var-root semantic-preview-col"
+      data-v-0e8f6da1=""
+    >
+      <nav
+        class="ant-breadcrumb semantic-mark-root css-var-v-0"
+      >
+        <ol>
+          <li
+            class="ant-breadcrumb-item semantic-mark-item"
+          >
+            <a
+              class="ant-breadcrumb-link"
+              href=""
+            >
+              <span
+                aria-label="home"
+                class="anticon anticon-home"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="home"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 00-44.4 0L77.5 505a63.9 63.9 0 00-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0018.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"
+                  />
+                </svg>
+              </span>
+            </a>
+          </li>
+          <li
+            class="ant-breadcrumb-separator semantic-mark-separator"
+          >
+            /
+          </li>
+          <li
+            class="ant-breadcrumb-item semantic-mark-item"
+          >
+            <a
+              class="ant-breadcrumb-link"
+              href=""
+            >
+              <span
+                aria-label="user"
+                class="anticon anticon-user"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="user"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+                  />
+                </svg>
+              </span>
+              <span>
+                Application List
+              </span>
+            </a>
+          </li>
+          <li
+            class="ant-breadcrumb-separator semantic-mark-separator"
+          >
+            /
+          </li>
+          <li
+            class="ant-breadcrumb-item semantic-mark-item"
+          >
+            <span
+              class="ant-breadcrumb-link"
+            >
+              Application
+            </span>
+          </li>
+          <!---->
+        </ol>
+      </nav>
+    </div>
+    <div
+      class="ant-col ant-col-8 css-var-root"
+      data-v-0e8f6da1=""
+    >
+      <ul
+        class="semantic-list"
+        data-v-0e8f6da1=""
+      >
+        <li
+          class="semantic-list-item"
+          data-v-0e8f6da1=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-0e8f6da1=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-0e8f6da1=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  root
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-0e8f6da1=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Root element with text color, font size, icon size and other basic styles, using flex layout with ordered list
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-0e8f6da1=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-0e8f6da1=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-0e8f6da1=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  item
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-0e8f6da1=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Item element with text color, link color transitions, hover effects, padding, border-radius, height, and margin styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-0e8f6da1=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-0e8f6da1=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-0e8f6da1=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  separator
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-0e8f6da1=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Separator element with margin and color styles for the divider
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`breadcrumb demo > renders basic correctly 1`] = `
+<nav
+  class="ant-breadcrumb css-var-root"
+>
+  <ol>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        Home
+      </span>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        Application Center
+      </a>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        Application List
+      </a>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        An Application
+      </span>
+    </li>
+    <!---->
+  </ol>
+</nav>
+`;
+
+exports[`breadcrumb demo > renders debug-routes correctly 1`] = `
+<nav
+  class="ant-breadcrumb css-var-root"
+>
+  <ol>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href="#/home"
+      >
+        Home
+      </a>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-overlay-link ant-dropdown-trigger"
+      >
+        <a
+          class="ant-breadcrumb-link"
+          href="#/home/user"
+        >
+          User
+        </a>
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <!---->
+    </li>
+    <!---->
+  </ol>
+</nav>
+`;
+
+exports[`breadcrumb demo > renders overlay correctly 1`] = `
+<nav
+  class="ant-breadcrumb css-var-root"
+>
+  <ol>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        Antdv Next
+      </span>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        Component
+      </a>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-overlay-link ant-dropdown-trigger"
+      >
+        <a
+          class="ant-breadcrumb-link"
+          href=""
+        >
+          General
+        </a>
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <!---->
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        Button
+      </span>
+    </li>
+    <!---->
+  </ol>
+</nav>
+`;
+
+exports[`breadcrumb demo > renders separator correctly 1`] = `
+<nav
+  class="ant-breadcrumb css-var-root"
+>
+  <ol>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        Home
+      </span>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      &gt;
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        Application Center
+      </a>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      &gt;
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        Application List
+      </a>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      &gt;
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        An Application
+      </span>
+    </li>
+    <!---->
+  </ol>
+</nav>
+`;
+
+exports[`breadcrumb demo > renders separator-component correctly 1`] = `
+<nav
+  class="ant-breadcrumb css-var-root"
+>
+  <ol>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        Location
+      </span>
+    </li>
+    <!---->
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      :
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        Application Center
+      </a>
+    </li>
+    <!---->
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        Application List
+      </a>
+    </li>
+    <!---->
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        An Application
+      </span>
+    </li>
+    <!---->
+  </ol>
+</nav>
+`;
+
+exports[`breadcrumb demo > renders style-class correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+  data-v-5c61aa3b=""
+>
+  <nav
+    aria-label="Breadcrumb with Object"
+    class="ant-breadcrumb demo-breadcrumb-root css-var-root"
+    data-v-5c61aa3b=""
+    style="border: 1px solid rgb(240, 240, 240); padding: 8px; border-radius: 4px;"
+  >
+    <ol>
+      <li
+        class="ant-breadcrumb-item demo-breadcrumb-item"
+        style="color: rgb(24, 144, 255);"
+      >
+        <span
+          class="ant-breadcrumb-link"
+        >
+          Antdv Next
+        </span>
+      </li>
+      <li
+        class="ant-breadcrumb-separator demo-breadcrumb-separator"
+        style="color: rgba(0, 0, 0, 0.45);"
+      >
+        /
+      </li>
+      <li
+        class="ant-breadcrumb-item demo-breadcrumb-item"
+        style="color: rgb(24, 144, 255);"
+      >
+        <span
+          class="ant-breadcrumb-link"
+        >
+          Component
+        </span>
+      </li>
+      <!---->
+    </ol>
+  </nav>
+  <nav
+    aria-label="Breadcrumb with Function"
+    class="ant-breadcrumb demo-breadcrumb-root css-var-root"
+    data-v-5c61aa3b=""
+    style="border: 1px solid rgb(245, 239, 255); padding: 8px; border-radius: 4px;"
+  >
+    <ol>
+      <li
+        class="ant-breadcrumb-item demo-breadcrumb-item"
+        style="color: rgb(143, 135, 241);"
+      >
+        <span
+          class="ant-breadcrumb-link"
+        >
+          Antdv Next
+        </span>
+      </li>
+      <li
+        class="ant-breadcrumb-separator demo-breadcrumb-separator"
+      >
+        /
+      </li>
+      <li
+        class="ant-breadcrumb-item demo-breadcrumb-item"
+        style="color: rgb(143, 135, 241);"
+      >
+        <span
+          class="ant-breadcrumb-link"
+        >
+          Component
+        </span>
+      </li>
+      <li
+        class="ant-breadcrumb-separator demo-breadcrumb-separator"
+      >
+        /
+      </li>
+      <li
+        class="ant-breadcrumb-item demo-breadcrumb-item"
+        style="color: rgb(143, 135, 241);"
+      >
+        <span
+          class="ant-breadcrumb-link"
+        >
+          Breadcrumb
+        </span>
+      </li>
+      <!---->
+    </ol>
+  </nav>
+</div>
+`;
+
+exports[`breadcrumb demo > renders with-icon correctly 1`] = `
+<nav
+  class="ant-breadcrumb css-var-root"
+>
+  <ol>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        <span
+          aria-label="home"
+          class="anticon anticon-home"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="home"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 00-44.4 0L77.5 505a63.9 63.9 0 00-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0018.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"
+            />
+          </svg>
+        </span>
+      </a>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        <span>
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+          <span>
+             Application List
+          </span>
+        </span>
+      </a>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        Application
+      </span>
+    </li>
+    <!---->
+  </ol>
+</nav>
+`;
+
+exports[`breadcrumb demo > renders with-params correctly 1`] = `
+<nav
+  class="ant-breadcrumb css-var-root"
+>
+  <ol>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        Users
+      </span>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        1
+      </a>
+    </li>
+    <!---->
+  </ol>
+</nav>
+`;
+
+exports[`breadcrumb demo > renders withIcon correctly 1`] = `
+<nav
+  class="ant-breadcrumb css-var-root"
+>
+  <ol>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        <span
+          aria-label="home"
+          class="anticon anticon-home"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="home"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 00-44.4 0L77.5 505a63.9 63.9 0 00-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0018.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"
+            />
+          </svg>
+        </span>
+      </a>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        <span
+          aria-label="user"
+          class="anticon anticon-user"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="user"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+            />
+          </svg>
+        </span>
+        <span>
+          Application List
+        </span>
+      </a>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        Application
+      </span>
+    </li>
+    <!---->
+  </ol>
+</nav>
+`;
+
+exports[`breadcrumb demo > renders withParams correctly 1`] = `
+<nav
+  class="ant-breadcrumb css-var-root"
+>
+  <ol>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <span
+        class="ant-breadcrumb-link"
+      >
+        Users
+      </span>
+    </li>
+    <li
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        1
+      </a>
+    </li>
+    <!---->
+  </ol>
+</nav>
+`;

--- a/packages/antdv-next/src/breadcrumb/tests/demo.test.tsx
+++ b/packages/antdv-next/src/breadcrumb/tests/demo.test.tsx
@@ -1,0 +1,3 @@
+import demoTest from '/@tests/shared/demoTest'
+
+demoTest('breadcrumb')


### PR DESCRIPTION
## Summary
- Add unit tests for Breadcrumb component
- Add semantic DOM tests for Breadcrumb (root, item, separator)
- Add demo snapshot tests

## Test Files
- `Breadcrumb.test.tsx` - 15 test cases
- `Breadcrumb.semantic.test.tsx` - 2 semantic DOM test cases
- `demo.test.tsx` - 11 demo snapshot tests

## Test Coverage

- Basic rendering (items, separator, custom separator)
- Link rendering (href, path with accumulated paths)
- onClick callback
- BreadcrumbItem / BreadcrumbSeparator children usage
- Icon in title
- itemRender custom render
- Menu dropdown
- Data attributes
- Semantic DOM (classes/styles as object and function, covering root + item + separator)
- RTL direction
- Snapshots