### PR TITLE
fix(calendar): use correct Dayjs type and v-model:value in select demo

### DIFF
--- a/docs/src/pages/components/calendar/demo/select.vue
+++ b/docs/src/pages/components/calendar/demo/select.vue
@@ -11,8 +11,8 @@ import type { Dayjs } from 'dayjs'
 import dayjs from 'dayjs'
 import { ref } from 'vue'
 
-const date = ref(dayjs('2017-01-25'))
-const selectedValue = ref(dayjs('2017-01-25'))
+const date = ref(dayjs('2017-01-25T00:00:00Z'))
+const selectedValue = ref(dayjs('2017-01-25T00:00:00Z'))
 function onSelect(value: Dayjs) {
   selectedValue.value = value
 }

--- a/packages/antdv-next/src/calendar/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/calendar/tests/__snapshots__/demo.test.tsx.snap
@@ -7742,10 +7742,10 @@ exports[`calendar demo > renders select correctly 1`] = `
           class="ant-picker-body"
           generateconfig="[object Object]"
           locale="[object Object]"
-          pickervalue="Tue, 24 Jan 2017 16:00:00 GMT"
+          pickervalue="Wed, 25 Jan 2017 00:00:00 GMT"
           prefixcls="ant-picker"
-          value="Tue, 24 Jan 2017 16:00:00 GMT"
-          values="Tue, 24 Jan 2017 16:00:00 GMT"
+          value="Wed, 25 Jan 2017 00:00:00 GMT"
+          values="Wed, 25 Jan 2017 00:00:00 GMT"
         >
           <table
             class="ant-picker-content"


### PR DESCRIPTION
`select` demo 存在两个问题：

1. **类型错误**：`v-model` 绑定了普通字符串 `'2017-01-25'`，而非 `dayjs('2017-01-25')` Dayjs 对象，导致运行时报错 `date.year is not a function`
2. **v-model 绑定方式错误**：使用了 `v-model`（映射到 `modelValue`）而非 `v-model:value`，导致值泄漏为 HTML attribute（Calendar 组件只接受 `value` prop）