### PR TITLE
fix: resolve verify-commit.js failure in git worktrees

### DIFF
--- a/scripts/verify-commit.js
+++ b/scripts/verify-commit.js
@@ -1,8 +1,10 @@
+import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import pico from 'picocolors'
 
-const msgPath = path.resolve('.git/COMMIT_EDITMSG')
+const gitDir = execSync('git rev-parse --git-dir', { encoding: 'utf-8' }).trim()
+const msgPath = path.resolve(gitDir, 'COMMIT_EDITMSG')
 const msg = readFileSync(msgPath, 'utf-8').trim()
 
 const commitRE


### PR DESCRIPTION
## 问题

`scripts/verify-commit.js` 将 commit message 路径硬编码为 `.git/COMMIT_EDITMSG`：

```js
const msgPath = path.resolve('.git/COMMIT_EDITMSG')
```

在普通仓库中 `.git` 是目录，没有问题。但在 **git worktree** 中，`.git` 是一个**文件**（内容为 `gitdir: /path/to/main/.git/worktrees/<name>`），不是目录。这会导致 `readFileSync` 抛出 `ENOTDIR` 错误，无法在 worktree 中提交。

## 解决方案

使用 `git rev-parse --git-dir` 获取真实的 git 目录路径，普通仓库和 worktree 均兼容：

```js
const gitDir = execSync('git rev-parse --git-dir', { encoding: 'utf-8' }).trim()
const msgPath = path.resolve(gitDir, 'COMMIT_EDITMSG')
```

- 普通仓库：`git rev-parse --git-dir` → `.git`（行为不变）
- Worktree：`git rev-parse --git-dir` → `/path/to/main/.git/worktrees/<name>`（正确路径）