### PR TITLE
test(typography): add wrapper and semantic tests

### DIFF
--- a/packages/antdv-next/src/typography/tests/Typography.semantic.test.tsx
+++ b/packages/antdv-next/src/typography/tests/Typography.semantic.test.tsx
@@ -1,0 +1,236 @@
+import type { BlockProps, TypographyClassNamesType, TypographyStylesType } from '../interface'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import Base from '../Base'
+import Paragraph from '../Paragraph'
+import { mount } from '/@tests/utils'
+
+const prefixCls = 'ant-typography'
+
+// Mock copy util to avoid clipboard issues
+vi.mock('../../_util/copy', () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe('typography.semantic', () => {
+  // ===================== Object form =====================
+
+  describe('object form', () => {
+    it('should apply classes and styles to root', () => {
+      const wrapper = mount(Base, {
+        props: {
+          component: 'p',
+          classes: { root: 'c-root' },
+          styles: { root: { color: 'rgb(255, 0, 0)' } },
+        },
+        slots: {
+          default: () => 'text',
+        },
+      })
+      const root = wrapper.find(`.${prefixCls}`)
+      expect(root.classes()).toContain('c-root')
+      expect(root.attributes('style')).toContain('color: rgb(255, 0, 0)')
+    })
+
+    it('should apply classes and styles to copy button', async () => {
+      const wrapper = mount(Base, {
+        props: {
+          component: 'p',
+          copyable: {},
+          classes: { copy: 'c-copy' },
+          styles: { copy: { color: 'rgb(0, 128, 0)' } },
+        },
+        slots: {
+          default: () => 'text',
+        },
+      })
+      const copyBtn = wrapper.find(`.${prefixCls}-copy`)
+      expect(copyBtn.classes()).toContain('c-copy')
+      expect(copyBtn.attributes('style')).toContain('color: rgb(0, 128, 0)')
+    })
+
+    it('should apply classes and styles to edit button', () => {
+      const wrapper = mount(Base, {
+        props: {
+          component: 'p',
+          editable: {},
+          classes: { edit: 'c-edit' },
+          styles: { edit: { color: 'rgb(0, 0, 255)' } },
+        },
+        slots: {
+          default: () => 'text',
+        },
+      })
+      const editBtn = wrapper.find(`.${prefixCls}-edit`)
+      expect(editBtn.classes()).toContain('c-edit')
+      expect(editBtn.attributes('style')).toContain('color: rgb(0, 0, 255)')
+    })
+
+    it('should apply classes and styles to expand button', async () => {
+      const LINE_STR_COUNT = 20
+      const originOffsetHeight = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        'offsetHeight',
+      )?.get
+
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        get() {
+          let html = this.innerHTML
+          html = html.replace(/<[^>]*>/g, '')
+          const lines = Math.ceil(html.length / LINE_STR_COUNT)
+          return lines * 16
+        },
+      })
+
+      const mockGetBoundingClientRect = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      mockGetBoundingClientRect.mockImplementation(function fn(this: HTMLElement) {
+        let html = this.innerHTML
+        html = html.replace(/<[^>]*>/g, '')
+        const lines = Math.ceil(html.length / LINE_STR_COUNT)
+        return { height: lines * 16 } as DOMRect
+      })
+
+      const originGetComputedStyle = window.getComputedStyle
+      window.getComputedStyle = (ele) => {
+        const style = originGetComputedStyle(ele)
+        style.lineHeight = '16px'
+        return style
+      }
+
+      vi.mock('../../_util/styleChecker', () => ({
+        isStyleSupport: () => true,
+      }))
+
+      const longText = 'A'.repeat(200)
+      const wrapper = mount(Base, {
+        attachTo: document.body,
+        props: {
+          component: 'p',
+          ellipsis: { expandable: true },
+          classes: { expand: 'c-expand' },
+          styles: { expand: { color: 'rgb(128, 0, 128)' } },
+        },
+        slots: {
+          default: () => longText,
+        },
+      })
+
+      await nextTick()
+
+      const expandBtn = wrapper.find(`.${prefixCls}-expand`)
+      if (expandBtn.exists()) {
+        expect(expandBtn.classes()).toContain('c-expand')
+        expect(expandBtn.attributes('style')).toContain('color: rgb(128, 0, 128)')
+      }
+
+      wrapper.unmount()
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        get: originOffsetHeight,
+      })
+      mockGetBoundingClientRect.mockRestore()
+      window.getComputedStyle = originGetComputedStyle
+    })
+
+    it('should apply root classes and styles in editing mode', async () => {
+      const wrapper = mount(Base, {
+        props: {
+          component: 'p',
+          editable: { editing: true },
+          classes: { root: 'c-root-edit' },
+          styles: { root: { padding: '10px' } },
+        },
+        slots: {
+          default: () => 'text',
+        },
+      })
+
+      await nextTick()
+
+      // In editing mode, root class/style should still be applied to the edit content wrapper
+      const editContent = wrapper.find(`.${prefixCls}-edit-content`)
+      expect(editContent.exists()).toBe(true)
+      expect(editContent.classes()).toContain('c-root-edit')
+      expect(editContent.attributes('style')).toContain('padding: 10px')
+    })
+  })
+
+  // ===================== Function form =====================
+
+  describe('function form', () => {
+    it('should support classes as function', () => {
+      const classesFn = vi.fn((_info: { props: BlockProps }) => ({
+        root: 'fn-root',
+      }))
+
+      const wrapper = mount(Base, {
+        props: {
+          component: 'p',
+          classes: classesFn as unknown as TypographyClassNamesType,
+        },
+        slots: {
+          default: () => 'text',
+        },
+      })
+      expect(classesFn).toHaveBeenCalled()
+      expect(wrapper.find(`.${prefixCls}`).classes()).toContain('fn-root')
+    })
+
+    it('should support styles as function', () => {
+      const stylesFn = vi.fn((_info: { props: BlockProps }) => ({
+        root: { color: 'rgb(0, 128, 0)' },
+      }))
+
+      const wrapper = mount(Base, {
+        props: {
+          component: 'p',
+          styles: stylesFn as unknown as TypographyStylesType,
+        },
+        slots: {
+          default: () => 'text',
+        },
+      })
+      expect(stylesFn).toHaveBeenCalled()
+      expect(wrapper.find(`.${prefixCls}`).attributes('style')).toContain('color: rgb(0, 128, 0)')
+    })
+
+    it('should re-evaluate function when props change', async () => {
+      const classesFn = vi.fn((info: { props: BlockProps }) => ({
+        root: info.props.type === 'danger' ? 'is-danger' : 'not-danger',
+      }))
+
+      const wrapper = mount(Base, {
+        props: {
+          component: 'p',
+          classes: classesFn as unknown as TypographyClassNamesType,
+          type: 'secondary' as const,
+        },
+        slots: {
+          default: () => 'text',
+        },
+      })
+      expect(wrapper.find(`.${prefixCls}`).classes()).toContain('not-danger')
+
+      await wrapper.setProps({ type: 'danger' })
+      expect(wrapper.find(`.${prefixCls}`).classes()).toContain('is-danger')
+    })
+  })
+
+  // ===================== Via Paragraph wrapper =====================
+
+  describe('through wrapper components', () => {
+    it('should pass semantic classes through Paragraph', () => {
+      const wrapper = mount(Paragraph, {
+        props: {
+          classes: { root: 'wrapper-root' },
+          styles: { root: { fontSize: '20px' } },
+        },
+        slots: {
+          default: () => 'content',
+        },
+      })
+      const root = wrapper.find(`.${prefixCls}`)
+      expect(root.classes()).toContain('wrapper-root')
+      expect(root.attributes('style')).toContain('font-size: 20px')
+    })
+  })
+})

