### PR TITLE
fix(layout): fix inverted responsive collapse logic in Sider

### DIFF
--- a/packages/antdv-next/src/layout/Sider.tsx
+++ b/packages/antdv-next/src/layout/Sider.tsx
@@ -117,7 +117,7 @@ const Sider = defineComponent<
   const responsiveHandler: (mql: MediaQueryListEvent | MediaQueryList) => void = (mql) => {
     below.value = mql.matches
     emit('breakpoint', mql.matches)
-    if (!collapsed.value !== mql.matches) {
+    if (collapsed.value !== mql.matches) {
       handleSetCollapsed(mql.matches, 'responsive')
     }
   }


### PR DESCRIPTION
The condition `!collapsed.value !== mql.matches` negates `collapsed` before comparing, inverting all 4 scenarios:

| collapsed | mql.matches | Expected | Actual (before fix) |
|:---------:|:-----------:|:--------:|:-------------------:|
| false | false | no-op | collapse |
| false | true | collapse | no-op |
| true | false | expand | no-op |
| true | true | no-op | expand |

Removed the extra `!` to match upstream React: `collapsed.value !== mql.matches`.