### PR TITLE
fix: update demoTest path after playground restructure

### DIFF
--- a/packages/antdv-next/src/alert/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/alert/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`alert demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <transition-stub
         appear="false"
@@ -147,28 +147,28 @@ exports[`alert demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -186,7 +186,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -197,11 +197,11 @@ exports[`alert demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -210,7 +210,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -233,7 +233,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -242,7 +242,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -287,20 +287,20 @@ exports[`alert demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -318,7 +318,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -329,11 +329,11 @@ exports[`alert demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -342,7 +342,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -365,7 +365,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -374,7 +374,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -419,20 +419,20 @@ exports[`alert demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -450,7 +450,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -461,11 +461,11 @@ exports[`alert demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -474,7 +474,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -497,7 +497,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -506,7 +506,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -551,20 +551,20 @@ exports[`alert demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -582,7 +582,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -593,11 +593,11 @@ exports[`alert demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -606,7 +606,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -629,7 +629,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -638,7 +638,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -683,20 +683,20 @@ exports[`alert demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -714,7 +714,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -725,11 +725,11 @@ exports[`alert demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -738,7 +738,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -761,7 +761,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -770,7 +770,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -815,20 +815,20 @@ exports[`alert demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -846,7 +846,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -857,11 +857,11 @@ exports[`alert demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -870,7 +870,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -893,7 +893,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -902,7 +902,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -947,20 +947,20 @@ exports[`alert demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -978,7 +978,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -989,11 +989,11 @@ exports[`alert demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1002,7 +1002,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1025,7 +1025,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1034,7 +1034,7 @@ exports[`alert demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2999,7 +2999,7 @@ exports[`alert demo > renders loop-banner correctly 1`] = `
 <transition-stub
   appear="false"
   css="true"
-  data-v-deb306fb=""
+  data-v-6f2f0c78=""
   leaveactiveclass="ant-alert-motion-leave ant-alert-motion-leave-active"
   leavefromclass="ant-alert-motion-leave"
   leavetoclass="ant-alert-motion-leave ant-alert-motion-leave-active"
@@ -3042,11 +3042,11 @@ exports[`alert demo > renders loop-banner correctly 1`] = `
       >
         <div
           class="alert-marquee"
-          data-v-deb306fb=""
+          data-v-6f2f0c78=""
         >
           <div
             class="alert-marquee__content"
-            data-v-deb306fb=""
+            data-v-6f2f0c78=""
           >
              I can be a Vue component, multiple components, or just some text. 
           </div>

--- a/packages/antdv-next/src/anchor/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/anchor/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`anchor demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="css-var-v-0 ant-anchor-css-var ant-anchor-wrapper semantic-mark-root"
@@ -87,28 +87,28 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -126,7 +126,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -137,11 +137,11 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -150,7 +150,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -173,7 +173,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -182,7 +182,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -227,20 +227,20 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -258,7 +258,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -269,11 +269,11 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -282,7 +282,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -305,7 +305,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -314,7 +314,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -359,20 +359,20 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -390,7 +390,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -401,11 +401,11 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -414,7 +414,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -437,7 +437,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -446,7 +446,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -491,20 +491,20 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -522,7 +522,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -533,11 +533,11 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -546,7 +546,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -569,7 +569,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -578,7 +578,7 @@ exports[`anchor demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/packages/antdv-next/src/auto-complete/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/auto-complete/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`auto-complete demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         style="position: absolute; height: 200px;"
@@ -60,28 +60,28 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -102,11 +102,11 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -115,7 +115,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -138,7 +138,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -147,7 +147,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -192,20 +192,20 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -226,11 +226,11 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -239,7 +239,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -262,7 +262,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -271,7 +271,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -316,20 +316,20 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -350,11 +350,11 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -363,7 +363,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -386,7 +386,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -395,7 +395,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -440,20 +440,20 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -474,11 +474,11 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -487,7 +487,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -510,7 +510,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -519,7 +519,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -564,20 +564,20 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -598,11 +598,11 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -611,7 +611,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -634,7 +634,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -643,7 +643,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -688,20 +688,20 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -722,11 +722,11 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -735,7 +735,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -758,7 +758,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -767,7 +767,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -812,20 +812,20 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -846,11 +846,11 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -859,7 +859,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -882,7 +882,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -891,7 +891,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -936,20 +936,20 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -970,11 +970,11 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -983,7 +983,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1006,7 +1006,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1015,7 +1015,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1060,20 +1060,20 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1094,11 +1094,11 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1107,7 +1107,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1130,7 +1130,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1139,7 +1139,7 @@ exports[`auto-complete demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/packages/antdv-next/src/badge/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/badge/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`badge demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <span
         class="ant-badge semantic-mark-root css-var-v-0"
@@ -60,28 +60,28 @@ exports[`badge demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -99,7 +99,7 @@ exports[`badge demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -110,11 +110,11 @@ exports[`badge demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -123,7 +123,7 @@ exports[`badge demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -146,7 +146,7 @@ exports[`badge demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -155,7 +155,7 @@ exports[`badge demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -200,20 +200,20 @@ exports[`badge demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -231,7 +231,7 @@ exports[`badge demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -242,11 +242,11 @@ exports[`badge demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -255,7 +255,7 @@ exports[`badge demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -278,7 +278,7 @@ exports[`badge demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -287,7 +287,7 @@ exports[`badge demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -342,15 +342,15 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
 >
   <div
     class="semantic-preview-container"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-row css-var-root semantic-preview-row"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="ant-col ant-col-16 css-var-root semantic-preview-col"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <div
           style="width: 100%;"
@@ -401,28 +401,28 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
       </div>
       <div
         class="ant-col ant-col-8 css-var-root"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <ul
           class="semantic-list"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <li
             class="semantic-list-item"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <!-- Title + Version -->
                 <div
                   class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   <h5
                     class="ant-typography css-var-root"
@@ -440,7 +440,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                   </h5>
                   <span
                     class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                    data-v-0e8f6da1=""
+                    data-v-dfc8ebef=""
                   >
                     1.0.0
                     <!---->
@@ -451,11 +451,11 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                 <!-- Pin + Sample -->
                 <div
                   class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   <button
                     class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                    data-v-0e8f6da1=""
+                    data-v-dfc8ebef=""
                     type="button"
                   >
                     <span
@@ -464,7 +464,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                       <span
                         aria-label="pushpin"
                         class="anticon anticon-pushpin"
-                        data-v-0e8f6da1=""
+                        data-v-dfc8ebef=""
                         role="img"
                       >
                         <svg
@@ -487,7 +487,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                   </button>
                   <button
                     class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                    data-v-0e8f6da1=""
+                    data-v-dfc8ebef=""
                     type="button"
                   >
                     <span
@@ -496,7 +496,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                       <span
                         aria-label="info-circle"
                         class="anticon anticon-info-circle"
-                        data-v-0e8f6da1=""
+                        data-v-dfc8ebef=""
                         role="img"
                       >
                         <svg
@@ -541,20 +541,20 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
           </li>
           <li
             class="semantic-list-item"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <!-- Title + Version -->
                 <div
                   class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   <h5
                     class="ant-typography css-var-root"
@@ -572,7 +572,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                   </h5>
                   <span
                     class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                    data-v-0e8f6da1=""
+                    data-v-dfc8ebef=""
                   >
                     1.0.0
                     <!---->
@@ -583,11 +583,11 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                 <!-- Pin + Sample -->
                 <div
                   class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   <button
                     class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                    data-v-0e8f6da1=""
+                    data-v-dfc8ebef=""
                     type="button"
                   >
                     <span
@@ -596,7 +596,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                       <span
                         aria-label="pushpin"
                         class="anticon anticon-pushpin"
-                        data-v-0e8f6da1=""
+                        data-v-dfc8ebef=""
                         role="img"
                       >
                         <svg
@@ -619,7 +619,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                   </button>
                   <button
                     class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                    data-v-0e8f6da1=""
+                    data-v-dfc8ebef=""
                     type="button"
                   >
                     <span
@@ -628,7 +628,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                       <span
                         aria-label="info-circle"
                         class="anticon anticon-info-circle"
-                        data-v-0e8f6da1=""
+                        data-v-dfc8ebef=""
                         role="img"
                       >
                         <svg
@@ -673,20 +673,20 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
           </li>
           <li
             class="semantic-list-item"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <!-- Title + Version -->
                 <div
                   class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   <h5
                     class="ant-typography css-var-root"
@@ -704,7 +704,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                   </h5>
                   <span
                     class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                    data-v-0e8f6da1=""
+                    data-v-dfc8ebef=""
                   >
                     1.0.0
                     <!---->
@@ -715,11 +715,11 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                 <!-- Pin + Sample -->
                 <div
                   class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   <button
                     class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                    data-v-0e8f6da1=""
+                    data-v-dfc8ebef=""
                     type="button"
                   >
                     <span
@@ -728,7 +728,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                       <span
                         aria-label="pushpin"
                         class="anticon anticon-pushpin"
-                        data-v-0e8f6da1=""
+                        data-v-dfc8ebef=""
                         role="img"
                       >
                         <svg
@@ -751,7 +751,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                   </button>
                   <button
                     class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                    data-v-0e8f6da1=""
+                    data-v-dfc8ebef=""
                     type="button"
                   >
                     <span
@@ -760,7 +760,7 @@ exports[`badge demo > renders _semantic_ribbon correctly 1`] = `
                       <span
                         aria-label="info-circle"
                         class="anticon anticon-info-circle"
-                        data-v-0e8f6da1=""
+                        data-v-dfc8ebef=""
                         role="img"
                       >
                         <svg

--- a/packages/antdv-next/src/breadcrumb/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/breadcrumb/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`breadcrumb demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <nav
         class="ant-breadcrumb semantic-mark-root css-var-v-0"
@@ -101,28 +101,28 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -140,7 +140,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -151,11 +151,11 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -164,7 +164,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -187,7 +187,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -196,7 +196,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -241,20 +241,20 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -272,7 +272,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -283,11 +283,11 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -296,7 +296,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -319,7 +319,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -328,7 +328,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -373,20 +373,20 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -404,7 +404,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -415,11 +415,11 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -428,7 +428,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -451,7 +451,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -460,7 +460,7 @@ exports[`breadcrumb demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -850,12 +850,12 @@ exports[`breadcrumb demo > renders separator-component correctly 1`] = `
 exports[`breadcrumb demo > renders style-class correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
-  data-v-5c61aa3b=""
+  data-v-34f9aa07=""
 >
   <nav
     aria-label="Breadcrumb with Object"
     class="ant-breadcrumb demo-breadcrumb-root css-var-root"
-    data-v-5c61aa3b=""
+    data-v-34f9aa07=""
     style="border: 1px solid rgb(240, 240, 240); padding: 8px; border-radius: 4px;"
   >
     <ol>
@@ -891,7 +891,7 @@ exports[`breadcrumb demo > renders style-class correctly 1`] = `
   <nav
     aria-label="Breadcrumb with Function"
     class="ant-breadcrumb demo-breadcrumb-root css-var-root"
-    data-v-5c61aa3b=""
+    data-v-34f9aa07=""
     style="border: 1px solid rgb(245, 239, 255); padding: 8px; border-radius: 4px;"
   >
     <ol>

--- a/packages/antdv-next/src/button/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/button/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`button demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <button
         class="ant-btn css-var-v-0 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid semantic-mark-root"
@@ -50,28 +50,28 @@ exports[`button demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -89,7 +89,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -100,11 +100,11 @@ exports[`button demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -113,7 +113,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -136,7 +136,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -145,7 +145,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -190,20 +190,20 @@ exports[`button demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -221,7 +221,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -232,11 +232,11 @@ exports[`button demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -245,7 +245,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -268,7 +268,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -277,7 +277,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -322,20 +322,20 @@ exports[`button demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -353,7 +353,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -364,11 +364,11 @@ exports[`button demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -377,7 +377,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -400,7 +400,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -409,7 +409,7 @@ exports[`button demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/packages/antdv-next/src/calendar/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/calendar/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`calendar demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="ant-picker-calendar ant-picker-calendar-full semantic-mark-root ant-picker-css-var css-var-v-0"
@@ -1035,28 +1035,28 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1074,7 +1074,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -1085,11 +1085,11 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1098,7 +1098,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1121,7 +1121,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1130,7 +1130,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1175,20 +1175,20 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1206,7 +1206,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -1217,11 +1217,11 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1230,7 +1230,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1253,7 +1253,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1262,7 +1262,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1307,20 +1307,20 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1338,7 +1338,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -1349,11 +1349,11 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1362,7 +1362,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1385,7 +1385,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1394,7 +1394,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1439,20 +1439,20 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1470,7 +1470,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -1481,11 +1481,11 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1494,7 +1494,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1517,7 +1517,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1526,7 +1526,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1571,20 +1571,20 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1602,7 +1602,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -1613,11 +1613,11 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1626,7 +1626,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1649,7 +1649,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1658,7 +1658,7 @@ exports[`calendar demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2732,11 +2732,11 @@ exports[`calendar demo > renders basic correctly 1`] = `
 exports[`calendar demo > renders card correctly 1`] = `
 <div
   class="wrapStyle"
-  data-v-7dd66aea=""
+  data-v-104d280d=""
 >
   <div
     class="ant-picker-calendar ant-picker-calendar-mini ant-picker-css-var css-var-root"
-    data-v-7dd66aea=""
+    data-v-104d280d=""
   >
     <div
       class="ant-picker-calendar-header"
@@ -3762,14 +3762,14 @@ exports[`calendar demo > renders card correctly 1`] = `
 exports[`calendar demo > renders customize-header correctly 1`] = `
 <div
   class="wrapStyle"
-  data-v-7a6d042c=""
+  data-v-bcf66787=""
 >
   <div
     class="ant-picker-calendar ant-picker-calendar-mini ant-picker-css-var css-var-root"
-    data-v-7a6d042c=""
+    data-v-bcf66787=""
   >
     <div
-      data-v-7a6d042c=""
+      data-v-bcf66787=""
       style="padding: 8px;"
     >
       <h4
@@ -3787,16 +3787,16 @@ exports[`calendar demo > renders customize-header correctly 1`] = `
       </h4>
       <div
         class="ant-flex css-var-root"
-        data-v-7a6d042c=""
+        data-v-bcf66787=""
         style="gap: 8px;"
       >
         <div
           class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-root ant-radio-css-var"
-          data-v-7a6d042c=""
+          data-v-bcf66787=""
         >
           <label
             class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
-            data-v-7a6d042c=""
+            data-v-bcf66787=""
           >
             <span
               class="ant-radio-button ant-radio-button-checked"
@@ -3816,7 +3816,7 @@ exports[`calendar demo > renders customize-header correctly 1`] = `
           </label>
           <label
             class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
-            data-v-7a6d042c=""
+            data-v-bcf66787=""
           >
             <span
               class="ant-radio-button"
@@ -4815,20 +4815,20 @@ exports[`calendar demo > renders customize-header correctly 1`] = `
 exports[`calendar demo > renders lunar correctly 1`] = `
 <div
   class="wrapper"
-  data-v-3925b29d=""
+  data-v-29990d89=""
 >
   <div
     class="ant-picker-calendar ant-picker-calendar-mini ant-picker-css-var css-var-root"
-    data-v-3925b29d=""
+    data-v-29990d89=""
   >
     <div
       class="ant-row ant-row-end css-var-root"
-      data-v-3925b29d=""
+      data-v-29990d89=""
       style="margin-left: -4px; margin-right: -4px; padding: 8px;"
     >
       <div
         class="ant-col css-var-root"
-        data-v-3925b29d=""
+        data-v-29990d89=""
         style="padding-left: 4px; padding-right: 4px;"
       >
         <!---->
@@ -4888,7 +4888,7 @@ exports[`calendar demo > renders lunar correctly 1`] = `
       </div>
       <div
         class="ant-col css-var-root"
-        data-v-3925b29d=""
+        data-v-29990d89=""
         style="padding-left: 4px; padding-right: 4px;"
       >
         <!---->
@@ -4948,16 +4948,16 @@ exports[`calendar demo > renders lunar correctly 1`] = `
       </div>
       <div
         class="ant-col css-var-root"
-        data-v-3925b29d=""
+        data-v-29990d89=""
         style="padding-left: 4px; padding-right: 4px;"
       >
         <div
           class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-root ant-radio-css-var"
-          data-v-3925b29d=""
+          data-v-29990d89=""
         >
           <label
             class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
-            data-v-3925b29d=""
+            data-v-29990d89=""
           >
             <span
               class="ant-radio-button ant-radio-button-checked"
@@ -4977,7 +4977,7 @@ exports[`calendar demo > renders lunar correctly 1`] = `
           </label>
           <label
             class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
-            data-v-3925b29d=""
+            data-v-29990d89=""
           >
             <span
               class="ant-radio-button"
@@ -5053,21 +5053,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         27
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初六
                       </div>
@@ -5080,21 +5080,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         28
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初七
                       </div>
@@ -5107,21 +5107,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         29
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初八
                       </div>
@@ -5134,21 +5134,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         30
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初九
                       </div>
@@ -5161,21 +5161,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         31
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初十
                       </div>
@@ -5188,21 +5188,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         1
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十一
                       </div>
@@ -5215,21 +5215,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         2
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十二
                       </div>
@@ -5244,21 +5244,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         3
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十三
                       </div>
@@ -5271,21 +5271,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         4
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十四
                       </div>
@@ -5298,21 +5298,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         5
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十五
                       </div>
@@ -5325,21 +5325,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         6
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十六
                       </div>
@@ -5352,21 +5352,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         7
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         白露
                       </div>
@@ -5379,21 +5379,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         8
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十八
                       </div>
@@ -5406,21 +5406,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         9
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十九
                       </div>
@@ -5435,21 +5435,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         10
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         二十
                       </div>
@@ -5462,21 +5462,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         11
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         廿一
                       </div>
@@ -5489,21 +5489,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         12
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         廿二
                       </div>
@@ -5516,21 +5516,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         13
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         廿三
                       </div>
@@ -5543,21 +5543,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         14
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         廿四
                       </div>
@@ -5570,21 +5570,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         15
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         廿五
                       </div>
@@ -5597,21 +5597,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         16
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         廿六
                       </div>
@@ -5626,21 +5626,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         17
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         廿七
                       </div>
@@ -5653,21 +5653,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell current today"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         18
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         廿八
                       </div>
@@ -5680,21 +5680,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         19
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         廿九
                       </div>
@@ -5707,21 +5707,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         20
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初一
                       </div>
@@ -5734,21 +5734,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         21
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初二
                       </div>
@@ -5761,21 +5761,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         22
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初三
                       </div>
@@ -5788,21 +5788,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         23
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         秋分
                       </div>
@@ -5817,21 +5817,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         24
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初五
                       </div>
@@ -5844,21 +5844,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         25
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初六
                       </div>
@@ -5871,21 +5871,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         26
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初七
                       </div>
@@ -5898,21 +5898,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         27
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初八
                       </div>
@@ -5925,21 +5925,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         28
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初九
                       </div>
@@ -5952,21 +5952,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class=""
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         29
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         初十
                       </div>
@@ -5979,21 +5979,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         30
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十一
                       </div>
@@ -6008,21 +6008,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         1
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         国庆节
                       </div>
@@ -6035,21 +6035,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         2
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十三
                       </div>
@@ -6062,21 +6062,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         3
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十四
                       </div>
@@ -6089,21 +6089,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         4
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         中秋节
                       </div>
@@ -6116,21 +6116,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         5
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十六
                       </div>
@@ -6143,21 +6143,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         6
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十七
                       </div>
@@ -6170,21 +6170,21 @@ exports[`calendar demo > renders lunar correctly 1`] = `
                 >
                   <div
                     class="dateCell"
-                    data-v-3925b29d=""
+                    data-v-29990d89=""
                   >
                     <div
                       class="text"
-                      data-v-3925b29d=""
+                      data-v-29990d89=""
                     >
                       <span
                         class="weekend gray"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         7
                       </span>
                       <div
                         class="lunar"
-                        data-v-3925b29d=""
+                        data-v-29990d89=""
                       >
                         十八
                       </div>
@@ -6204,7 +6204,7 @@ exports[`calendar demo > renders lunar correctly 1`] = `
 exports[`calendar demo > renders notice-calendar correctly 1`] = `
 <div
   class="ant-picker-calendar ant-picker-calendar-full ant-picker-css-var css-var-root"
-  data-v-5cbe6d19=""
+  data-v-8217d8bf=""
 >
   <div
     class="ant-picker-calendar-header"
@@ -6424,7 +6424,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6446,7 +6446,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6468,7 +6468,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6490,7 +6490,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6512,7 +6512,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6534,7 +6534,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6556,7 +6556,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6580,7 +6580,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6602,7 +6602,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6624,7 +6624,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6646,7 +6646,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6668,7 +6668,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6690,14 +6690,14 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     >
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-warning"
@@ -6710,11 +6710,11 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                         </span>
                       </li>
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-success"
@@ -6747,7 +6747,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6771,14 +6771,14 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     >
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-warning"
@@ -6791,11 +6791,11 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                         </span>
                       </li>
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-success"
@@ -6808,11 +6808,11 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                         </span>
                       </li>
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-error"
@@ -6845,7 +6845,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6867,7 +6867,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6889,7 +6889,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6911,7 +6911,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -6933,14 +6933,14 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     >
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-warning"
@@ -6953,11 +6953,11 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                         </span>
                       </li>
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-success"
@@ -6970,11 +6970,11 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                         </span>
                       </li>
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-error"
@@ -6987,11 +6987,11 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                         </span>
                       </li>
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-error"
@@ -7004,11 +7004,11 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                         </span>
                       </li>
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-error"
@@ -7021,11 +7021,11 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                         </span>
                       </li>
                       <li
-                        data-v-5cbe6d19=""
+                        data-v-8217d8bf=""
                       >
                         <span
                           class="ant-badge ant-badge-status ant-badge-not-a-wrapper css-var-root"
-                          data-v-5cbe6d19=""
+                          data-v-8217d8bf=""
                         >
                           <span
                             class="ant-badge-status-dot ant-badge-status-error"
@@ -7058,7 +7058,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7082,7 +7082,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7104,7 +7104,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7126,7 +7126,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7148,7 +7148,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7170,7 +7170,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7192,7 +7192,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7214,7 +7214,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7238,7 +7238,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7260,7 +7260,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7282,7 +7282,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7304,7 +7304,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7326,7 +7326,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7348,7 +7348,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7370,7 +7370,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7394,7 +7394,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7416,7 +7416,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7438,7 +7438,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7460,7 +7460,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7482,7 +7482,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7504,7 +7504,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -7526,7 +7526,7 @@ exports[`calendar demo > renders notice-calendar correctly 1`] = `
                   >
                     <ul
                       class="events"
-                      data-v-5cbe6d19=""
+                      data-v-8217d8bf=""
                     />
                   </div>
                 </div>
@@ -8599,11 +8599,11 @@ exports[`calendar demo > renders select correctly 1`] = `
 exports[`calendar demo > renders style-class correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
-  data-v-478eb4d8=""
+  data-v-a98beb61=""
 >
   <div
     class="ant-picker-calendar ant-picker-calendar-mini custom-calendar-root ant-picker-css-var css-var-root"
-    data-v-478eb4d8=""
+    data-v-a98beb61=""
     style="border-radius: 8px; width: 600px;"
   >
     <div
@@ -9626,7 +9626,7 @@ exports[`calendar demo > renders style-class correctly 1`] = `
   </div>
   <div
     class="ant-picker-calendar ant-picker-calendar-full custom-calendar-root ant-picker-css-var css-var-root"
-    data-v-478eb4d8=""
+    data-v-a98beb61=""
     style="border: 2px solid rgb(189, 227, 195); border-radius: 10px; background-color: rgba(189, 227, 195, 0.3);"
   >
     <div

--- a/packages/antdv-next/src/divider/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/divider/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`divider demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div>
         <p>
@@ -106,28 +106,28 @@ exports[`divider demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -148,11 +148,11 @@ exports[`divider demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -161,7 +161,7 @@ exports[`divider demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -184,7 +184,7 @@ exports[`divider demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -193,7 +193,7 @@ exports[`divider demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -238,20 +238,20 @@ exports[`divider demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -272,11 +272,11 @@ exports[`divider demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -285,7 +285,7 @@ exports[`divider demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -308,7 +308,7 @@ exports[`divider demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -317,7 +317,7 @@ exports[`divider demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -362,20 +362,20 @@ exports[`divider demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -396,11 +396,11 @@ exports[`divider demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -409,7 +409,7 @@ exports[`divider demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -432,7 +432,7 @@ exports[`divider demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -441,7 +441,7 @@ exports[`divider demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/packages/antdv-next/src/empty/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/empty/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`empty demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="css-var-v-0 ant-empty semantic-mark-root"
@@ -65,28 +65,28 @@ exports[`empty demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -104,7 +104,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -115,11 +115,11 @@ exports[`empty demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -128,7 +128,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -151,7 +151,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -160,7 +160,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -205,20 +205,20 @@ exports[`empty demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -236,7 +236,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -247,11 +247,11 @@ exports[`empty demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -260,7 +260,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -283,7 +283,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -292,7 +292,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -337,20 +337,20 @@ exports[`empty demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -368,7 +368,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -379,11 +379,11 @@ exports[`empty demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -392,7 +392,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -415,7 +415,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -424,7 +424,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -469,20 +469,20 @@ exports[`empty demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -500,7 +500,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -511,11 +511,11 @@ exports[`empty demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -524,7 +524,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -547,7 +547,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -556,7 +556,7 @@ exports[`empty demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1503,7 +1503,7 @@ exports[`empty demo > renders simple correctly 1`] = `
 exports[`empty demo > renders style-class correctly 1`] = `
 <div
   class="css-var-root ant-empty empty-demo-root"
-  data-v-f363cf89=""
+  data-v-13e7e764=""
   style="padding: 24px; background: rgb(250, 250, 250);"
 >
   <div
@@ -1583,7 +1583,7 @@ exports[`empty demo > renders style-class correctly 1`] = `
   >
     <button
       class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
-      data-v-f363cf89=""
+      data-v-13e7e764=""
       type="button"
     >
       <transition-stub

--- a/packages/antdv-next/src/input-number/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/input-number/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`input-number demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         style="display: flex; flex-direction: column; gap: 16px;"
@@ -176,28 +176,28 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -218,11 +218,11 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -231,7 +231,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -254,7 +254,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -263,7 +263,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -308,20 +308,20 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -342,11 +342,11 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -355,7 +355,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -378,7 +378,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -387,7 +387,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -432,20 +432,20 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -466,11 +466,11 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -479,7 +479,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -502,7 +502,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -511,7 +511,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -556,20 +556,20 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -590,11 +590,11 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -603,7 +603,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -626,7 +626,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -635,7 +635,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -680,20 +680,20 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -714,11 +714,11 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -727,7 +727,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -750,7 +750,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -759,7 +759,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -804,20 +804,20 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -838,11 +838,11 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -851,7 +851,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -874,7 +874,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -883,7 +883,7 @@ exports[`input-number demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -3043,11 +3043,11 @@ exports[`input-number demo > renders status correctly 1`] = `
 exports[`input-number demo > renders style-class correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
-  data-v-d8f2fdb6=""
+  data-v-cbcba30a=""
 >
   <div
     class="ant-input-number ant-input-number-mode-input css-var-root ant-input-number-css-var shard ant-input-number-outlined shard"
-    data-v-d8f2fdb6=""
+    data-v-cbcba30a=""
   >
     <!---->
     <!---->
@@ -3123,7 +3123,7 @@ exports[`input-number demo > renders style-class correctly 1`] = `
   </div>
   <div
     class="ant-input-number ant-input-number-mode-input css-var-root ant-input-number-css-var shard ant-input-number-outlined ant-input-number-lg shard"
-    data-v-d8f2fdb6=""
+    data-v-cbcba30a=""
     style="background-color: rgba(250, 250, 250, 0.5); border-color: rgb(114, 46, 209);"
   >
     <!---->

--- a/packages/antdv-next/src/input/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/input/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`input demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         style="width: 100%;"
@@ -82,28 +82,28 @@ exports[`input demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -124,11 +124,11 @@ exports[`input demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -137,7 +137,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -160,7 +160,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -169,7 +169,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -214,20 +214,20 @@ exports[`input demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -248,11 +248,11 @@ exports[`input demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -261,7 +261,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -284,7 +284,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -293,7 +293,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -338,20 +338,20 @@ exports[`input demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -372,11 +372,11 @@ exports[`input demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -385,7 +385,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -408,7 +408,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -417,7 +417,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -462,20 +462,20 @@ exports[`input demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -496,11 +496,11 @@ exports[`input demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -509,7 +509,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -532,7 +532,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -541,7 +541,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -586,20 +586,20 @@ exports[`input demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -620,11 +620,11 @@ exports[`input demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -633,7 +633,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -656,7 +656,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -665,7 +665,7 @@ exports[`input demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -717,15 +717,15 @@ exports[`input demo > renders _semantic correctly 1`] = `
 exports[`input demo > renders _semantic-otp correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="ant-otp css-var-v-0 semantic-mark-root"
@@ -844,28 +844,28 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -886,11 +886,11 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -899,7 +899,7 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -922,7 +922,7 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -931,7 +931,7 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -976,20 +976,20 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1010,11 +1010,11 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1023,7 +1023,7 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1046,7 +1046,7 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1055,7 +1055,7 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1100,20 +1100,20 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1134,11 +1134,11 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1147,7 +1147,7 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1170,7 +1170,7 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1179,7 +1179,7 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1231,15 +1231,15 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
 exports[`input demo > renders _semantic-password correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         style="width: 100%;"
@@ -1333,28 +1333,28 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1375,11 +1375,11 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1388,7 +1388,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1411,7 +1411,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1420,7 +1420,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1465,20 +1465,20 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1499,11 +1499,11 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1512,7 +1512,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1535,7 +1535,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1544,7 +1544,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1589,20 +1589,20 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1623,11 +1623,11 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1636,7 +1636,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1659,7 +1659,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1668,7 +1668,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1713,20 +1713,20 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1747,11 +1747,11 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1760,7 +1760,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1783,7 +1783,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1792,7 +1792,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1837,20 +1837,20 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1871,11 +1871,11 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1884,7 +1884,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1907,7 +1907,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1916,7 +1916,7 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1968,15 +1968,15 @@ exports[`input demo > renders _semantic-password correctly 1`] = `
 exports[`input demo > renders _semantic-search correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         style="width: 100%;"
@@ -2093,28 +2093,28 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -2135,11 +2135,11 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2148,7 +2148,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2171,7 +2171,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2180,7 +2180,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2225,20 +2225,20 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -2259,11 +2259,11 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2272,7 +2272,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2295,7 +2295,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2304,7 +2304,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2349,20 +2349,20 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -2383,11 +2383,11 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2396,7 +2396,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2419,7 +2419,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2428,7 +2428,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2473,20 +2473,20 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -2507,11 +2507,11 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2520,7 +2520,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2543,7 +2543,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2552,7 +2552,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2597,20 +2597,20 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -2631,11 +2631,11 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2644,7 +2644,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2667,7 +2667,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2676,7 +2676,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2721,20 +2721,20 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -2755,11 +2755,11 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2768,7 +2768,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2791,7 +2791,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2800,7 +2800,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2845,20 +2845,20 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -2879,11 +2879,11 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2892,7 +2892,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2915,7 +2915,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2924,7 +2924,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2969,20 +2969,20 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -3003,11 +3003,11 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -3016,7 +3016,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -3039,7 +3039,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -3048,7 +3048,7 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -3100,15 +3100,15 @@ exports[`input demo > renders _semantic-search correctly 1`] = `
 exports[`input demo > renders _semantic-textarea correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         style="width: 100%;"
@@ -3141,28 +3141,28 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -3183,11 +3183,11 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -3196,7 +3196,7 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -3219,7 +3219,7 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -3228,7 +3228,7 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -3273,20 +3273,20 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -3307,11 +3307,11 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -3320,7 +3320,7 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -3343,7 +3343,7 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -3352,7 +3352,7 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -3397,20 +3397,20 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -3431,11 +3431,11 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -3444,7 +3444,7 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -3467,7 +3467,7 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -3476,7 +3476,7 @@ exports[`input demo > renders _semantic-textarea correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -6284,11 +6284,11 @@ exports[`input demo > renders status correctly 1`] = `
 exports[`input demo > renders style-class correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-large ant-flex-vertical"
-  data-v-6ca4263f=""
+  data-v-769a5a90=""
 >
   <input
     class="ant-input ant-input-outlined css-var-root ant-input-css-var effect"
-    data-v-6ca4263f=""
+    data-v-769a5a90=""
     name="input-object"
     placeholder="Object"
     type="text"
@@ -6296,7 +6296,7 @@ exports[`input demo > renders style-class correctly 1`] = `
   />
   <input
     class="ant-input ant-input-outlined css-var-root ant-input-css-var effect"
-    data-v-6ca4263f=""
+    data-v-769a5a90=""
     name="input-fn"
     placeholder="Function"
     style="border-color: rgb(105, 111, 199);"
@@ -6306,7 +6306,7 @@ exports[`input demo > renders style-class correctly 1`] = `
   <span
     class="ant-input-affix-wrapper ant-input-textarea-affix-wrapper ant-input-textarea-show-count ant-input-show-count ant-input-outlined css-var-root ant-input-css-var effect"
     data-count="0"
-    data-v-6ca4263f=""
+    data-v-769a5a90=""
     style="border-color: rgb(189, 227, 195);"
   >
     <!---->
@@ -6332,7 +6332,7 @@ exports[`input demo > renders style-class correctly 1`] = `
   </span>
   <span
     class="ant-input-affix-wrapper ant-input-outlined ant-input-password ant-input-password-middle css-var-root ant-input-css-var effect"
-    data-v-6ca4263f=""
+    data-v-769a5a90=""
     style="border-color: rgb(245, 211, 196);"
   >
     <!---->
@@ -6376,7 +6376,7 @@ exports[`input demo > renders style-class correctly 1`] = `
   </span>
   <div
     class="ant-otp css-var-root effect"
-    data-v-6ca4263f=""
+    data-v-769a5a90=""
     name="otp-fn"
     role="group"
   >
@@ -6498,7 +6498,7 @@ exports[`input demo > renders style-class correctly 1`] = `
   </div>
   <div
     class="ant-space-compact css-var-root ant-input-search css-var-root ant-input-search-large effect"
-    data-v-6ca4263f=""
+    data-v-769a5a90=""
     style="color: rgb(77, 168, 218);"
   >
     <input

--- a/packages/antdv-next/src/layout/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/layout/tests/__snapshots__/demo.test.tsx.snap
@@ -3,48 +3,48 @@
 exports[`layout demo > renders basic correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-gap-middle"
-  data-v-579aa1c1=""
+  data-v-8a9a70e8=""
 >
   <div
     class="ant-layout demo-layout css-var-root demo-layout"
-    data-v-579aa1c1=""
+    data-v-8a9a70e8=""
   >
     <header
       class="ant-layout-header demo-header css-var-root demo-header"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
     >
        Header 
     </header>
     <main
       class="ant-layout-content demo-content css-var-root demo-content"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
     >
        Content 
     </main>
     <footer
       class="ant-layout-footer demo-footer css-var-root demo-footer"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
     >
        Footer 
     </footer>
   </div>
   <div
     class="ant-layout demo-layout css-var-root demo-layout"
-    data-v-579aa1c1=""
+    data-v-8a9a70e8=""
   >
     <header
       class="ant-layout-header demo-header css-var-root demo-header"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
     >
        Header 
     </header>
     <div
       class="ant-layout ant-layout-has-sider css-var-root"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
     >
       <aside
         class="ant-layout-sider ant-layout-sider-dark demo-sider css-var-root"
-        data-v-579aa1c1=""
+        data-v-8a9a70e8=""
         style="flex: 0 0 25%; max-width: 25%; min-width: 25%; width: 25%;"
       >
         <div
@@ -56,41 +56,41 @@ exports[`layout demo > renders basic correctly 1`] = `
       </aside>
       <main
         class="ant-layout-content demo-content css-var-root demo-content"
-        data-v-579aa1c1=""
+        data-v-8a9a70e8=""
       >
          Content 
       </main>
     </div>
     <footer
       class="ant-layout-footer demo-footer css-var-root demo-footer"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
     >
        Footer 
     </footer>
   </div>
   <div
     class="ant-layout demo-layout css-var-root demo-layout"
-    data-v-579aa1c1=""
+    data-v-8a9a70e8=""
   >
     <header
       class="ant-layout-header demo-header css-var-root demo-header"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
     >
        Header 
     </header>
     <div
       class="ant-layout ant-layout-has-sider css-var-root"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
     >
       <main
         class="ant-layout-content demo-content css-var-root demo-content"
-        data-v-579aa1c1=""
+        data-v-8a9a70e8=""
       >
          Content 
       </main>
       <aside
         class="ant-layout-sider ant-layout-sider-dark demo-sider css-var-root"
-        data-v-579aa1c1=""
+        data-v-8a9a70e8=""
         style="flex: 0 0 25%; max-width: 25%; min-width: 25%; width: 25%;"
       >
         <div
@@ -103,18 +103,18 @@ exports[`layout demo > renders basic correctly 1`] = `
     </div>
     <footer
       class="ant-layout-footer demo-footer css-var-root demo-footer"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
     >
        Footer 
     </footer>
   </div>
   <div
     class="ant-layout ant-layout-has-sider demo-layout css-var-root demo-layout"
-    data-v-579aa1c1=""
+    data-v-8a9a70e8=""
   >
     <aside
       class="ant-layout-sider ant-layout-sider-dark demo-sider css-var-root"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
       style="flex: 0 0 25%; max-width: 25%; min-width: 25%; width: 25%;"
     >
       <div
@@ -126,23 +126,23 @@ exports[`layout demo > renders basic correctly 1`] = `
     </aside>
     <div
       class="ant-layout css-var-root"
-      data-v-579aa1c1=""
+      data-v-8a9a70e8=""
     >
       <header
         class="ant-layout-header demo-header css-var-root demo-header"
-        data-v-579aa1c1=""
+        data-v-8a9a70e8=""
       >
          Header 
       </header>
       <main
         class="ant-layout-content demo-content css-var-root demo-content"
-        data-v-579aa1c1=""
+        data-v-8a9a70e8=""
       >
          Content 
       </main>
       <footer
         class="ant-layout-footer demo-footer css-var-root demo-footer"
-        data-v-579aa1c1=""
+        data-v-8a9a70e8=""
       >
          Footer 
       </footer>
@@ -154,11 +154,11 @@ exports[`layout demo > renders basic correctly 1`] = `
 exports[`layout demo > renders custom-trigger correctly 1`] = `
 <div
   class="ant-layout ant-layout-has-sider css-var-root"
-  data-v-05304da6=""
+  data-v-abdf83f8=""
 >
   <aside
     class="ant-layout-sider ant-layout-sider-dark css-var-root"
-    data-v-05304da6=""
+    data-v-abdf83f8=""
     style="flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;"
   >
     <div
@@ -166,7 +166,7 @@ exports[`layout demo > renders custom-trigger correctly 1`] = `
     >
       <div
         class="demo-logo-vertical"
-        data-v-05304da6=""
+        data-v-abdf83f8=""
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark css-var-root ant-menu-css-var"
@@ -297,16 +297,16 @@ exports[`layout demo > renders custom-trigger correctly 1`] = `
   </aside>
   <div
     class="ant-layout css-var-root"
-    data-v-05304da6=""
+    data-v-abdf83f8=""
   >
     <header
       class="ant-layout-header custom-header css-var-root custom-header"
-      data-v-05304da6=""
+      data-v-abdf83f8=""
       style="background: rgb(255, 255, 255);"
     >
       <button
         class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only trigger-button"
-        data-v-05304da6=""
+        data-v-abdf83f8=""
         type="button"
       >
         <span
@@ -315,7 +315,7 @@ exports[`layout demo > renders custom-trigger correctly 1`] = `
           <span
             aria-label="menu-fold"
             class="anticon anticon-menu-fold"
-            data-v-05304da6=""
+            data-v-abdf83f8=""
             role="img"
           >
             <svg
@@ -339,7 +339,7 @@ exports[`layout demo > renders custom-trigger correctly 1`] = `
     </header>
     <main
       class="ant-layout-content custom-content css-var-root custom-content"
-      data-v-05304da6=""
+      data-v-abdf83f8=""
       style="background: rgb(255, 255, 255); border-radius: 8px;"
     >
        Content 
@@ -351,15 +351,15 @@ exports[`layout demo > renders custom-trigger correctly 1`] = `
 exports[`layout demo > renders fixed correctly 1`] = `
 <div
   class="ant-layout css-var-root"
-  data-v-37e708ae=""
+  data-v-37deaf19=""
 >
   <header
     class="ant-layout-header demo-header css-var-root demo-header"
-    data-v-37e708ae=""
+    data-v-37deaf19=""
   >
     <div
       class="demo-logo"
-      data-v-37e708ae=""
+      data-v-37deaf19=""
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark demo-menu css-var-root ant-menu-css-var"
@@ -458,11 +458,11 @@ exports[`layout demo > renders fixed correctly 1`] = `
   </header>
   <main
     class="ant-layout-content demo-content css-var-root demo-content"
-    data-v-37e708ae=""
+    data-v-37deaf19=""
   >
     <nav
       class="ant-breadcrumb demo-breadcrumb css-var-root"
-      data-v-37e708ae=""
+      data-v-37deaf19=""
     >
       <ol>
         <li
@@ -507,7 +507,7 @@ exports[`layout demo > renders fixed correctly 1`] = `
     </nav>
     <div
       class="demo-content-box"
-      data-v-37e708ae=""
+      data-v-37deaf19=""
       style="background: rgb(255, 255, 255); border-radius: 8px;"
     >
        Content 
@@ -515,7 +515,7 @@ exports[`layout demo > renders fixed correctly 1`] = `
   </main>
   <footer
     class="ant-layout-footer demo-footer css-var-root demo-footer"
-    data-v-37e708ae=""
+    data-v-37deaf19=""
   >
      Antdv Next ©2026 Created by Ant UED 
   </footer>
@@ -525,11 +525,11 @@ exports[`layout demo > renders fixed correctly 1`] = `
 exports[`layout demo > renders fixed-sider correctly 1`] = `
 <div
   class="ant-layout ant-layout-has-sider css-var-root"
-  data-v-20492677=""
+  data-v-dc441303=""
 >
   <aside
     class="ant-layout-sider ant-layout-sider-dark css-var-root"
-    data-v-20492677=""
+    data-v-dc441303=""
     style="overflow: auto; height: 100vh; position: sticky; inset-inline-start: 0; top: 0px; scrollbar-width: thin; scrollbar-gutter: stable; flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;"
   >
     <div
@@ -537,7 +537,7 @@ exports[`layout demo > renders fixed-sider correctly 1`] = `
     >
       <div
         class="demo-logo-vertical"
-        data-v-20492677=""
+        data-v-dc441303=""
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark css-var-root ant-menu-css-var"
@@ -848,432 +848,432 @@ exports[`layout demo > renders fixed-sider correctly 1`] = `
   </aside>
   <div
     class="ant-layout css-var-root"
-    data-v-20492677=""
+    data-v-dc441303=""
   >
     <header
       class="ant-layout-header fixed-header css-var-root fixed-header"
-      data-v-20492677=""
+      data-v-dc441303=""
       style="background: rgb(255, 255, 255);"
     />
     <main
       class="ant-layout-content fixed-content css-var-root fixed-content"
-      data-v-20492677=""
+      data-v-dc441303=""
     >
       <div
         class="fixed-content-box"
-        data-v-20492677=""
+        data-v-dc441303=""
         style="background: rgb(255, 255, 255); border-radius: 8px;"
       >
         <p
-          data-v-20492677=""
+          data-v-dc441303=""
         >
           long content
         </p>
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
-        />
-        more 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
-        />
-        ... 
-        <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         more 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         more 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         more 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         ... 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
         />
         more 
         <br
-          data-v-20492677=""
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        ... 
+        <br
+          data-v-dc441303=""
+        />
+        more 
+        <br
+          data-v-dc441303=""
         />
       </div>
     </main>
     <footer
       class="ant-layout-footer fixed-footer css-var-root fixed-footer"
-      data-v-20492677=""
+      data-v-dc441303=""
     >
        Antdv Next ©2026 Created by Ant UED 
     </footer>
@@ -1284,11 +1284,11 @@ exports[`layout demo > renders fixed-sider correctly 1`] = `
 exports[`layout demo > renders responsive correctly 1`] = `
 <div
   class="ant-layout ant-layout-has-sider css-var-root"
-  data-v-b36dc6c3=""
+  data-v-c531d7ce=""
 >
   <aside
     class="ant-layout-sider ant-layout-sider-dark ant-layout-sider-collapsed ant-layout-sider-below ant-layout-sider-zero-width css-var-root"
-    data-v-b36dc6c3=""
+    data-v-c531d7ce=""
     style="flex: 0 0 0px; max-width: 0px; min-width: 0px; width: 0px;"
   >
     <div
@@ -1296,7 +1296,7 @@ exports[`layout demo > renders responsive correctly 1`] = `
     >
       <div
         class="demo-logo-vertical"
-        data-v-b36dc6c3=""
+        data-v-c531d7ce=""
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-vertical ant-menu-dark ant-menu-inline-collapsed css-var-root ant-menu-css-var"
@@ -1461,7 +1461,7 @@ exports[`layout demo > renders responsive correctly 1`] = `
       <span
         aria-label="bars"
         class="anticon anticon-bars"
-        data-v-b36dc6c3=""
+        data-v-c531d7ce=""
         role="img"
       >
         <svg
@@ -1482,20 +1482,20 @@ exports[`layout demo > renders responsive correctly 1`] = `
   </aside>
   <div
     class="ant-layout css-var-root"
-    data-v-b36dc6c3=""
+    data-v-c531d7ce=""
   >
     <header
       class="ant-layout-header responsive-header css-var-root responsive-header"
-      data-v-b36dc6c3=""
+      data-v-c531d7ce=""
       style="background: rgb(255, 255, 255);"
     />
     <main
       class="ant-layout-content responsive-content css-var-root responsive-content"
-      data-v-b36dc6c3=""
+      data-v-c531d7ce=""
     >
       <div
         class="responsive-content-box"
-        data-v-b36dc6c3=""
+        data-v-c531d7ce=""
         style="background: rgb(255, 255, 255); border-radius: 8px;"
       >
          content 
@@ -1503,7 +1503,7 @@ exports[`layout demo > renders responsive correctly 1`] = `
     </main>
     <footer
       class="ant-layout-footer responsive-footer css-var-root responsive-footer"
-      data-v-b36dc6c3=""
+      data-v-c531d7ce=""
     >
        Antdv Next ©2026 Created by Ant UED 
     </footer>
@@ -1514,11 +1514,11 @@ exports[`layout demo > renders responsive correctly 1`] = `
 exports[`layout demo > renders side correctly 1`] = `
 <div
   class="ant-layout ant-layout-has-sider side-layout css-var-root side-layout"
-  data-v-a42faed5=""
+  data-v-a29884ea=""
 >
   <aside
     class="ant-layout-sider ant-layout-sider-dark ant-layout-sider-has-trigger css-var-root"
-    data-v-a42faed5=""
+    data-v-a29884ea=""
     style="flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;"
   >
     <div
@@ -1526,7 +1526,7 @@ exports[`layout demo > renders side correctly 1`] = `
     >
       <div
         class="demo-logo-vertical"
-        data-v-a42faed5=""
+        data-v-a29884ea=""
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark css-var-root ant-menu-css-var"
@@ -1785,7 +1785,7 @@ exports[`layout demo > renders side correctly 1`] = `
       <span
         aria-label="left"
         class="anticon anticon-left"
-        data-v-a42faed5=""
+        data-v-a29884ea=""
         role="img"
       >
         <svg
@@ -1806,20 +1806,20 @@ exports[`layout demo > renders side correctly 1`] = `
   </aside>
   <div
     class="ant-layout css-var-root"
-    data-v-a42faed5=""
+    data-v-a29884ea=""
   >
     <header
       class="ant-layout-header side-header css-var-root side-header"
-      data-v-a42faed5=""
+      data-v-a29884ea=""
       style="background: rgb(255, 255, 255);"
     />
     <main
       class="ant-layout-content side-content css-var-root side-content"
-      data-v-a42faed5=""
+      data-v-a29884ea=""
     >
       <nav
         class="ant-breadcrumb side-breadcrumb css-var-root"
-        data-v-a42faed5=""
+        data-v-a29884ea=""
       >
         <ol>
           <li
@@ -1850,7 +1850,7 @@ exports[`layout demo > renders side correctly 1`] = `
       </nav>
       <div
         class="side-content-box"
-        data-v-a42faed5=""
+        data-v-a29884ea=""
         style="background: rgb(255, 255, 255); border-radius: 8px;"
       >
          Bill is a cat. 
@@ -1858,7 +1858,7 @@ exports[`layout demo > renders side correctly 1`] = `
     </main>
     <footer
       class="ant-layout-footer side-footer css-var-root side-footer"
-      data-v-a42faed5=""
+      data-v-a29884ea=""
     >
        Antdv Next ©2026 Created by Ant UED 
     </footer>
@@ -1869,15 +1869,15 @@ exports[`layout demo > renders side correctly 1`] = `
 exports[`layout demo > renders top correctly 1`] = `
 <div
   class="ant-layout css-var-root"
-  data-v-ce68d8a7=""
+  data-v-6c1c6387=""
 >
   <header
     class="ant-layout-header demo-header css-var-root demo-header"
-    data-v-ce68d8a7=""
+    data-v-6c1c6387=""
   >
     <div
       class="demo-logo"
-      data-v-ce68d8a7=""
+      data-v-6c1c6387=""
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark demo-menu css-var-root ant-menu-css-var"
@@ -2180,11 +2180,11 @@ exports[`layout demo > renders top correctly 1`] = `
   </header>
   <main
     class="ant-layout-content demo-content css-var-root demo-content"
-    data-v-ce68d8a7=""
+    data-v-6c1c6387=""
   >
     <nav
       class="ant-breadcrumb demo-breadcrumb css-var-root"
-      data-v-ce68d8a7=""
+      data-v-6c1c6387=""
     >
       <ol>
         <li
@@ -2229,7 +2229,7 @@ exports[`layout demo > renders top correctly 1`] = `
     </nav>
     <div
       class="demo-content-box"
-      data-v-ce68d8a7=""
+      data-v-6c1c6387=""
       style="background: rgb(255, 255, 255); border-radius: 8px;"
     >
        Content 
@@ -2237,7 +2237,7 @@ exports[`layout demo > renders top correctly 1`] = `
   </main>
   <footer
     class="ant-layout-footer demo-footer css-var-root demo-footer"
-    data-v-ce68d8a7=""
+    data-v-6c1c6387=""
   >
      Antdv Next ©2026 Created by Ant UED 
   </footer>
@@ -2247,15 +2247,15 @@ exports[`layout demo > renders top correctly 1`] = `
 exports[`layout demo > renders top-side correctly 1`] = `
 <div
   class="ant-layout css-var-root"
-  data-v-680aeaac=""
+  data-v-6569885e=""
 >
   <header
     class="ant-layout-header demo-header css-var-root demo-header"
-    data-v-680aeaac=""
+    data-v-6569885e=""
   >
     <div
       class="demo-logo"
-      data-v-680aeaac=""
+      data-v-6569885e=""
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark demo-menu css-var-root ant-menu-css-var"
@@ -2354,11 +2354,11 @@ exports[`layout demo > renders top-side correctly 1`] = `
   </header>
   <div
     class="demo-body"
-    data-v-680aeaac=""
+    data-v-6569885e=""
   >
     <nav
       class="ant-breadcrumb demo-breadcrumb css-var-root"
-      data-v-680aeaac=""
+      data-v-6569885e=""
     >
       <ol>
         <li
@@ -2403,12 +2403,12 @@ exports[`layout demo > renders top-side correctly 1`] = `
     </nav>
     <div
       class="ant-layout ant-layout-has-sider demo-inner css-var-root demo-inner"
-      data-v-680aeaac=""
+      data-v-6569885e=""
       style="background: rgb(255, 255, 255); border-radius: 8px;"
     >
       <aside
         class="ant-layout-sider ant-layout-sider-dark css-var-root"
-        data-v-680aeaac=""
+        data-v-6569885e=""
         style="background: rgb(255, 255, 255); flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;"
       >
         <div
@@ -2701,7 +2701,7 @@ exports[`layout demo > renders top-side correctly 1`] = `
       </aside>
       <main
         class="ant-layout-content demo-content css-var-root demo-content"
-        data-v-680aeaac=""
+        data-v-6569885e=""
       >
          Content 
       </main>
@@ -2709,7 +2709,7 @@ exports[`layout demo > renders top-side correctly 1`] = `
   </div>
   <footer
     class="ant-layout-footer demo-footer css-var-root demo-footer"
-    data-v-680aeaac=""
+    data-v-6569885e=""
   >
      Antdv Next ©2026 Created by Ant UED 
   </footer>
@@ -2719,15 +2719,15 @@ exports[`layout demo > renders top-side correctly 1`] = `
 exports[`layout demo > renders top-side-2 correctly 1`] = `
 <div
   class="ant-layout css-var-root"
-  data-v-191fd412=""
+  data-v-6783405e=""
 >
   <header
     class="ant-layout-header demo-header css-var-root demo-header"
-    data-v-191fd412=""
+    data-v-6783405e=""
   >
     <div
       class="demo-logo"
-      data-v-191fd412=""
+      data-v-6783405e=""
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark demo-menu css-var-root ant-menu-css-var"
@@ -2826,11 +2826,11 @@ exports[`layout demo > renders top-side-2 correctly 1`] = `
   </header>
   <div
     class="ant-layout ant-layout-has-sider css-var-root"
-    data-v-191fd412=""
+    data-v-6783405e=""
   >
     <aside
       class="ant-layout-sider ant-layout-sider-dark css-var-root"
-      data-v-191fd412=""
+      data-v-6783405e=""
       style="background: rgb(255, 255, 255); flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;"
     >
       <div
@@ -3123,11 +3123,11 @@ exports[`layout demo > renders top-side-2 correctly 1`] = `
     </aside>
     <div
       class="ant-layout demo-main css-var-root demo-main"
-      data-v-191fd412=""
+      data-v-6783405e=""
     >
       <nav
         class="ant-breadcrumb demo-breadcrumb css-var-root"
-        data-v-191fd412=""
+        data-v-6783405e=""
       >
         <ol>
           <li
@@ -3172,7 +3172,7 @@ exports[`layout demo > renders top-side-2 correctly 1`] = `
       </nav>
       <main
         class="ant-layout-content demo-content css-var-root demo-content"
-        data-v-191fd412=""
+        data-v-6783405e=""
         style="background: rgb(255, 255, 255); border-radius: 8px;"
       >
          Content 

--- a/packages/antdv-next/src/qrcode/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/qrcode/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`qr-code demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="ant-qrcode css-var-v-0 semantic-mark-root"
@@ -60,28 +60,28 @@ exports[`qr-code demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -102,11 +102,11 @@ exports[`qr-code demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -115,7 +115,7 @@ exports[`qr-code demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -138,7 +138,7 @@ exports[`qr-code demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -147,7 +147,7 @@ exports[`qr-code demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -192,20 +192,20 @@ exports[`qr-code demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -226,11 +226,11 @@ exports[`qr-code demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -239,7 +239,7 @@ exports[`qr-code demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -262,7 +262,7 @@ exports[`qr-code demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -271,7 +271,7 @@ exports[`qr-code demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/packages/antdv-next/src/result/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/result/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`result demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="ant-result ant-result-info css-var-v-0 semantic-mark-root"
@@ -83,28 +83,28 @@ exports[`result demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -122,7 +122,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -133,11 +133,11 @@ exports[`result demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -146,7 +146,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -169,7 +169,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -178,7 +178,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -223,20 +223,20 @@ exports[`result demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -254,7 +254,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -265,11 +265,11 @@ exports[`result demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -278,7 +278,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -301,7 +301,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -310,7 +310,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -355,20 +355,20 @@ exports[`result demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -386,7 +386,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -397,11 +397,11 @@ exports[`result demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -410,7 +410,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -433,7 +433,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -442,7 +442,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -487,20 +487,20 @@ exports[`result demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -518,7 +518,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -529,11 +529,11 @@ exports[`result demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -542,7 +542,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -565,7 +565,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -574,7 +574,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -619,20 +619,20 @@ exports[`result demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -650,7 +650,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -661,11 +661,11 @@ exports[`result demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -674,7 +674,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -697,7 +697,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -706,7 +706,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -751,20 +751,20 @@ exports[`result demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -782,7 +782,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -793,11 +793,11 @@ exports[`result demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -806,7 +806,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -829,7 +829,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -838,7 +838,7 @@ exports[`result demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/packages/antdv-next/src/segmented/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/segmented/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`segmented demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         aria-label="segmented control"
@@ -115,28 +115,28 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -154,7 +154,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -165,11 +165,11 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -178,7 +178,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -201,7 +201,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -210,7 +210,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -255,20 +255,20 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -286,7 +286,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -297,11 +297,11 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -310,7 +310,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -333,7 +333,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -342,7 +342,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -387,20 +387,20 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -418,7 +418,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -429,11 +429,11 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -442,7 +442,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -465,7 +465,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -474,7 +474,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -519,20 +519,20 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -550,7 +550,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -561,11 +561,11 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -574,7 +574,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -597,7 +597,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -606,7 +606,7 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2051,13 +2051,13 @@ exports[`segmented demo > renders size correctly 1`] = `
 exports[`segmented demo > renders style-class correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
-  data-v-af829106=""
+  data-v-0de51c46=""
 >
   <div
     aria-label="segmented control"
     class="ant-segmented custom-segmented-root css-var-root custom-segmented-root css-var-root"
     classes="[object Object]"
-    data-v-af829106=""
+    data-v-0de51c46=""
     role="radiogroup"
     size="middle"
     style="padding: 4px; width: 260px;"
@@ -2200,7 +2200,7 @@ exports[`segmented demo > renders style-class correctly 1`] = `
     aria-label="segmented control"
     class="ant-segmented ant-segmented-vertical custom-segmented-root ant-segmented-vertical css-var-root custom-segmented-root ant-segmented-vertical css-var-root"
     classes="[object Object]"
-    data-v-af829106=""
+    data-v-0de51c46=""
     role="radiogroup"
     size="middle"
     style="border: 1px solid rgb(119, 190, 240); padding: 4px; width: 100px;"

--- a/packages/antdv-next/src/select/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/select/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`select demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         style="position: absolute; height: 200px;"
@@ -140,28 +140,28 @@ exports[`select demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -182,11 +182,11 @@ exports[`select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -195,7 +195,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -218,7 +218,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -227,7 +227,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -272,20 +272,20 @@ exports[`select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -306,11 +306,11 @@ exports[`select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -319,7 +319,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -342,7 +342,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -351,7 +351,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -396,20 +396,20 @@ exports[`select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -430,11 +430,11 @@ exports[`select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -443,7 +443,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -466,7 +466,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -475,7 +475,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -520,20 +520,20 @@ exports[`select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -554,11 +554,11 @@ exports[`select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -567,7 +567,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -590,7 +590,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -599,7 +599,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -644,20 +644,20 @@ exports[`select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -678,11 +678,11 @@ exports[`select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -691,7 +691,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -714,7 +714,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -723,7 +723,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -768,20 +768,20 @@ exports[`select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -802,11 +802,11 @@ exports[`select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -815,7 +815,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -838,7 +838,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -847,7 +847,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -892,20 +892,20 @@ exports[`select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -926,11 +926,11 @@ exports[`select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -939,7 +939,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -962,7 +962,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -971,7 +971,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1016,20 +1016,20 @@ exports[`select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1050,11 +1050,11 @@ exports[`select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1063,7 +1063,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1086,7 +1086,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1095,7 +1095,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1140,20 +1140,20 @@ exports[`select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1174,11 +1174,11 @@ exports[`select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1187,7 +1187,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1210,7 +1210,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1219,7 +1219,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1264,20 +1264,20 @@ exports[`select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1298,11 +1298,11 @@ exports[`select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1311,7 +1311,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1334,7 +1334,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1343,7 +1343,7 @@ exports[`select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/packages/antdv-next/src/skeleton/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/skeleton/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`skeleton demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="ant-skeleton ant-skeleton-with-avatar semantic-mark-root css-var-v-0"
@@ -43,28 +43,28 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -82,7 +82,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -93,11 +93,11 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -106,7 +106,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -129,7 +129,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -138,7 +138,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -183,20 +183,20 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -214,7 +214,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -225,11 +225,11 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -238,7 +238,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -261,7 +261,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -270,7 +270,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -315,20 +315,20 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -346,7 +346,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -357,11 +357,11 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -370,7 +370,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -393,7 +393,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -402,7 +402,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -447,20 +447,20 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -478,7 +478,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -489,11 +489,11 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -502,7 +502,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -525,7 +525,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -534,7 +534,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -579,20 +579,20 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -610,7 +610,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -621,11 +621,11 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -634,7 +634,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -657,7 +657,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -666,7 +666,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -711,20 +711,20 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -742,7 +742,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -753,11 +753,11 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -766,7 +766,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -789,7 +789,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -798,7 +798,7 @@ exports[`skeleton demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1670,13 +1670,13 @@ exports[`skeleton demo > renders element correctly 1`] = `
 
 exports[`skeleton demo > renders list correctly 1`] = `
 <div
-  data-v-48b18ec8=""
+  data-v-a84cf8c1=""
 >
   <button
     aria-checked="false"
     checked="false"
     class="ant-switch css-var-root"
-    data-v-48b18ec8=""
+    data-v-a84cf8c1=""
     role="switch"
     style="margin-bottom: 16px;"
     type="button"
@@ -1703,7 +1703,7 @@ exports[`skeleton demo > renders list correctly 1`] = `
   </button>
   <a-list
     data-source="[object Object],[object Object],[object Object]"
-    data-v-48b18ec8=""
+    data-v-a84cf8c1=""
     item-layout="vertical"
     size="large"
   />
@@ -1713,11 +1713,11 @@ exports[`skeleton demo > renders list correctly 1`] = `
 exports[`skeleton demo > renders style-class correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-gap-middle"
-  data-v-71d571c0=""
+  data-v-f65891a8=""
 >
   <div
     class="ant-skeleton ant-skeleton-with-avatar skeleton-root css-var-root"
-    data-v-71d571c0=""
+    data-v-f65891a8=""
   >
     <div
       class="skeleton-header ant-skeleton-header"
@@ -1739,7 +1739,7 @@ exports[`skeleton demo > renders style-class correctly 1`] = `
   </div>
   <div
     class="ant-skeleton ant-skeleton-active skeleton-root css-var-root"
-    data-v-71d571c0=""
+    data-v-f65891a8=""
     style="border: 1px solid rgba(229, 243, 254, 0.3);"
   >
     <!---->

--- a/packages/antdv-next/src/space/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/space/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`space demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-v-0 semantic-mark-root"
@@ -104,28 +104,28 @@ exports[`space demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -146,11 +146,11 @@ exports[`space demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -159,7 +159,7 @@ exports[`space demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -182,7 +182,7 @@ exports[`space demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -191,7 +191,7 @@ exports[`space demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -236,20 +236,20 @@ exports[`space demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -270,11 +270,11 @@ exports[`space demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -283,7 +283,7 @@ exports[`space demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -306,7 +306,7 @@ exports[`space demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -315,7 +315,7 @@ exports[`space demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -360,20 +360,20 @@ exports[`space demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -394,11 +394,11 @@ exports[`space demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -407,7 +407,7 @@ exports[`space demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -430,7 +430,7 @@ exports[`space demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -439,7 +439,7 @@ exports[`space demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/packages/antdv-next/src/spin/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/spin/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`spin demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         style="position: relative; width: 500px; height: 100px; display: flex; align-items: center; justify-content: center;"
@@ -49,28 +49,28 @@ exports[`spin demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -88,7 +88,7 @@ exports[`spin demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -99,11 +99,11 @@ exports[`spin demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -112,7 +112,7 @@ exports[`spin demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -135,7 +135,7 @@ exports[`spin demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -144,7 +144,7 @@ exports[`spin demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -189,20 +189,20 @@ exports[`spin demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -220,7 +220,7 @@ exports[`spin demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -231,11 +231,11 @@ exports[`spin demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -244,7 +244,7 @@ exports[`spin demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -267,7 +267,7 @@ exports[`spin demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -276,7 +276,7 @@ exports[`spin demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/packages/antdv-next/src/statistic/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/statistic/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`statistic demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         style="position: absolute;"
@@ -80,28 +80,28 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -119,7 +119,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -130,11 +130,11 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -143,7 +143,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -166,7 +166,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -175,7 +175,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -220,20 +220,20 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -251,7 +251,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -262,11 +262,11 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -275,7 +275,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -298,7 +298,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -307,7 +307,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -352,20 +352,20 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -383,7 +383,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -394,11 +394,11 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -407,7 +407,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -430,7 +430,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -439,7 +439,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -484,20 +484,20 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -515,7 +515,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -526,11 +526,11 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -539,7 +539,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -562,7 +562,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -571,7 +571,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -616,20 +616,20 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -647,7 +647,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -658,11 +658,11 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -671,7 +671,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -694,7 +694,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -703,7 +703,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -748,20 +748,20 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -779,7 +779,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -790,11 +790,11 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -803,7 +803,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -826,7 +826,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -835,7 +835,7 @@ exports[`statistic demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1175,11 +1175,11 @@ exports[`statistic demo > renders card correctly 1`] = `
 exports[`statistic demo > renders style-class correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
-  data-v-aae0cc76=""
+  data-v-739f6bf9=""
 >
   <div
     class="ant-statistic custom-statistic-root css-var-root"
-    data-v-aae0cc76=""
+    data-v-739f6bf9=""
   >
     <div
       class="ant-statistic-header"
@@ -1201,7 +1201,7 @@ exports[`statistic demo > renders style-class correctly 1`] = `
         <span
           aria-label="arrow-up"
           class="anticon anticon-arrow-up"
-          data-v-aae0cc76=""
+          data-v-739f6bf9=""
           role="img"
         >
           <svg
@@ -1237,7 +1237,7 @@ exports[`statistic demo > renders style-class correctly 1`] = `
   </div>
   <div
     class="ant-statistic custom-statistic-root css-var-root"
-    data-v-aae0cc76=""
+    data-v-739f6bf9=""
   >
     <div
       class="ant-statistic-header"
@@ -1259,7 +1259,7 @@ exports[`statistic demo > renders style-class correctly 1`] = `
         <span
           aria-label="arrow-down"
           class="anticon anticon-arrow-down"
-          data-v-aae0cc76=""
+          data-v-739f6bf9=""
           role="img"
         >
           <svg

--- a/packages/antdv-next/src/switch/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/switch/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`switch demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <button
         aria-checked="false"
@@ -44,28 +44,28 @@ exports[`switch demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -83,7 +83,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -94,11 +94,11 @@ exports[`switch demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -107,7 +107,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -130,7 +130,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -139,7 +139,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -184,20 +184,20 @@ exports[`switch demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -215,7 +215,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -226,11 +226,11 @@ exports[`switch demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -239,7 +239,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -262,7 +262,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -271,7 +271,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -316,20 +316,20 @@ exports[`switch demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -347,7 +347,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.3
                   <!---->
@@ -358,11 +358,11 @@ exports[`switch demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -371,7 +371,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -394,7 +394,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -403,7 +403,7 @@ exports[`switch demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -752,13 +752,13 @@ exports[`switch demo > renders size correctly 1`] = `
 exports[`switch demo > renders style-class correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
-  data-v-9d494092=""
+  data-v-355da09f=""
 >
   <button
     aria-checked="false"
     checked="false"
     class="ant-switch ant-switch-small custom-switch-root css-var-root"
-    data-v-9d494092=""
+    data-v-355da09f=""
     role="switch"
     style="background-color: rgb(245, 210, 210);"
     type="button"
@@ -787,7 +787,7 @@ exports[`switch demo > renders style-class correctly 1`] = `
     aria-checked="false"
     checked="false"
     class="ant-switch custom-switch-root css-var-root"
-    data-v-9d494092=""
+    data-v-355da09f=""
     role="switch"
     style="background-color: rgb(189, 227, 195);"
     type="button"

--- a/packages/antdv-next/src/tag/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/tag/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`tag demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <span
         class="ant-tag semantic-mark-root ant-tag-filled css-var-v-0"
@@ -47,28 +47,28 @@ exports[`tag demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -86,7 +86,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -97,11 +97,11 @@ exports[`tag demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -110,7 +110,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -133,7 +133,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -142,7 +142,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -187,20 +187,20 @@ exports[`tag demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -218,7 +218,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -229,11 +229,11 @@ exports[`tag demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -242,7 +242,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -265,7 +265,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -274,7 +274,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -319,20 +319,20 @@ exports[`tag demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -350,7 +350,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -361,11 +361,11 @@ exports[`tag demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -374,7 +374,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -397,7 +397,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -406,7 +406,7 @@ exports[`tag demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2828,24 +2828,24 @@ exports[`tag demo > renders status correctly 1`] = `
 exports[`tag demo > renders style-class correctly 1`] = `
 <div
   class="ant-space ant-space-vertical ant-space-gap-row-large ant-space-gap-col-large css-var-root"
-  data-v-68e04929=""
+  data-v-7f4de261=""
 >
   <div
     class="ant-space-item"
   >
     <div
       class="ant-flex css-var-root ant-flex-gap-middle"
-      data-v-68e04929=""
+      data-v-7f4de261=""
     >
       <span
         class="ant-tag custom-tag-root ant-tag-filled css-var-root"
-        data-v-68e04929=""
+        data-v-7f4de261=""
         style="background-color: rgb(230, 247, 255);"
       >
         <span
           aria-label="check-circle"
           class="anticon anticon-check-circle"
-          data-v-68e04929=""
+          data-v-7f4de261=""
           role="img"
           style="color: rgb(82, 196, 26);"
         >
@@ -2877,13 +2877,13 @@ exports[`tag demo > renders style-class correctly 1`] = `
       </span>
       <span
         class="ant-tag custom-tag-root ant-tag-filled css-var-root"
-        data-v-68e04929=""
+        data-v-7f4de261=""
         style="background-color: rgb(245, 239, 255);"
       >
         <span
           aria-label="close-circle"
           class="anticon anticon-close-circle"
-          data-v-68e04929=""
+          data-v-7f4de261=""
           role="img"
           style="color: rgb(143, 135, 241);"
         >
@@ -2919,11 +2919,11 @@ exports[`tag demo > renders style-class correctly 1`] = `
   >
     <div
       class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
-      data-v-68e04929=""
+      data-v-7f4de261=""
     >
       <div
         class="ant-tag-checkable-group css-var-root custom-tag-root"
-        data-v-68e04929=""
+        data-v-7f4de261=""
         style="gap: 12px; padding: 8px 12px; background-color: rgba(82, 196, 26, 0.08); border-radius: 8px;"
       >
         <span
@@ -2956,7 +2956,7 @@ exports[`tag demo > renders style-class correctly 1`] = `
       </div>
       <div
         class="ant-tag-checkable-group css-var-root custom-tag-root"
-        data-v-68e04929=""
+        data-v-7f4de261=""
         style="gap: 16px; padding: 8px 12px; background-color: rgba(143, 135, 241, 0.08); border-radius: 8px;"
       >
         <span

--- a/packages/antdv-next/src/transfer/tests/__snapshots__/demo.test.ts.snap
+++ b/packages/antdv-next/src/transfer/tests/__snapshots__/demo.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`transfer demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="ant-transfer css-var-v-0 ant-transfer-css-var semantic-mark-root"
@@ -824,28 +824,28 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -866,11 +866,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -879,7 +879,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -902,7 +902,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -911,7 +911,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -956,20 +956,20 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -990,11 +990,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1003,7 +1003,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1026,7 +1026,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1035,7 +1035,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1080,20 +1080,20 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1114,11 +1114,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1127,7 +1127,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1150,7 +1150,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1159,7 +1159,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1204,20 +1204,20 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1238,11 +1238,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1251,7 +1251,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1274,7 +1274,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1283,7 +1283,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1328,20 +1328,20 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1362,11 +1362,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1375,7 +1375,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1398,7 +1398,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1407,7 +1407,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1452,20 +1452,20 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1486,11 +1486,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1499,7 +1499,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1522,7 +1522,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1531,7 +1531,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1576,20 +1576,20 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1610,11 +1610,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1623,7 +1623,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1646,7 +1646,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1655,7 +1655,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1700,20 +1700,20 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1734,11 +1734,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1747,7 +1747,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1770,7 +1770,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1779,7 +1779,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1824,20 +1824,20 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1858,11 +1858,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1871,7 +1871,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1894,7 +1894,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1903,7 +1903,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1948,20 +1948,20 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1982,11 +1982,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1995,7 +1995,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2018,7 +2018,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2027,7 +2027,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2072,20 +2072,20 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -2106,11 +2106,11 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2119,7 +2119,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -2142,7 +2142,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -2151,7 +2151,7 @@ exports[`transfer demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -3994,7 +3994,7 @@ exports[`transfer demo > renders basic correctly 1`] = `
 exports[`transfer demo > renders custom-item correctly 1`] = `
 <div
   class="ant-transfer css-var-root ant-transfer-css-var"
-  data-v-452d0f41=""
+  data-v-2cf4954d=""
 >
   <div
     class="ant-transfer-section"
@@ -6886,12 +6886,12 @@ exports[`transfer demo > renders status correctly 1`] = `
 exports[`transfer demo > renders style-class correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-large ant-flex-vertical"
-  data-v-daae5a8a=""
+  data-v-77803f29=""
   style="width: 100%;"
 >
   <div
     class="ant-transfer ant-transfer-status-error css-var-root ant-transfer-css-var"
-    data-v-daae5a8a=""
+    data-v-77803f29=""
   >
     <div
       class="ant-transfer-section transfer-demo-section"
@@ -7546,7 +7546,7 @@ exports[`transfer demo > renders style-class correctly 1`] = `
   </div>
   <div
     class="ant-transfer ant-transfer-status-warning css-var-root ant-transfer-css-var"
-    data-v-daae5a8a=""
+    data-v-77803f29=""
   >
     <div
       class="ant-transfer-section transfer-demo-section"
@@ -8207,7 +8207,7 @@ exports[`transfer demo > renders style-class correctly 1`] = `
 exports[`transfer demo > renders tree-transfer correctly 1`] = `
 <div
   class="ant-transfer ant-transfer-customize-list css-var-root ant-transfer-css-var tree-transfer"
-  data-v-efe414ce=""
+  data-v-6ddf457b=""
 >
   <div
     class="ant-transfer-section"
@@ -8233,12 +8233,12 @@ exports[`transfer demo > renders tree-transfer correctly 1`] = `
         class="ant-transfer-list-body-customize-wrapper"
       >
         <div
-          data-v-efe414ce=""
+          data-v-6ddf457b=""
           style="padding: 8px;"
         >
           <div
             class="ant-tree ant-tree-icon-hide ant-tree-block-node css-var-root"
-            data-v-efe414ce=""
+            data-v-6ddf457b=""
           >
             <div
               aria-hidden="true"

--- a/packages/antdv-next/src/tree-select/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/tree-select/tests/__snapshots__/demo.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`tree-select demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         style="position: absolute; height: 200px;"
@@ -133,28 +133,28 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -175,11 +175,11 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -188,7 +188,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -211,7 +211,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -220,7 +220,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -265,20 +265,20 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -299,11 +299,11 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -312,7 +312,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -335,7 +335,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -344,7 +344,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -389,20 +389,20 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -423,11 +423,11 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -436,7 +436,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -459,7 +459,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -468,7 +468,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -513,20 +513,20 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -547,11 +547,11 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -560,7 +560,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -583,7 +583,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -592,7 +592,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -637,20 +637,20 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -671,11 +671,11 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -684,7 +684,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -707,7 +707,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -716,7 +716,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -761,20 +761,20 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -795,11 +795,11 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -808,7 +808,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -831,7 +831,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -840,7 +840,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -885,20 +885,20 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -919,11 +919,11 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -932,7 +932,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -955,7 +955,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -964,7 +964,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1009,20 +1009,20 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -1043,11 +1043,11 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1056,7 +1056,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -1079,7 +1079,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -1088,7 +1088,7 @@ exports[`tree-select demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/packages/antdv-next/src/tree/tests/__snapshots__/demo.test.ts.snap
+++ b/packages/antdv-next/src/tree/tests/__snapshots__/demo.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`tree demo > renders _semantic correctly 1`] = `
 <div
   class="semantic-preview-container"
-  data-v-0e8f6da1=""
+  data-v-dfc8ebef=""
 >
   <div
     class="ant-row css-var-root semantic-preview-row"
-    data-v-0e8f6da1=""
+    data-v-dfc8ebef=""
   >
     <div
       class="ant-col ant-col-16 css-var-root semantic-preview-col"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <div
         class="ant-tree css-var-v-0 semantic-mark-root"
@@ -243,28 +243,28 @@ exports[`tree demo > renders _semantic correctly 1`] = `
     </div>
     <div
       class="ant-col ant-col-8 css-var-root"
-      data-v-0e8f6da1=""
+      data-v-dfc8ebef=""
     >
       <ul
         class="semantic-list"
-        data-v-0e8f6da1=""
+        data-v-dfc8ebef=""
       >
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -282,7 +282,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -293,11 +293,11 @@ exports[`tree demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -306,7 +306,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -329,7 +329,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -338,7 +338,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -383,20 +383,20 @@ exports[`tree demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -414,7 +414,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -425,11 +425,11 @@ exports[`tree demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -438,7 +438,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -461,7 +461,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -470,7 +470,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -515,20 +515,20 @@ exports[`tree demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -546,7 +546,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -557,11 +557,11 @@ exports[`tree demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -570,7 +570,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -593,7 +593,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -602,7 +602,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -647,20 +647,20 @@ exports[`tree demo > renders _semantic correctly 1`] = `
         </li>
         <li
           class="semantic-list-item"
-          data-v-0e8f6da1=""
+          data-v-dfc8ebef=""
         >
           <div
             class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-            data-v-0e8f6da1=""
+            data-v-dfc8ebef=""
           >
             <div
               class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
-              data-v-0e8f6da1=""
+              data-v-dfc8ebef=""
             >
               <!-- Title + Version -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <h5
                   class="ant-typography css-var-root"
@@ -678,7 +678,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                 >
                   1.0.0
                   <!---->
@@ -689,11 +689,11 @@ exports[`tree demo > renders _semantic correctly 1`] = `
               <!-- Pin + Sample -->
               <div
                 class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
-                data-v-0e8f6da1=""
+                data-v-dfc8ebef=""
               >
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -702,7 +702,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="pushpin"
                       class="anticon anticon-pushpin"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg
@@ -725,7 +725,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                 </button>
                 <button
                   class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
-                  data-v-0e8f6da1=""
+                  data-v-dfc8ebef=""
                   type="button"
                 >
                   <span
@@ -734,7 +734,7 @@ exports[`tree demo > renders _semantic correctly 1`] = `
                     <span
                       aria-label="info-circle"
                       class="anticon anticon-info-circle"
-                      data-v-0e8f6da1=""
+                      data-v-dfc8ebef=""
                       role="img"
                     >
                       <svg

--- a/tests/shared/demoTest.ts
+++ b/tests/shared/demoTest.ts
@@ -13,7 +13,7 @@ interface DemoTestOptions {
 }
 
 export default function demoTest(component: string, options: DemoTestOptions = {}) {
-  const demoDir = resolve(rootDir, 'playground/src/pages/components', component, 'demo')
+  const demoDir = resolve(rootDir, 'docs/src/pages/components', component, 'demo')
 
   let files: string[] = []
   try {

--- a/vitest-plugin.ts
+++ b/vitest-plugin.ts
@@ -43,7 +43,7 @@ export default defineConfig({
       },
       {
         find: '@',
-        replacement: path.resolve(baseUrl, './playground/src'),
+        replacement: path.resolve(baseUrl, './docs/src'),
       },
     ],
   },


### PR DESCRIPTION
## 问题

#195 重构将文档站从 `playground/` 迁移到 `docs/`，但有两处引用未同步更新：

1. `tests/shared/demoTest.ts` L16：demo 目录路径仍指向 `playground/src/pages/components`
2. `vitest-plugin.ts` L46：`@` alias 仍指向 `./playground/src`

导致 **64 个 demo 测试全部静默 skip**（不会报错，只是 `describe.skip`），25 个已有的 demo snapshot 成为死文件，不再被任何测试验证。

## 修复

- `tests/shared/demoTest.ts`：`playground/src/pages/components` → `docs/src/pages/components`
- `vitest-plugin.ts`：`@` alias `./playground/src` → `./docs/src`
- 重新生成 25 个 demo snapshot（因文件路径变化导致 Vue scoped style hash 更新）

## 验证

修复后全量测试：`123 test files passed, 57 snapshots updated, 0 failed`