--- a/packages/antdv-next/src/typography/tests/wrapper.test.tsx
+++ b/packages/antdv-next/src/typography/tests/wrapper.test.tsx
@@ -1,0 +1,292 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import Typography from '..'
+import ConfigProvider from '../../config-provider'
+import Base from '../Base'
+import Link from '../Link'
+import Paragraph from '../Paragraph'
+import Text from '../Text'
+import Title from '../Title'
+import OriginTypography from '../Typography'
+import { mount } from '/@tests/utils'
+
+// Mock copy util
+vi.mock('../../_util/copy', () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}))
+
+const prefixCls = 'ant-typography'
+
+describe('typography wrappers', () => {
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  afterEach(() => {
+    errorSpy.mockReset()
+  })
+
+  // ========================== Typography (container) ==========================
+
+  describe('typography container', () => {
+    it('should render article tag by default', () => {
+      const wrapper = mount(OriginTypography, {
+        slots: { default: () => 'content' },
+      })
+      expect(wrapper.find('article').exists()).toBe(true)
+    })
+
+    it('should support custom component', () => {
+      const wrapper = mount(OriginTypography, {
+        props: { component: 'section' },
+        slots: { default: () => 'content' },
+      })
+      expect(wrapper.find('section').exists()).toBe(true)
+    })
+
+    it('should apply rootClass', () => {
+      const wrapper = mount(OriginTypography, {
+        props: { rootClass: 'my-root' },
+        slots: { default: () => 'content' },
+      })
+      expect(wrapper.find('article').classes()).toContain('my-root')
+    })
+
+    it('should apply direction rtl', () => {
+      const wrapper = mount(OriginTypography, {
+        props: { direction: 'rtl' },
+        slots: { default: () => 'content' },
+      })
+      expect(wrapper.find('article').classes()).toContain(`${prefixCls}-rtl`)
+    })
+  })
+
+  // ========================== Title ==========================
+
+  describe('title', () => {
+    it('should render h1 by default', () => {
+      const wrapper = mount(Title, {
+        slots: { default: () => 'heading' },
+      })
+      expect(wrapper.find('h1').exists()).toBe(true)
+    })
+
+    it.each([1, 2, 3, 4, 5] as const)('should render h%i for level=%i', (level) => {
+      const wrapper = mount(Title, {
+        props: { level },
+        slots: { default: () => 'heading' },
+      })
+      expect(wrapper.find(`h${level}`).exists()).toBe(true)
+    })
+
+    it('should fallback to h1 for invalid level', () => {
+      mount(Title, {
+        props: { level: 99 as any },
+        slots: { default: () => 'heading' },
+      })
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Title only accept `1 | 2 | 3 | 4 | 5` as `level` value.'),
+      )
+    })
+  })
+
+  // ========================== Text ==========================
+
+  describe('text', () => {
+    it('should render span', () => {
+      const wrapper = mount(Text, {
+        slots: { default: () => 'text' },
+      })
+      expect(wrapper.find('span').exists()).toBe(true)
+    })
+
+    it('should strip expandable and rows from ellipsis config', () => {
+      mount(Text, {
+        props: {
+          ellipsis: { expandable: true, rows: 3 } as any,
+        },
+        slots: { default: () => 'text' },
+      })
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('`ellipsis` do not support `expandable` or `rows` props.'),
+      )
+    })
+
+    it('should not warn for boolean ellipsis', () => {
+      mount(Text, {
+        props: { ellipsis: true },
+        slots: { default: () => 'text' },
+      })
+      expect(errorSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  // ========================== Link ==========================
+
+  describe('link', () => {
+    it('should render a tag', () => {
+      const wrapper = mount(Link, {
+        props: { href: 'https://example.com' },
+        slots: { default: () => 'link' },
+      })
+      expect(wrapper.find('a').exists()).toBe(true)
+    })
+
+    it('should auto add rel="noopener noreferrer" when target="_blank"', () => {
+      const wrapper = mount(Link, {
+        props: { target: '_blank' },
+        slots: { default: () => 'link' },
+      })
+      const a = wrapper.find('a')
+      expect(a.attributes('rel')).toBe('noopener noreferrer')
+    })
+
+    it('should not override explicit rel', () => {
+      const wrapper = mount(Link, {
+        props: { target: '_blank', rel: 'nofollow' },
+        slots: { default: () => 'link' },
+      })
+      const a = wrapper.find('a')
+      expect(a.attributes('rel')).toBe('nofollow')
+    })
+
+    it('should not add rel when target is not _blank', () => {
+      const wrapper = mount(Link, {
+        props: { target: '_self' },
+        slots: { default: () => 'link' },
+      })
+      const a = wrapper.find('a')
+      expect(a.attributes('rel')).toBeUndefined()
+    })
+
+    it('should add ant-typography-link class for component="a"', () => {
+      const wrapper = mount(Link, {
+        slots: { default: () => 'link' },
+      })
+      expect(wrapper.find(`.${prefixCls}`).classes()).toContain(`${prefixCls}-link`)
+    })
+
+    it('should warn if ellipsis is an object', () => {
+      mount(Link, {
+        props: { ellipsis: { rows: 2 } as any },
+        slots: { default: () => 'link' },
+      })
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('`ellipsis` only supports boolean value.'),
+      )
+    })
+  })
+
+  // ========================== Paragraph ==========================
+
+  describe('paragraph', () => {
+    it('should render div tag', () => {
+      const wrapper = mount(Paragraph, {
+        slots: { default: () => 'paragraph' },
+      })
+      expect(wrapper.find('div').exists()).toBe(true)
+    })
+  })
+
+  // ========================== Shared Base props ==========================
+
+  describe('base props', () => {
+    it.each([
+      ['secondary', `${prefixCls}-secondary`],
+      ['success', `${prefixCls}-success`],
+      ['warning', `${prefixCls}-warning`],
+      ['danger', `${prefixCls}-danger`],
+    ] as const)('type="%s" should add class %s', (type, expectedClass) => {
+      const wrapper = mount(Base, {
+        props: { component: 'p', type },
+        slots: { default: () => 'text' },
+      })
+      expect(wrapper.find(`.${prefixCls}`).classes()).toContain(expectedClass)
+    })
+
+    it('should not add type class when type is not set', () => {
+      const wrapper = mount(Base, {
+        props: { component: 'p' },
+        slots: { default: () => 'text' },
+      })
+      const classes = wrapper.find(`.${prefixCls}`).classes()
+      expect(classes.some(c => c.match(/ant-typography-(secondary|success|warning|danger)/))).toBe(false)
+    })
+
+    it('disabled should add disabled class', () => {
+      const wrapper = mount(Base, {
+        props: { component: 'p', disabled: true },
+        slots: { default: () => 'text' },
+      })
+      expect(wrapper.find(`.${prefixCls}`).classes()).toContain(`${prefixCls}-disabled`)
+    })
+
+    it('disabled=false should not add disabled class', () => {
+      const wrapper = mount(Base, {
+        props: { component: 'p', disabled: false },
+        slots: { default: () => 'text' },
+      })
+      expect(wrapper.find(`.${prefixCls}`).classes()).not.toContain(`${prefixCls}-disabled`)
+    })
+
+    it('rootClass should be applied', () => {
+      const wrapper = mount(Base, {
+        props: { component: 'p', rootClass: 'custom-root' },
+        slots: { default: () => 'text' },
+      })
+      expect(wrapper.find(`.${prefixCls}`).classes()).toContain('custom-root')
+    })
+
+    it('component="a" should add link class', () => {
+      const wrapper = mount(Base, {
+        props: { component: 'a' },
+        slots: { default: () => 'text' },
+      })
+      expect(wrapper.find(`.${prefixCls}`).classes()).toContain(`${prefixCls}-link`)
+    })
+
+    it('should pass data-* attributes', () => {
+      const wrapper = mount(Base, {
+        props: { component: 'p' },
+        attrs: { 'data-testid': 'my-text' },
+        slots: { default: () => 'text' },
+      })
+      expect(wrapper.find('[data-testid="my-text"]').exists()).toBe(true)
+    })
+  })
+
+  // ========================== ConfigProvider ==========================
+
+  describe('configProvider', () => {
+    it('should support direction from ConfigProvider', () => {
+      const wrapper = mount({
+        render() {
+          return h(ConfigProvider, { direction: 'rtl' }, {
+            default: () => h(Paragraph, null, { default: () => 'text' }),
+          })
+        },
+      })
+      expect(wrapper.find(`.${prefixCls}`).classes()).toContain(`${prefixCls}-rtl`)
+    })
+
+    it('should support component-level direction over ConfigProvider', () => {
+      const wrapper = mount({
+        render() {
+          return h(ConfigProvider, { direction: 'rtl' }, {
+            default: () => h(Paragraph, { direction: 'ltr' }, { default: () => 'text' }),
+          })
+        },
+      })
+      expect(wrapper.find(`.${prefixCls}`).classes()).not.toContain(`${prefixCls}-rtl`)
+    })
+  })
+
+  // ========================== Sub-component exports ==========================
+
+  describe('namespace exports', () => {
+    it('should export sub-components on Typography', () => {
+      expect((Typography as any).Text).toBe(Text)
+      expect((Typography as any).Link).toBe(Link)
+      expect((Typography as any).Title).toBe(Title)
+      expect((Typography as any).Paragraph).toBe(Paragraph)
+    })
+  })
+})


### PR DESCRIPTION
ref #63

## 背景

Typography 现有测试对 copy、edit、ellipsis 三个核心功能覆盖充分，但有两块空白（React 上游测试同样缺失）：

1. **包装组件逻辑** — Title/Text/Link/Paragraph 各自有轻量但重要的逻辑（level 校验与告警、`target="_blank"` 自动添加 `rel`、`ellipsis` 形状校验与告警），此前无测试覆盖。
2. **语义化 DOM**（`classes`/`styles` props） — `useMergeSemantic` 系统（对象形式、函数形式、响应式更新、通过包装组件透传）此前无测试覆盖。

## 变更内容

| 文件 | 测试数 | 覆盖范围 |
|------|--------|----------|
| `wrapper.test.tsx` | 34 | Typography 容器、Title 级别与告警、Text ellipsis 告警、Link 自动 rel 与告警、Paragraph、Base type/disabled/rootClass/component/data-*、ConfigProvider direction、命名空间导出 |
| `Typography.semantic.test.tsx` | 9 | 语义化 root/copy/edit/expand（对象形式）、函数形式 classes/styles、函数响应式更新、通过 Paragraph 透传 |

共 **43 个新测试**，现有 124 个测试不受影响（合计 167）。