### PR TITLE
test(button): add unit tests and semantic DOM tests for Button

### DIFF
--- a/packages/antdv-next/src/button/tests/Button.semantic.test.tsx
+++ b/packages/antdv-next/src/button/tests/Button.semantic.test.tsx
@@ -1,0 +1,120 @@
+import type { BaseButtonProps } from '..'
+import { SearchOutlined } from '@antdv-next/icons'
+import { describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import Button from '..'
+import { mount } from '../../../../../tests/utils'
+import ConfigProvider from '../../config-provider'
+
+describe('button.Semantic', () => {
+  it('should support classNames and styles', () => {
+    const wrapper = mount(Button, {
+      props: {
+        icon: h(SearchOutlined),
+        classes: { root: 'custom-root', icon: 'custom-icon', content: 'custom-content' },
+        styles: { root: { margin: '10px' }, icon: { fontSize: '20px' }, content: { padding: '5px' } },
+      },
+      slots: {
+        default: () => 'Test',
+      },
+    })
+
+    const rootElement = wrapper.find('.ant-btn')
+    expect(rootElement.classes()).toContain('custom-root')
+    expect(rootElement.attributes('style')).toContain('margin: 10px')
+
+    const iconElement = wrapper.find('.ant-btn-icon')
+    expect(iconElement.classes()).toContain('custom-icon')
+    expect(iconElement.attributes('style')).toContain('font-size: 20px')
+  })
+
+  it('should support classNames and styles as functions', async () => {
+    const classNamesFn = vi.fn((info: { props: BaseButtonProps }) => {
+      if (info.props.type === 'primary') {
+        return { root: 'primary-button' }
+      }
+      return { root: 'default-button' }
+    })
+
+    const stylesFn = vi.fn((info: { props: BaseButtonProps }) => {
+      if (info.props.type === 'primary') {
+        return { root: { backgroundColor: '#1890ff' } }
+      }
+      return { root: { backgroundColor: '#ffffff' } }
+    })
+
+    const wrapper = mount(Button, {
+      props: {
+        type: 'primary',
+        classes: classNamesFn,
+        styles: stylesFn,
+      },
+      slots: {
+        default: () => 'Test',
+      },
+    })
+
+    expect(classNamesFn).toHaveBeenCalled()
+    expect(stylesFn).toHaveBeenCalled()
+
+    const rootElement = wrapper.find('.ant-btn')
+    expect(rootElement.classes()).toContain('primary-button')
+
+    await wrapper.setProps({ type: 'default' })
+
+    const updatedRootElement = wrapper.find('.ant-btn')
+    expect(updatedRootElement.classes()).toContain('default-button')
+  })
+
+  it('should merge context and component classNames and styles', () => {
+    const contextClassNames = {
+      root: 'context-root',
+      icon: 'context-icon',
+    }
+    const contextStyles = {
+      root: { margin: '10px' },
+      icon: { fontSize: '16px' },
+    }
+    const componentClassNames = {
+      root: 'component-root',
+      content: 'component-content',
+    }
+    const componentStyles = {
+      root: { padding: '5px' },
+    }
+
+    const wrapper = mount(ConfigProvider, {
+      props: {
+        button: {
+          classes: contextClassNames,
+          styles: contextStyles,
+        },
+      },
+      slots: {
+        default: () => (
+          <Button
+            icon={h(SearchOutlined)}
+            classes={componentClassNames}
+            styles={componentStyles}
+          >
+            Test
+          </Button>
+        ),
+      },
+    })
+
+    const rootElement = wrapper.find('.ant-btn')
+    const iconElement = wrapper.find('.ant-btn-icon')
+
+    expect(rootElement.classes()).toContain('context-root')
+    expect(rootElement.classes()).toContain('component-root')
+
+    const rootStyle = rootElement.attributes('style')
+    expect(rootStyle).toContain('margin: 10px')
+    expect(rootStyle).toContain('padding: 5px')
+
+    expect(iconElement.classes()).toContain('context-icon')
+    const iconStyle = iconElement.attributes('style')
+    expect(iconStyle).toContain('font-size: 16px')
+  })
+})

--- a/packages/antdv-next/src/button/tests/Button.test.tsx
+++ b/packages/antdv-next/src/button/tests/Button.test.tsx
@@ -1,0 +1,265 @@
+import { SearchOutlined } from '@antdv-next/icons'
+import { describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import Button from '..'
+import rtlTest from '../../../../../tests/shared/rtlTest'
+import { mount } from '../../../../../tests/utils'
+
+describe('button', () => {
+  rtlTest(() => h(Button, null, { default: () => 'test' }))
+
+  it('should render default button', () => {
+    const wrapper = mount(Button, {
+      slots: {
+        default: () => 'Button',
+      },
+    })
+    expect(wrapper.find('.ant-btn').exists()).toBe(true)
+    expect(wrapper.text()).toBe('Button')
+  })
+
+  it('should render all type variants with correct classes', () => {
+    const typeMap: Record<string, string> = {
+      primary: 'ant-btn-variant-solid',
+      default: 'ant-btn-variant-outlined',
+      dashed: 'ant-btn-variant-dashed',
+      link: 'ant-btn-variant-link',
+      text: 'ant-btn-variant-text',
+    }
+    Object.entries(typeMap).forEach(([type, expectedClass]) => {
+      const wrapper = mount(Button, {
+        props: { type: type as any },
+        slots: { default: () => type },
+      })
+      expect(wrapper.find(`.${expectedClass}`).exists()).toBe(true)
+    })
+  })
+
+  it('should render different sizes', () => {
+    const sizes = ['large', 'middle', 'small'] as const
+    sizes.forEach((size) => {
+      const wrapper = mount(Button, {
+        props: { size },
+        slots: { default: () => size },
+      })
+      if (size === 'large') {
+        expect(wrapper.find('.ant-btn-lg').exists()).toBe(true)
+      }
+      else if (size === 'small') {
+        expect(wrapper.find('.ant-btn-sm').exists()).toBe(true)
+      }
+      else {
+        expect(wrapper.find('.ant-btn-lg').exists()).toBe(false)
+        expect(wrapper.find('.ant-btn-sm').exists()).toBe(false)
+      }
+    })
+  })
+
+  it('should render disabled button', () => {
+    const onClick = vi.fn()
+    const wrapper = mount(Button, {
+      props: { disabled: true, onClick },
+      slots: { default: () => 'Disabled' },
+    })
+    expect(wrapper.find('.ant-btn').attributes('disabled')).toBeDefined()
+    wrapper.find('.ant-btn').trigger('click')
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('should render loading button', () => {
+    const wrapper = mount(Button, {
+      props: { loading: true },
+      slots: { default: () => 'Loading' },
+    })
+    expect(wrapper.find('.ant-btn-loading').exists()).toBe(true)
+  })
+
+  it('should render custom loading icon via slot', () => {
+    const wrapper = mount(Button, {
+      props: { loading: true },
+      slots: {
+        loadingIcon: () => h('span', { class: 'custom-loading' }, 'Loading...'),
+        default: () => 'Button',
+      },
+    })
+    expect(wrapper.find('.custom-loading').exists()).toBe(true)
+  })
+
+  it('should handle icon placement end with loading state', () => {
+    const wrapper = mount(Button, {
+      props: {
+        loading: true,
+        iconPlacement: 'end',
+      },
+      slots: { default: () => 'Loading' },
+    })
+    expect(wrapper.find('.ant-btn-icon-end').exists()).toBe(true)
+    expect(wrapper.find('.ant-btn-loading').exists()).toBe(true)
+  })
+
+  it('should not show loading immediately with delay', () => {
+    const wrapper = mount(() => (
+      <Button loading={{ delay: 200 }}>Loading</Button>
+    ))
+    // With delay, loading class should not appear immediately
+    expect(wrapper.find('.ant-btn-loading').exists()).toBe(false)
+  })
+
+  it('should auto focus when autoFocus is true', () => {
+    const wrapper = mount(Button, {
+      props: { autoFocus: true },
+      slots: { default: () => 'Focus' },
+      attachTo: document.body,
+    })
+    expect(document.activeElement).toBe(wrapper.find('button').element)
+    wrapper.unmount()
+  })
+
+  it('should render icon', () => {
+    const wrapper = mount(Button, {
+      props: {
+        icon: h(SearchOutlined),
+      },
+      slots: { default: () => 'Search' },
+    })
+    expect(wrapper.find('.anticon-search').exists()).toBe(true)
+  })
+
+  it('should render icon slot', () => {
+    const wrapper = mount(Button, {
+      slots: {
+        icon: () => h(SearchOutlined),
+        default: () => 'Search',
+      },
+    })
+    expect(wrapper.find('.anticon-search').exists()).toBe(true)
+  })
+
+  it('should support icon placement end', () => {
+    const wrapper = mount(Button, {
+      props: {
+        icon: h(SearchOutlined),
+        iconPlacement: 'end',
+      },
+      slots: { default: () => 'Search' },
+    })
+    expect(wrapper.find('.ant-btn-icon-end').exists()).toBe(true)
+  })
+
+  it('should render circle shape', () => {
+    const wrapper = mount(Button, {
+      props: {
+        shape: 'circle',
+        icon: h(SearchOutlined),
+      },
+    })
+    expect(wrapper.find('.ant-btn-circle').exists()).toBe(true)
+  })
+
+  it('should render round shape', () => {
+    const wrapper = mount(Button, {
+      props: { shape: 'round' },
+      slots: { default: () => 'Round' },
+    })
+    expect(wrapper.find('.ant-btn-round').exists()).toBe(true)
+  })
+
+  it('should render block button', () => {
+    const wrapper = mount(Button, {
+      props: { block: true },
+      slots: { default: () => 'Block' },
+    })
+    expect(wrapper.find('.ant-btn-block').exists()).toBe(true)
+  })
+
+  it('should render ghost button', () => {
+    const wrapper = mount(Button, {
+      props: { ghost: true, type: 'primary' },
+      slots: { default: () => 'Ghost' },
+    })
+    expect(wrapper.find('.ant-btn-background-ghost').exists()).toBe(true)
+  })
+
+  it('should render danger button', () => {
+    const wrapper = mount(Button, {
+      props: { danger: true },
+      slots: { default: () => 'Danger' },
+    })
+    expect(wrapper.find('.ant-btn-dangerous').exists()).toBe(true)
+  })
+
+  it('should render as anchor when href is provided', () => {
+    const wrapper = mount(Button, {
+      props: { href: 'https://example.com', target: '_blank' },
+      slots: { default: () => 'Link' },
+    })
+    expect(wrapper.find('a').exists()).toBe(true)
+    expect(wrapper.find('a').attributes('href')).toBe('https://example.com')
+    expect(wrapper.find('a').attributes('target')).toBe('_blank')
+  })
+
+  it('should render with htmlType', () => {
+    const wrapper = mount(Button, {
+      props: { htmlType: 'submit' },
+      slots: { default: () => 'Submit' },
+    })
+    expect(wrapper.find('button').attributes('type')).toBe('submit')
+  })
+
+  it('should trigger click event', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(Button, {
+      props: { onClick },
+      slots: { default: () => 'Click' },
+    })
+    await wrapper.find('.ant-btn').trigger('click')
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('should not trigger click when loading', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(Button, {
+      props: { loading: true, onClick },
+      slots: { default: () => 'Loading' },
+    })
+    await wrapper.find('.ant-btn').trigger('click')
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('should render color and variant', () => {
+    const wrapper = mount(Button, {
+      props: { color: 'danger', variant: 'solid' },
+      slots: { default: () => 'Danger Solid' },
+    })
+    expect(wrapper.find('.ant-btn-color-dangerous').exists()).toBe(true)
+    expect(wrapper.find('.ant-btn-variant-solid').exists()).toBe(true)
+  })
+
+  it('should support data attributes', () => {
+    const wrapper = mount(() => (
+      <Button data-test="btn-test">Test</Button>
+    ))
+    expect(wrapper.find('[data-test="btn-test"]').exists()).toBe(true)
+  })
+
+  it('should match primary snapshot', () => {
+    const wrapper = mount(() => (
+      <Button type="primary" size="large">Primary</Button>
+    ))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('should match icon button snapshot', () => {
+    const wrapper = mount(() => (
+      <Button type="primary" shape="circle" icon={h(SearchOutlined)} />
+    ))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('should match loading snapshot', () => {
+    const wrapper = mount(() => (
+      <Button type="primary" loading={true}>Loading</Button>
+    ))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/packages/antdv-next/src/button/tests/__snapshots__/Button.test.tsx.snap
+++ b/packages/antdv-next/src/button/tests/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`button > rtl render > component should be rendered correctly in RTL direction 1`] = `
+<div
+  data-v-app=""
+>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-rtl"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+      test
+    </span>
+    <!---->
+  </button>
+</div>
+`;
+
+exports[`button > should match icon button snapshot 1`] = `
+"<button type="button" class="ant-btn css-var-root ant-btn-circle ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only"><span class="ant-btn-icon"><span role="img" aria-label="search" class="anticon anticon-search"><svg data-icon="search" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896" focusable="false"><path d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"></path></svg></span></span>
+  <!---->
+  <!---->
+</button>"
+`;
+
+exports[`button > should match loading snapshot 1`] = `
+"<button type="button" class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-loading">
+  <transition-stub name="ant-btn-loading-icon-motion" appear="false" persisted="false" css="true"><span class="ant-btn-icon ant-btn-loading-icon"><span role="img" aria-label="loading" class="anticon anticon-loading anticon-spin"><svg data-icon="loading" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="0 0 1024 1024" focusable="false"><path d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"></path></svg></span></span></transition-stub><span>Loading</span>
+  <!---->
+</button>"
+`;
+
+exports[`button > should match primary snapshot 1`] = `
+"<button type="button" class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-lg">
+  <transition-stub name="ant-btn-loading-icon-motion" appear="false" persisted="false" css="true">
+    <!---->
+  </transition-stub><span>Primary</span>
+  <!---->
+</button>"
+`;

--- a/packages/antdv-next/src/button/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/button/tests/__snapshots__/demo.test.tsx.snap
@@ -1,0 +1,3825 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`button demo > renders _semantic correctly 1`] = `
+<div
+  class="semantic-preview-container"
+  data-v-0e8f6da1=""
+>
+  <div
+    class="ant-row css-var-root semantic-preview-row"
+    data-v-0e8f6da1=""
+  >
+    <div
+      class="ant-col ant-col-16 css-var-root semantic-preview-col"
+      data-v-0e8f6da1=""
+    >
+      <button
+        class="ant-btn css-var-v-0 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid semantic-mark-root"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon semantic-mark-icon"
+        >
+          <span
+            aria-label="ant-design"
+            class="anticon anticon-ant-design"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="ant-design"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M716.3 313.8c19-18.9 19-49.7 0-68.6l-69.9-69.9.1.1c-18.5-18.5-50.3-50.3-95.3-95.2-21.2-20.7-55.5-20.5-76.5.5L80.9 474.2a53.84 53.84 0 000 76.4L474.6 944a54.14 54.14 0 0076.5 0l165.1-165c19-18.9 19-49.7 0-68.6a48.7 48.7 0 00-68.7 0l-125 125.2c-5.2 5.2-13.3 5.2-18.5 0L189.5 521.4c-5.2-5.2-5.2-13.3 0-18.5l314.4-314.2c.4-.4.9-.7 1.3-1.1 5.2-4.1 12.4-3.7 17.2 1.1l125.2 125.1c19 19 49.8 19 68.7 0zM408.6 514.4a106.3 106.2 0 10212.6 0 106.3 106.2 0 10-212.6 0zm536.2-38.6L821.9 353.5c-19-18.9-49.8-18.9-68.7.1a48.4 48.4 0 000 68.6l83 82.9c5.2 5.2 5.2 13.3 0 18.5l-81.8 81.7a48.4 48.4 0 000 68.6 48.7 48.7 0 0068.7 0l121.8-121.7a53.93 53.93 0 00-.1-76.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="semantic-mark-content"
+        >
+           Antdv Next 
+        </span>
+        <!---->
+      </button>
+    </div>
+    <div
+      class="ant-col ant-col-8 css-var-root"
+      data-v-0e8f6da1=""
+    >
+      <ul
+        class="semantic-list"
+        data-v-0e8f6da1=""
+      >
+        <li
+          class="semantic-list-item"
+          data-v-0e8f6da1=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-0e8f6da1=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-0e8f6da1=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  root
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-0e8f6da1=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Root element with comprehensive button styling including border, background, padding, border-radius, box-shadow, transitions, cursor, font-weight, alignment, and layout properties
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-0e8f6da1=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-0e8f6da1=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-0e8f6da1=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  icon
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-0e8f6da1=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Icon element with font-size, color inheritance, and SVG style reset for proper icon display
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-0e8f6da1=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-0e8f6da1=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-0e8f6da1=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  content
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-0e8f6da1=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-0e8f6da1=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-0e8f6da1=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-0e8f6da1=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Content element that wraps button text with typography styles including nowrap, text-align center, and Chinese character spacing optimization
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`button demo > renders basic correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Primary Button 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+      Default Button
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Dashed Button 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Text Button 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-link ant-btn-color-link ant-btn-variant-link"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Link Button 
+    </span>
+    <!---->
+  </button>
+</div>
+`;
+
+exports[`button demo > renders block correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  style="width: 100%;"
+>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-block"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Primary 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-block"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Default 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed ant-btn-block"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Dashed 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-block"
+    disabled=""
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       disabled 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-block"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       text 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-block"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Link 
+    </span>
+    <!---->
+  </button>
+</div>
+`;
+
+exports[`button demo > renders chinese-space correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       确定 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       确定 
+    </span>
+    <!---->
+  </button>
+</div>
+`;
+
+exports[`button demo > renders color-variant correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  >
+    <div
+      class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-solid ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Solid 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Outlined 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-dashed ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Dashed 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-filled ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Filled 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Text 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-link ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Link 
+        </span>
+        <!---->
+      </button>
+    </div>
+    <div
+      class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Solid 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-primary ant-btn-variant-outlined ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Outlined 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-primary ant-btn-variant-dashed ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Dashed 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-primary ant-btn-variant-filled ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Filled 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-primary ant-btn-variant-text ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Text 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Link 
+        </span>
+        <!---->
+      </button>
+    </div>
+    <div
+      class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-dangerous ant-btn-variant-solid ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Solid 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Outlined 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-dangerous ant-btn-variant-dashed ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Dashed 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-dangerous ant-btn-variant-filled ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Filled 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-dangerous ant-btn-variant-text ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Text 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-dangerous ant-btn-variant-link ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Link 
+        </span>
+        <!---->
+      </button>
+    </div>
+    <div
+      class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-pink ant-btn-variant-solid ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Solid 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-pink ant-btn-variant-outlined ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Outlined 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-pink ant-btn-variant-dashed ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Dashed 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-pink ant-btn-variant-filled ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Filled 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-pink ant-btn-variant-text ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Text 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-pink ant-btn-variant-link ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Link 
+        </span>
+        <!---->
+      </button>
+    </div>
+    <div
+      class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-purple ant-btn-variant-solid ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Solid 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-purple ant-btn-variant-outlined ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Outlined 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-purple ant-btn-variant-dashed ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Dashed 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-purple ant-btn-variant-filled ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Filled 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-purple ant-btn-variant-text ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Text 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-purple ant-btn-variant-link ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Link 
+        </span>
+        <!---->
+      </button>
+    </div>
+    <div
+      class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-cyan ant-btn-variant-solid ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Solid 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-cyan ant-btn-variant-outlined ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Outlined 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-cyan ant-btn-variant-dashed ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Dashed 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-cyan ant-btn-variant-filled ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Filled 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-cyan ant-btn-variant-text ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Text 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-cyan ant-btn-variant-link ant-btn-sm"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Link 
+        </span>
+        <!---->
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`button demo > renders component-token correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+>
+  <div
+    class="ant-flex css-var-v-0 ant-flex-wrap-wrap ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-v-0 ant-btn-text ant-btn-color-default ant-btn-variant-text"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         TEXT 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-0 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         CONTAINED 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-0 ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+        OUTLINED
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-v-0 ant-flex-wrap-wrap ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-v-0 ant-btn-text ant-btn-color-default ant-btn-variant-text"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         TEXT 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-0 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         CONTAINED 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-1 ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         OUTLINED 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-v-0 ant-flex-wrap-wrap ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-v-0 ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         TEXT 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-0 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         CONTAINED 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-0 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         OUTLINED 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-v-2 ant-flex-wrap-wrap ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-v-2 ant-btn-text ant-btn-color-default ant-btn-variant-text"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Text 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-2 ant-btn-link ant-btn-color-link ant-btn-variant-link"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Link 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-2 ant-btn-default ant-btn-color-primary ant-btn-variant-text"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Primary Text 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-2 ant-btn-default ant-btn-color-primary ant-btn-variant-link"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Primary Link 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-v-3 ant-flex-align-start ant-flex-gap-small ant-flex-vertical"
+  >
+    <button
+      class="ant-btn css-var-v-3 ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+        Default Button
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-3 ant-btn-round ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Default Button 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-3 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Default Button 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-3 ant-btn-round ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Default Button 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-3 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Default Button 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-v-3 ant-btn-round ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Default Button 
+      </span>
+      <!---->
+    </button>
+  </div>
+</div>
+`;
+
+exports[`button demo > renders danger correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Primary 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Default 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-dashed ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-dashed"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Dashed 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-text ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-text"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Text 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-link ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-link"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Link 
+    </span>
+    <!---->
+  </button>
+</div>
+`;
+
+exports[`button demo > renders disabled correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-flex-start ant-flex-gap-small ant-flex-vertical"
+>
+  <div
+    class="ant-flex css-var-root ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Primary 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Primary(disabled) 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+        Default
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Default(disabled) 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Dashed 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Dashed(disabled) 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Text 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Text(disabled) 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-link ant-btn-color-link ant-btn-variant-link"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Link 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-link ant-btn-color-link ant-btn-variant-link"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Link(disabled) 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-gap-small"
+  >
+    <a
+      aria-disabled="false"
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      href="https://ant.design/index-cn"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Href Primary 
+      </span>
+    </a>
+    <a
+      aria-disabled="true"
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-disabled"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Href Primary(disabled) 
+      </span>
+    </a>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Danger Default 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Danger Default(disabled) 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-text ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-text"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Danger Text 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-text ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-text"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Danger Text(disabled) 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-link ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-link"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Danger Link 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-link ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-link"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Danger Link(disabled) 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-gap-small site-button-ghost-wrapper"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-background-ghost"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Ghost 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-background-ghost"
+      disabled=""
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Ghost(disabled) 
+      </span>
+      <!---->
+    </button>
+  </div>
+</div>
+`;
+
+exports[`button demo > renders ghost correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small site-button-ghost-wrapper"
+>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-outlined ant-btn-background-ghost"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Primary 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-background-ghost"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Default 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed ant-btn-background-ghost"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Dashed 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-background-ghost"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Danger 
+    </span>
+    <!---->
+  </button>
+</div>
+`;
+
+exports[`button demo > renders icon correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+>
+  <div
+    class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-circle ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="search"
+          class="anticon anticon-search"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="search"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+            />
+          </svg>
+        </span>
+      </span>
+      <!---->
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-circle ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         A 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="search"
+          class="anticon anticon-search"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="search"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span>
+         Search 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-circle ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="search"
+          class="anticon anticon-search"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="search"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+            />
+          </svg>
+        </span>
+      </span>
+      <!---->
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="search"
+          class="anticon anticon-search"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="search"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span>
+         Search 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-circle ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="search"
+          class="anticon anticon-search"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="search"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+            />
+          </svg>
+        </span>
+      </span>
+      <!---->
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="search"
+          class="anticon anticon-search"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="search"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span>
+         Search 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-circle ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="search"
+          class="anticon anticon-search"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="search"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+            />
+          </svg>
+        </span>
+      </span>
+      <!---->
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="search"
+          class="anticon anticon-search"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="search"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span>
+         Search 
+      </span>
+      <!---->
+    </button>
+    <a
+      aria-disabled="false"
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+      href="https://www.google.com"
+      target="_blank"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="search"
+          class="anticon anticon-search"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="search"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+            />
+          </svg>
+        </span>
+      </span>
+      <!---->
+    </a>
+  </div>
+</div>
+`;
+
+exports[`button demo > renders icon-placement correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+  >
+    <div
+      class="ant-space-item"
+    >
+      <div
+        class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+      >
+        <label
+          class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+        >
+          <span
+            class="ant-radio-button"
+            name="v-0"
+          >
+            <input
+              class="ant-radio-button-input"
+              type="radio"
+            />
+            <span
+              class="ant-radio-button-inner"
+            />
+          </span>
+          <span
+            class="ant-radio-button-label"
+          >
+             start 
+          </span>
+        </label>
+        <label
+          class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+        >
+          <span
+            class="ant-radio-button ant-radio-button-checked"
+            name="v-0"
+          >
+            <input
+              checked=""
+              class="ant-radio-button-input"
+              type="radio"
+            />
+            <span
+              class="ant-radio-button-inner"
+            />
+          </span>
+          <span
+            class="ant-radio-button-label"
+          >
+             end 
+          </span>
+        </label>
+      </div>
+    </div>
+    <!---->
+  </div>
+  <div
+    class="ant-divider css-var-root ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-plain"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+       Preview 
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  >
+    <div
+      class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-circle ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <!---->
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-circle ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           A 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-end"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+           Search 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-circle ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <!---->
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-end"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+           Search 
+        </span>
+        <!---->
+      </button>
+    </div>
+    <div
+      class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-circle ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <!---->
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-end"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+           Search 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-circle ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed ant-btn-icon-only"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <!---->
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed ant-btn-icon-end"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+           Search 
+        </span>
+        <!---->
+      </button>
+      <a
+        aria-disabled="false"
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-icon-end"
+        href="https://www.google.com"
+        target="_blank"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <!---->
+      </a>
+      <button
+        class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-loading ant-btn-icon-end"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <span
+            class="ant-btn-icon ant-btn-loading-icon"
+          >
+            <span
+              aria-label="loading"
+              class="anticon anticon-loading anticon-spin"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="loading"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 1024 1024"
+                width="1em"
+              >
+                <path
+                  d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                />
+              </svg>
+            </span>
+          </span>
+        </transition-stub>
+        <span>
+           Loading 
+        </span>
+        <!---->
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`button demo > renders linear-gradient correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+  >
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-lg linear-gradient-button"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="ant-design"
+            class="anticon anticon-ant-design"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="ant-design"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M716.3 313.8c19-18.9 19-49.7 0-68.6l-69.9-69.9.1.1c-18.5-18.5-50.3-50.3-95.3-95.2-21.2-20.7-55.5-20.5-76.5.5L80.9 474.2a53.84 53.84 0 000 76.4L474.6 944a54.14 54.14 0 0076.5 0l165.1-165c19-18.9 19-49.7 0-68.6a48.7 48.7 0 00-68.7 0l-125 125.2c-5.2 5.2-13.3 5.2-18.5 0L189.5 521.4c-5.2-5.2-5.2-13.3 0-18.5l314.4-314.2c.4-.4.9-.7 1.3-1.1 5.2-4.1 12.4-3.7 17.2 1.1l125.2 125.1c19 19 49.8 19 68.7 0zM408.6 514.4a106.3 106.2 0 10212.6 0 106.3 106.2 0 10-212.6 0zm536.2-38.6L821.9 353.5c-19-18.9-49.8-18.9-68.7.1a48.4 48.4 0 000 68.6l83 82.9c5.2 5.2 5.2 13.3 0 18.5l-81.8 81.7a48.4 48.4 0 000 68.6 48.7 48.7 0 0068.7 0l121.8-121.7a53.93 53.93 0 00-.1-76.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+           Gradient Button 
+        </span>
+        <!---->
+      </button>
+    </div>
+    <!---->
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg linear-gradient-button"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Button 
+        </span>
+        <!---->
+      </button>
+    </div>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`button demo > renders loading correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+>
+  <div
+    class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-loading"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <span
+          class="ant-btn-icon ant-btn-loading-icon"
+        >
+          <span
+            aria-label="loading"
+            class="anticon anticon-loading anticon-spin"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="loading"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+              />
+            </svg>
+          </span>
+        </span>
+      </transition-stub>
+      <span>
+         Loading 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm ant-btn-loading"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <span
+          class="ant-btn-icon ant-btn-loading-icon"
+        >
+          <span
+            aria-label="loading"
+            class="anticon anticon-loading anticon-spin"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="loading"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+              />
+            </svg>
+          </span>
+        </span>
+      </transition-stub>
+      <span>
+         Loading 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-loading"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon ant-btn-loading-icon"
+      >
+        <span
+          aria-label="loading"
+          class="anticon anticon-loading anticon-spin"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="loading"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 1024 1024"
+            width="1em"
+          >
+            <path
+              d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+            />
+          </svg>
+        </span>
+      </span>
+      <!---->
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-loading"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="sync"
+          class="anticon anticon-sync anticon-spin"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="sync"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M168 504.2c1-43.7 10-86.1 26.9-126 17.3-41 42.1-77.7 73.7-109.4S337 212.3 378 195c42.4-17.9 87.4-27 133.9-27s91.5 9.1 133.8 27A341.5 341.5 0 01755 268.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.7 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c0-6.7-7.7-10.5-12.9-6.3l-56.4 44.1C765.8 155.1 646.2 92 511.8 92 282.7 92 96.3 275.6 92 503.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8zm756 7.8h-60c-4.4 0-7.9 3.5-8 7.8-1 43.7-10 86.1-26.9 126-17.3 41-42.1 77.8-73.7 109.4A342.45 342.45 0 01512.1 856a342.24 342.24 0 01-243.2-100.8c-9.9-9.9-19.2-20.4-27.8-31.4l60.2-47a8 8 0 00-3-14.1l-175.7-43c-5-1.2-9.9 2.6-9.9 7.7l-.7 181c0 6.7 7.7 10.5 12.9 6.3l56.4-44.1C258.2 868.9 377.8 932 512.2 932c229.2 0 415.5-183.7 419.8-411.8a8 8 0 00-8-8.2z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span>
+         Loading Icon 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Icon Start 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         IconEnd 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="poweroff"
+          class="anticon anticon-poweroff"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="poweroff"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M705.6 124.9a8 8 0 00-11.6 7.2v64.2c0 5.5 2.9 10.6 7.5 13.6a352.2 352.2 0 0162.2 49.8c32.7 32.8 58.4 70.9 76.3 113.3a355 355 0 0127.9 138.7c0 48.1-9.4 94.8-27.9 138.7a355.92 355.92 0 01-76.3 113.3 353.06 353.06 0 01-113.2 76.4c-43.8 18.6-90.5 28-138.5 28s-94.7-9.4-138.5-28a353.06 353.06 0 01-113.2-76.4A355.92 355.92 0 01184 650.4a355 355 0 01-27.9-138.7c0-48.1 9.4-94.8 27.9-138.7 17.9-42.4 43.6-80.5 76.3-113.3 19-19 39.8-35.6 62.2-49.8 4.7-2.9 7.5-8.1 7.5-13.6V132c0-6-6.3-9.8-11.6-7.2C178.5 195.2 82 339.3 80 506.3 77.2 745.1 272.5 943.5 511.2 944c239 .5 432.8-193.3 432.8-432.4 0-169.2-97-315.7-238.4-386.7zM480 560h64c4.4 0 8-3.6 8-8V88c0-4.4-3.6-8-8-8h-64c-4.4 0-8 3.6-8 8v464c0 4.4 3.6 8 8 8z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span>
+         Icon Replace 
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="poweroff"
+          class="anticon anticon-poweroff"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="poweroff"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M705.6 124.9a8 8 0 00-11.6 7.2v64.2c0 5.5 2.9 10.6 7.5 13.6a352.2 352.2 0 0162.2 49.8c32.7 32.8 58.4 70.9 76.3 113.3a355 355 0 0127.9 138.7c0 48.1-9.4 94.8-27.9 138.7a355.92 355.92 0 01-76.3 113.3 353.06 353.06 0 01-113.2 76.4c-43.8 18.6-90.5 28-138.5 28s-94.7-9.4-138.5-28a353.06 353.06 0 01-113.2-76.4A355.92 355.92 0 01184 650.4a355 355 0 01-27.9-138.7c0-48.1 9.4-94.8 27.9-138.7 17.9-42.4 43.6-80.5 76.3-113.3 19-19 39.8-35.6 62.2-49.8 4.7-2.9 7.5-8.1 7.5-13.6V132c0-6-6.3-9.8-11.6-7.2C178.5 195.2 82 339.3 80 506.3 77.2 745.1 272.5 943.5 511.2 944c239 .5 432.8-193.3 432.8-432.4 0-169.2-97-315.7-238.4-386.7zM480 560h64c4.4 0 8-3.6 8-8V88c0-4.4-3.6-8-8-8h-64c-4.4 0-8 3.6-8 8v464c0 4.4 3.6 8 8 8z"
+            />
+          </svg>
+        </span>
+      </span>
+      <!---->
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="poweroff"
+          class="anticon anticon-poweroff"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="poweroff"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M705.6 124.9a8 8 0 00-11.6 7.2v64.2c0 5.5 2.9 10.6 7.5 13.6a352.2 352.2 0 0162.2 49.8c32.7 32.8 58.4 70.9 76.3 113.3a355 355 0 0127.9 138.7c0 48.1-9.4 94.8-27.9 138.7a355.92 355.92 0 01-76.3 113.3 353.06 353.06 0 01-113.2 76.4c-43.8 18.6-90.5 28-138.5 28s-94.7-9.4-138.5-28a353.06 353.06 0 01-113.2-76.4A355.92 355.92 0 01184 650.4a355 355 0 01-27.9-138.7c0-48.1 9.4-94.8 27.9-138.7 17.9-42.4 43.6-80.5 76.3-113.3 19-19 39.8-35.6 62.2-49.8 4.7-2.9 7.5-8.1 7.5-13.6V132c0-6-6.3-9.8-11.6-7.2C178.5 195.2 82 339.3 80 506.3 77.2 745.1 272.5 943.5 511.2 944c239 .5 432.8-193.3 432.8-432.4 0-169.2-97-315.7-238.4-386.7zM480 560h64c4.4 0 8-3.6 8-8V88c0-4.4-3.6-8-8-8h-64c-4.4 0-8 3.6-8 8v464c0 4.4 3.6 8 8 8z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span>
+         Loading Icon 
+      </span>
+      <!---->
+    </button>
+  </div>
+</div>
+`;
+
+exports[`button demo > renders multiple correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-flex-start ant-flex-gap-small ant-flex-vertical"
+>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       primary 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+      secondary
+    </span>
+    <!---->
+  </button>
+  <div
+    class="ant-space-compact css-var-root"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-compact-item ant-btn-compact-first-item"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+        Actions
+      </span>
+      <!---->
+    </button>
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-last-item ant-dropdown-trigger"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="ellipsis"
+          class="anticon anticon-ellipsis"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="ellipsis"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+            />
+          </svg>
+        </span>
+      </span>
+      <!---->
+      <!---->
+    </button>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`button demo > renders size correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-0"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+        <span
+          class="ant-radio-button-inner"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Large 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+        <span
+          class="ant-radio-button-inner"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Default 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+        <span
+          class="ant-radio-button-inner"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Small 
+      </span>
+    </label>
+  </div>
+  <div
+    class="ant-divider css-var-root ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-plain"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+       Preview 
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-align-flex-start ant-flex-gap-small ant-flex-vertical"
+  >
+    <div
+      class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-lg"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Primary 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Default 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed ant-btn-lg"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+           Dashed 
+        </span>
+        <!---->
+      </button>
+    </div>
+    <button
+      class="ant-btn css-var-root ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-lg"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Link 
+      </span>
+      <!---->
+    </button>
+    <div
+      class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-small"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-lg ant-btn-icon-only"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="download"
+            class="anticon anticon-download"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="download"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M505.7 661a8 8 0 0012.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+        <!---->
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-circle ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-lg ant-btn-icon-only"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="download"
+            class="anticon anticon-download"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="download"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M505.7 661a8 8 0 0012.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+        <!---->
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-round ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-lg ant-btn-icon-only"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="download"
+            class="anticon anticon-download"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="download"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M505.7 661a8 8 0 0012.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+        <!---->
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-round ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-lg"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="download"
+            class="anticon anticon-download"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="download"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M505.7 661a8 8 0 0012.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+           Download 
+        </span>
+        <!---->
+      </button>
+      <button
+        class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-lg"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="download"
+            class="anticon anticon-download"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="download"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M505.7 661a8 8 0 0012.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V168c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8zM878 626h-60c-4.4 0-8 3.6-8 8v154H214V634c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v198c0 17.7 14.3 32 32 32h684c17.7 0 32-14.3 32-32V634c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+           Download 
+        </span>
+        <!---->
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`button demo > renders style-class correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-gap-small"
+>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined demo-button-root"
+    style="box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05);"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span
+      class="demo-button-content"
+    >
+       Object 
+    </span>
+    <!---->
+  </button>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid demo-button-root"
+    style="background-color: rgb(23, 23, 23);"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span
+      class="demo-button-content"
+      style="color: rgb(255, 255, 255);"
+    >
+       Function 
+    </span>
+    <!---->
+  </button>
+</div>
+`;

--- a/packages/antdv-next/src/button/tests/demo.test.tsx
+++ b/packages/antdv-next/src/button/tests/demo.test.tsx
@@ -1,0 +1,3 @@
+import demoTest from '/@tests/shared/demoTest'
+
+demoTest('button')


### PR DESCRIPTION
## Summary
- Add unit tests for Button component
- Add semantic DOM tests for Button (root, icon, content) with ConfigProvider merge test
- Add demo snapshot tests

## Test Files
- `Button.test.tsx` - 27 test cases
- `Button.semantic.test.tsx` - 3 semantic DOM test cases (including ConfigProvider merge)
- `demo.test.tsx` - 16 demo snapshot tests

## Test Coverage

- Type variants (primary, default, dashed, link, text) with correct class mapping
- Sizes (large, middle, small)
- Disabled state (attribute + click prevention)
- Loading state (basic, delay, custom loadingIcon slot, icon placement + loading)
- AutoFocus
- Icon rendering (prop, slot, placement end)
- Shapes (circle, round)
- Block, ghost, danger
- Anchor button (href, target)
- htmlType
- Click events (normal + loading prevention)
- Color + variant combination
- Data attributes
- Semantic DOM (classes/styles as object and function, covering root + icon + content)
- ConfigProvider context merge (Button is in PASSED_PROPS)
- RTL direction
- Snapshots