### PR TITLE
fix(config-provider): add missing masonry config to PASSED_PROPS

### DIFF
--- a/packages/antdv-next/src/config-provider/define.ts
+++ b/packages/antdv-next/src/config-provider/define.ts
@@ -22,6 +22,7 @@ import type {
   InputConfig,
   InputNumberConfig,
   InputSearchConfig,
+  MasonryConfig,
   MentionsConfig,
   MenuConfig,
   ModalConfig,
@@ -145,6 +146,7 @@ export interface ConfigProviderProps {
   rangePicker?: RangePickerConfig
   dropdown?: ComponentStyleConfig
   flex?: FlexConfig
+  masonry?: MasonryConfig
   // /**
   //  * Wave is special component which only patch on the effect of component interaction.
   //  */

--- a/packages/antdv-next/src/config-provider/index.tsx
+++ b/packages/antdv-next/src/config-provider/index.tsx
@@ -91,6 +91,7 @@ const PASSED_PROPS: Exclude<
   'upload',
   'datePicker',
   'breadcrumb',
+  'masonry',
   'descriptions',
   'divider',
   'flex',


### PR DESCRIPTION
## Summary

- Add `masonry` to `PASSED_PROPS` array in `config-provider/index.tsx`
- Add `MasonryConfig` import and `masonry?: MasonryConfig` to `ConfigProviderProps` in `config-provider/define.ts`

`MasonryConfig` was already defined in `context.ts` and consumed by the Masonry component via `useComponentBaseConfig('masonry')`, but the ConfigProvider was not forwarding the config because `masonry` was missing from both `PASSED_PROPS` and `ConfigProviderProps`.