### PR TITLE
fix(modal): cancel button is hidden in info/success/warning modals

### DIFF
--- a/packages/antdv-next/src/modal/ConfirmDialog.tsx
+++ b/packages/antdv-next/src/modal/ConfirmDialog.tsx
@@ -78,7 +78,7 @@ export const ConfirmContent = defineComponent<
 
     const [locale] = useLocale('Modal', getConfirmLocale())
     const mergedLocale = computed(() => props.locale || locale?.value)
-    const okTextLocale = computed(() => props?.okText ?? (mergedOkCancel ? mergedLocale.value?.okText : mergedLocale.value?.justOkText))
+    const okTextLocale = computed(() => props?.okText ?? (mergedOkCancel.value ? mergedLocale.value?.okText : mergedLocale.value?.justOkText))
     const cancelTextLocale = computed(() => props?.cancelText ?? mergedLocale.value?.cancelText)
 
     const { closable } = props
@@ -88,7 +88,7 @@ export const ConfirmContent = defineComponent<
       autoFocusButton,
       cancelTextLocale: cancelTextLocale.value,
       okTextLocale: okTextLocale.value,
-      mergedOkCancel,
+      mergedOkCancel: mergedOkCancel.value,
       onClose,
       ...props,
     }))

--- a/packages/antdv-next/src/modal/tests/Modal.test.tsx
+++ b/packages/antdv-next/src/modal/tests/Modal.test.tsx
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Modal from '..'
+import { waitFakeTimer } from '/@tests/utils'
+
+describe('modal static', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(async () => {
+    Modal.destroyAll()
+    await waitFakeTimer(1, 5)
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('modal.info should not show cancel button by default', async () => {
+    Modal.info({
+      title: 'This is a notification message',
+      content: 'some messages',
+    })
+
+    await waitFakeTimer(1, 5)
+
+    expect(document.querySelectorAll('.ant-modal-confirm-btns .ant-btn')).toHaveLength(1)
+  })
+
+  it('modal.confirm should show cancel button by default', async () => {
+    Modal.confirm({
+      title: 'This is a confirm message',
+      content: 'some messages',
+    })
+
+    await waitFakeTimer(1, 5)
+
+    expect(document.querySelectorAll('.ant-modal-confirm-btns .ant-btn')).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
close #165 