### PR TITLE
test(radio): add unit tests for Radio, RadioGroup, RadioButton

### DIFF
--- a/packages/antdv-next/src/radio/tests/Radio.semantic.test.tsx
+++ b/packages/antdv-next/src/radio/tests/Radio.semantic.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import Radio from '..'
+import ConfigProvider from '../../config-provider'
+import { mount } from '/@tests/utils'
+
+const prefixCls = 'ant-radio'
+
+describe('radio semantic', () => {
+  // ===================== classes (object form) =====================
+
+  it('should apply semantic classes as object', () => {
+    const wrapper = mount(Radio, {
+      props: {
+        classes: {
+          root: 'custom-root',
+          icon: 'custom-icon',
+          label: 'custom-label',
+        },
+      },
+      slots: { default: () => 'Test' },
+    })
+    expect(wrapper.find('label').classes()).toContain('custom-root')
+    expect(wrapper.find(`.${prefixCls}`).classes()).toContain('custom-icon')
+    expect(wrapper.find(`.${prefixCls}-label`).classes()).toContain('custom-label')
+  })
+
+  // ===================== styles (object form) =====================
+
+  it('should apply semantic styles as object', () => {
+    const wrapper = mount(Radio, {
+      props: {
+        styles: {
+          root: { backgroundColor: 'rgb(255, 0, 0)' },
+          icon: { backgroundColor: 'rgb(0, 255, 0)' },
+          label: { backgroundColor: 'rgb(0, 0, 255)' },
+        },
+      },
+      slots: { default: () => 'Test' },
+    })
+    expect(wrapper.find('label').attributes('style')).toContain('background-color: rgb(255, 0, 0)')
+    expect(wrapper.find(`.${prefixCls}`).attributes('style')).toContain('background-color: rgb(0, 255, 0)')
+    expect(wrapper.find(`.${prefixCls}-label`).attributes('style')).toContain('background-color: rgb(0, 0, 255)')
+  })
+
+  // ===================== both classes and styles =====================
+
+  it('should support both classes and styles together', () => {
+    const wrapper = mount(Radio, {
+      props: {
+        classes: { root: 'c-root', icon: 'c-icon', label: 'c-label' },
+        styles: {
+          root: { color: 'rgb(255, 0, 0)' },
+          icon: { color: 'rgb(0, 255, 0)' },
+          label: { color: 'rgb(0, 0, 255)' },
+        },
+      },
+      slots: { default: () => 'Test' },
+    })
+    expect(wrapper.find('label').classes()).toContain('c-root')
+    expect(wrapper.find('label').attributes('style')).toContain('color: rgb(255, 0, 0)')
+    expect(wrapper.find(`.${prefixCls}`).classes()).toContain('c-icon')
+    expect(wrapper.find(`.${prefixCls}`).attributes('style')).toContain('color: rgb(0, 255, 0)')
+    expect(wrapper.find(`.${prefixCls}-label`).classes()).toContain('c-label')
+    expect(wrapper.find(`.${prefixCls}-label`).attributes('style')).toContain('color: rgb(0, 0, 255)')
+  })
+
+  // ===================== ConfigProvider semantic merging =====================
+
+  it('should merge ConfigProvider classes with component classes', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider radio={{ classes: { root: 'ctx-root', icon: 'ctx-icon' } }}>
+        <Radio classes={{ root: 'comp-root', label: 'comp-label' }}>Test</Radio>
+      </ConfigProvider>
+    ))
+    const label = wrapper.find('label')
+    expect(label.classes()).toContain('ctx-root')
+    expect(label.classes()).toContain('comp-root')
+    expect(wrapper.find(`.${prefixCls}`).classes()).toContain('ctx-icon')
+    expect(wrapper.find(`.${prefixCls}-label`).classes()).toContain('comp-label')
+  })
+
+  it('should merge ConfigProvider styles with component styles', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider radio={{ styles: { root: { margin: '1px' } } }}>
+        <Radio styles={{ root: { padding: '2px' } }}>Test</Radio>
+      </ConfigProvider>
+    ))
+    const style = wrapper.find('label').attributes('style')!
+    expect(style).toContain('margin: 1px')
+    expect(style).toContain('padding: 2px')
+  })
+
+  // ===================== partial classes =====================
+
+  it('should apply partial classes without affecting other slots', () => {
+    const wrapper = mount(Radio, {
+      props: {
+        classes: { root: 'only-root' },
+      },
+      slots: { default: () => 'Test' },
+    })
+    expect(wrapper.find('label').classes()).toContain('only-root')
+    // icon and label should not have extra custom classes
+    expect(wrapper.find(`.${prefixCls}`).classes()).not.toContain('only-root')
+    expect(wrapper.find(`.${prefixCls}-label`).classes()).not.toContain('only-root')
+  })
+
+  it('should apply partial styles without affecting other slots', () => {
+    const wrapper = mount(Radio, {
+      props: {
+        styles: { icon: { color: 'rgb(255, 0, 0)' } },
+      },
+      slots: { default: () => 'Test' },
+    })
+    expect(wrapper.find(`.${prefixCls}`).attributes('style')).toContain('color: rgb(255, 0, 0)')
+    // root should not have the style
+    expect(wrapper.find('label').attributes('style') ?? '').not.toContain('color: rgb(255, 0, 0)')
+  })
+})

--- a/packages/antdv-next/src/radio/tests/Radio.test.tsx
+++ b/packages/antdv-next/src/radio/tests/Radio.test.tsx
@@ -1,0 +1,861 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import Radio, { RadioButton, RadioGroup } from '..'
+import ConfigProvider from '../../config-provider'
+import { useFormItemInputContextProvider } from '../../form/context'
+import mountTest from '/@tests/shared/mountTest'
+import rtlTest from '/@tests/shared/rtlTest'
+import { mount } from '/@tests/utils'
+
+const prefixCls = 'ant-radio'
+const groupPrefixCls = `${prefixCls}-group`
+
+describe('radio', () => {
+  mountTest(Radio)
+  mountTest(RadioGroup)
+  mountTest(RadioButton)
+  rtlTest(() => h(Radio))
+  rtlTest(() => h(RadioGroup))
+  rtlTest(() => h(RadioButton))
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ===================== Basic rendering =====================
+
+  it('should render a label wrapper with radio input', () => {
+    const wrapper = mount(Radio)
+    expect(wrapper.find('label').exists()).toBe(true)
+    expect(wrapper.find('label').classes()).toContain(`${prefixCls}-wrapper`)
+    expect(wrapper.find('input[type="radio"]').exists()).toBe(true)
+  })
+
+  it('should render children in label span', () => {
+    const wrapper = mount(Radio, {
+      slots: { default: () => 'Option A' },
+    })
+    const label = wrapper.find(`.${prefixCls}-label`)
+    expect(label.exists()).toBe(true)
+    expect(label.text()).toBe('Option A')
+  })
+
+  it('should not render label span when no children', () => {
+    const wrapper = mount(Radio)
+    expect(wrapper.find(`.${prefixCls}-label`).exists()).toBe(false)
+  })
+
+  it('should not render label span when children are empty', () => {
+    const wrapper = mount(Radio, {
+      slots: { default: () => '' },
+    })
+    expect(wrapper.find(`.${prefixCls}-label`).exists()).toBe(false)
+  })
+
+  // ===================== checked prop =====================
+
+  it('should be checked when checked is true', () => {
+    const wrapper = mount(Radio, {
+      props: { checked: true },
+    })
+    expect(wrapper.find('label').classes()).toContain(`${prefixCls}-wrapper-checked`)
+  })
+
+  it('should not be checked when checked is false', () => {
+    const wrapper = mount(Radio, {
+      props: { checked: false },
+    })
+    expect(wrapper.find('label').classes()).not.toContain(`${prefixCls}-wrapper-checked`)
+  })
+
+  // ===================== disabled prop =====================
+
+  it('should add disabled class when disabled', () => {
+    const wrapper = mount(Radio, {
+      props: { disabled: true },
+    })
+    expect(wrapper.find('label').classes()).toContain(`${prefixCls}-wrapper-disabled`)
+  })
+
+  it('should not be disabled by default', () => {
+    const wrapper = mount(Radio)
+    expect(wrapper.find('label').classes()).not.toContain(`${prefixCls}-wrapper-disabled`)
+  })
+
+  // ===================== DisabledContext =====================
+
+  it('should inherit disabled from ConfigProvider', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider componentDisabled>
+        <Radio>A</Radio>
+      </ConfigProvider>
+    ))
+    expect(wrapper.find('label').classes()).toContain(`${prefixCls}-wrapper-disabled`)
+  })
+
+  it('should use own disabled over context disabled', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider componentDisabled>
+        <Radio disabled={false}>A</Radio>
+      </ConfigProvider>
+    ))
+    expect(wrapper.find('label').classes()).not.toContain(`${prefixCls}-wrapper-disabled`)
+  })
+
+  // ===================== title prop =====================
+
+  it('should set title attribute', () => {
+    const wrapper = mount(Radio, {
+      props: { title: 'my-title' },
+    })
+    expect(wrapper.find('label').attributes('title')).toBe('my-title')
+  })
+
+  // ===================== value prop =====================
+
+  it('should use value to determine checked state in group', () => {
+    const wrapper = mount(() => (
+      <RadioGroup value="B">
+        <Radio value="A">A</Radio>
+        <Radio value="B">B</Radio>
+      </RadioGroup>
+    ))
+    const labels = wrapper.findAll('label')
+    expect(labels[0].classes()).not.toContain(`${prefixCls}-wrapper-checked`)
+    expect(labels[1].classes()).toContain(`${prefixCls}-wrapper-checked`)
+  })
+
+  // ===================== Events =====================
+
+  it('should emit mouseenter and mouseleave events', async () => {
+    const onMouseenter = vi.fn()
+    const onMouseleave = vi.fn()
+    const wrapper = mount(Radio, {
+      props: { onMouseenter, onMouseleave },
+    })
+    await wrapper.find('label').trigger('mouseenter')
+    expect(onMouseenter).toHaveBeenCalledTimes(1)
+
+    await wrapper.find('label').trigger('mouseleave')
+    expect(onMouseleave).toHaveBeenCalledTimes(1)
+  })
+
+  it('should emit change event', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(Radio, {
+      props: { onChange },
+    })
+    await wrapper.find('input').trigger('change')
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  // ===================== rootClass =====================
+
+  it('should apply rootClass', () => {
+    const wrapper = mount(Radio, {
+      props: { rootClass: 'custom-root' },
+    })
+    expect(wrapper.find('label').classes()).toContain('custom-root')
+  })
+
+  // ===================== Attrs passthrough =====================
+
+  it('should pass style to label', () => {
+    const wrapper = mount(() => <Radio style={{ color: 'red' }}>A</Radio>)
+    expect(wrapper.find('label').attributes('style')).toContain('color: red')
+  })
+
+  it('should pass data attributes to label', () => {
+    const wrapper = mount(() => <Radio data-testid="radio-1">A</Radio>)
+    expect(wrapper.find('label').attributes('data-testid')).toBe('radio-1')
+  })
+
+  // ===================== RTL =====================
+
+  it('should have rtl class in rtl direction', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider direction="rtl">
+        <Radio>A</Radio>
+      </ConfigProvider>
+    ))
+    expect(wrapper.find('label').classes()).toContain(`${prefixCls}-wrapper-rtl`)
+  })
+
+  // ===================== Form item context =====================
+
+  it('should add in-form-item class when inside FormItem', () => {
+    const FormItemProvider = defineComponent({
+      setup(_, { slots }) {
+        useFormItemInputContextProvider(ref({ isFormItemInput: true }))
+        return () => slots.default?.()
+      },
+    })
+    const wrapper = mount(() => (
+      <FormItemProvider>
+        <Radio>A</Radio>
+      </FormItemProvider>
+    ))
+    expect(wrapper.find('label').classes()).toContain(`${prefixCls}-wrapper-in-form-item`)
+  })
+
+  // ===================== expose =====================
+
+  it('should expose focus and blur methods', () => {
+    const wrapper = mount(Radio)
+    const vm = wrapper.vm as any
+    expect(typeof vm.focus).toBe('function')
+    expect(typeof vm.blur).toBe('function')
+  })
+
+  // ===================== Static property =====================
+
+  it('should have static __ANT_RADIO property', () => {
+    expect((Radio as any).__ANT_RADIO).toBe(true)
+  })
+
+  it('should have static Button and Group properties', () => {
+    expect((Radio as any).Button).toBe(RadioButton)
+    expect((Radio as any).Group).toBe(RadioGroup)
+  })
+
+  // ===================== Snapshot =====================
+
+  it('should match snapshot', () => {
+    const wrapper = mount(() => (
+      <Radio value="A" checked>Option A</Radio>
+    ))
+    expect(wrapper.element).toMatchSnapshot()
+  })
+})
+
+describe('radio group', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ===================== Basic rendering =====================
+
+  it('should render a div with group class', () => {
+    const wrapper = mount(RadioGroup)
+    expect(wrapper.find('div').classes()).toContain(groupPrefixCls)
+  })
+
+  it('should render children radios', () => {
+    const wrapper = mount(RadioGroup, {
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+          <Radio value="B">B</Radio>,
+        ],
+      },
+    })
+    expect(wrapper.findAll('input[type="radio"]').length).toBe(2)
+  })
+
+  // ===================== defaultValue (uncontrolled) =====================
+
+  it('should select radio matching defaultValue', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { defaultValue: 'B' },
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+          <Radio value="B">B</Radio>,
+        ],
+      },
+    })
+    const labels = wrapper.findAll('label')
+    expect(labels[0].classes()).not.toContain(`${prefixCls}-wrapper-checked`)
+    expect(labels[1].classes()).toContain(`${prefixCls}-wrapper-checked`)
+  })
+
+  // ===================== value (controlled) =====================
+
+  it('should be controlled by value prop', async () => {
+    const wrapper = mount(RadioGroup, {
+      props: { value: 'A' },
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+          <Radio value="B">B</Radio>,
+        ],
+      },
+    })
+    const labels = wrapper.findAll('label')
+    expect(labels[0].classes()).toContain(`${prefixCls}-wrapper-checked`)
+    expect(labels[1].classes()).not.toContain(`${prefixCls}-wrapper-checked`)
+
+    await wrapper.setProps({ value: 'B' })
+    expect(labels[0].classes()).not.toContain(`${prefixCls}-wrapper-checked`)
+    expect(labels[1].classes()).toContain(`${prefixCls}-wrapper-checked`)
+  })
+
+  // ===================== change and update:value =====================
+
+  it('should emit change and update:value when selecting a different radio', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(RadioGroup, {
+      props: { value: 'A', onChange },
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+          <Radio value="B">B</Radio>,
+        ],
+      },
+    })
+    const inputs = wrapper.findAll('input')
+    await inputs[1].trigger('change')
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(wrapper.emitted('update:value')).toBeTruthy()
+    expect(wrapper.emitted('update:value')![0]).toEqual(['B'])
+  })
+
+  it('should not emit change when selecting the already selected radio', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(RadioGroup, {
+      props: { value: 'A', onChange },
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+          <Radio value="B">B</Radio>,
+        ],
+      },
+    })
+    const inputs = wrapper.findAll('input')
+    await inputs[0].trigger('change')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('should update internal value in uncontrolled mode', async () => {
+    const wrapper = mount(RadioGroup, {
+      props: { defaultValue: 'A' },
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+          <Radio value="B">B</Radio>,
+        ],
+      },
+    })
+    const inputs = wrapper.findAll('input')
+    const labels = wrapper.findAll('label')
+
+    await inputs[1].trigger('change')
+    await nextTick()
+    expect(labels[1].classes()).toContain(`${prefixCls}-wrapper-checked`)
+  })
+
+  // ===================== disabled =====================
+
+  it('should disable all radios when group is disabled', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { disabled: true },
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+          <Radio value="B">B</Radio>,
+        ],
+      },
+    })
+    const labels = wrapper.findAll('label')
+    expect(labels[0].classes()).toContain(`${prefixCls}-wrapper-disabled`)
+    expect(labels[1].classes()).toContain(`${prefixCls}-wrapper-disabled`)
+  })
+
+  // ===================== name =====================
+
+  it('should pass name to all radios', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { name: 'my-group' },
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+          <Radio value="B">B</Radio>,
+        ],
+      },
+    })
+    // VcCheckbox renders name on the wrapper span, not the native input
+    wrapper.findAll(`.${prefixCls}`).forEach((radio) => {
+      expect(radio.attributes('name')).toBe('my-group')
+    })
+  })
+
+  // ===================== size =====================
+
+  it.each(['large', 'small'] as const)('should apply %s size class', (size) => {
+    const wrapper = mount(RadioGroup, {
+      props: { size },
+    })
+    expect(wrapper.find('div').classes()).toContain(`${groupPrefixCls}-${size}`)
+  })
+
+  it('should inherit size from ConfigProvider', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider componentSize="small">
+        <RadioGroup>
+          <Radio value="A">A</Radio>
+        </RadioGroup>
+      </ConfigProvider>
+    ))
+    expect(wrapper.find(`.${groupPrefixCls}`).classes()).toContain(`${groupPrefixCls}-small`)
+  })
+
+  // ===================== buttonStyle =====================
+
+  it('should apply outline buttonStyle by default', () => {
+    const wrapper = mount(RadioGroup)
+    expect(wrapper.find('div').classes()).toContain(`${groupPrefixCls}-outline`)
+  })
+
+  it('should apply solid buttonStyle', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { buttonStyle: 'solid' },
+    })
+    expect(wrapper.find('div').classes()).toContain(`${groupPrefixCls}-solid`)
+  })
+
+  // ===================== optionType =====================
+
+  it('should render button-style radios when optionType is button', () => {
+    const wrapper = mount(RadioGroup, {
+      props: {
+        optionType: 'button',
+        options: [
+          { label: 'A', value: 'A' },
+          { label: 'B', value: 'B' },
+        ],
+      },
+    })
+    expect(wrapper.findAll(`.${prefixCls}-button-wrapper`).length).toBe(2)
+  })
+
+  // ===================== block =====================
+
+  it('should apply block class', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { block: true },
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+        ],
+      },
+    })
+    expect(wrapper.find('div').classes()).toContain(`${groupPrefixCls}-block`)
+    expect(wrapper.find('label').classes()).toContain(`${prefixCls}-wrapper-block`)
+  })
+
+  // ===================== vertical =====================
+
+  it('should apply vertical class', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { vertical: true },
+    })
+    expect(wrapper.find('div').classes()).toContain(`${prefixCls}-group-vertical`)
+  })
+
+  // ===================== options prop =====================
+
+  it('should render from string options', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { options: ['Apple', 'Banana', 'Cherry'] },
+    })
+    expect(wrapper.findAll('input[type="radio"]').length).toBe(3)
+    expect(wrapper.text()).toContain('Apple')
+    expect(wrapper.text()).toContain('Banana')
+    expect(wrapper.text()).toContain('Cherry')
+  })
+
+  it('should render from number options', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { options: [1, 2, 3] },
+    })
+    expect(wrapper.findAll('input[type="radio"]').length).toBe(3)
+  })
+
+  it('should render from object options', () => {
+    const wrapper = mount(RadioGroup, {
+      props: {
+        options: [
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b', disabled: true },
+        ],
+      },
+    })
+    const inputs = wrapper.findAll('input[type="radio"]')
+    expect(inputs.length).toBe(2)
+    // Second option should be disabled
+    const labels = wrapper.findAll('label')
+    expect(labels[1].classes()).toContain(`${prefixCls}-wrapper-disabled`)
+  })
+
+  it('should apply option style, class, title, id', () => {
+    const wrapper = mount(RadioGroup, {
+      props: {
+        options: [
+          { label: 'A', value: 'a', style: { color: 'red' }, class: 'opt-a', title: 'Option A', id: 'opt-a' },
+        ],
+      },
+    })
+    const label = wrapper.find('label')
+    expect(label.attributes('style')).toContain('color: red')
+    expect(label.classes()).toContain('opt-a')
+    expect(label.attributes('title')).toBe('Option A')
+  })
+
+  it('should disable individual option when group is not disabled', () => {
+    const wrapper = mount(RadioGroup, {
+      props: {
+        options: [
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b', disabled: true },
+        ],
+      },
+    })
+    const labels = wrapper.findAll('label')
+    expect(labels[0].classes()).not.toContain(`${prefixCls}-wrapper-disabled`)
+    expect(labels[1].classes()).toContain(`${prefixCls}-wrapper-disabled`)
+  })
+
+  it('should disable all options when group disabled overrides individual', () => {
+    const wrapper = mount(RadioGroup, {
+      props: {
+        disabled: true,
+        options: [
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b', disabled: false },
+        ],
+      },
+    })
+    const labels = wrapper.findAll('label')
+    expect(labels[0].classes()).toContain(`${prefixCls}-wrapper-disabled`)
+    expect(labels[1].classes()).toContain(`${prefixCls}-wrapper-disabled`)
+  })
+
+  // ===================== labelRender =====================
+
+  it('should support labelRender prop for object options', () => {
+    const wrapper = mount(RadioGroup, {
+      props: {
+        options: [
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b' },
+        ],
+        labelRender: ({ item, index }: { item: any, index: number }) => `Custom-${item.label}-${index}`,
+      },
+    })
+    expect(wrapper.text()).toContain('Custom-A-0')
+    expect(wrapper.text()).toContain('Custom-B-1')
+  })
+
+  it('should support labelRender prop for string options', () => {
+    const wrapper = mount(RadioGroup, {
+      props: {
+        options: ['X', 'Y'],
+        labelRender: ({ item }: { item: any }) => `Prefix-${item.label}`,
+      },
+    })
+    expect(wrapper.text()).toContain('Prefix-X')
+    expect(wrapper.text()).toContain('Prefix-Y')
+  })
+
+  it('should support labelRender slot over prop', () => {
+    const wrapper = mount(RadioGroup, {
+      props: {
+        options: [{ label: 'A', value: 'a' }],
+        labelRender: () => 'FROM_PROP',
+      },
+      slots: {
+        labelRender: ({ item }: { item: any }) => `FROM_SLOT_${item.label}`,
+      },
+    })
+    expect(wrapper.text()).toContain('FROM_SLOT_A')
+    expect(wrapper.text()).not.toContain('FROM_PROP')
+  })
+
+  // ===================== id =====================
+
+  it('should apply id to the wrapper div', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { id: 'my-radio-group' },
+    })
+    expect(wrapper.find('div').attributes('id')).toBe('my-radio-group')
+  })
+
+  // ===================== rootClass =====================
+
+  it('should apply rootClass to the group', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { rootClass: 'custom-group' },
+    })
+    expect(wrapper.find('div').classes()).toContain('custom-group')
+  })
+
+  // ===================== Attrs passthrough =====================
+
+  it('should pass data and aria attributes', () => {
+    const wrapper = mount(() => (
+      <RadioGroup data-group="1" aria-label="radio group" />
+    ))
+    expect(wrapper.find('div').attributes('data-group')).toBe('1')
+    expect(wrapper.find('div').attributes('aria-label')).toBe('radio group')
+  })
+
+  it('should pass style to the group div', () => {
+    const wrapper = mount(() => (
+      <RadioGroup style={{ marginTop: '10px' }} />
+    ))
+    expect(wrapper.find('div').attributes('style')).toContain('margin-top: 10px')
+  })
+
+  // ===================== RTL =====================
+
+  it('should apply rtl class', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider direction="rtl">
+        <RadioGroup>
+          <Radio value="A">A</Radio>
+        </RadioGroup>
+      </ConfigProvider>
+    ))
+    expect(wrapper.find(`.${groupPrefixCls}`).classes()).toContain(`${groupPrefixCls}-rtl`)
+  })
+
+  // ===================== Events =====================
+
+  it('should emit mouseenter and mouseleave', async () => {
+    const onMouseenter = vi.fn()
+    const onMouseleave = vi.fn()
+    const wrapper = mount(RadioGroup, {
+      props: { onMouseenter, onMouseleave },
+    })
+    await wrapper.find('div').trigger('mouseenter')
+    expect(onMouseenter).toHaveBeenCalledTimes(1)
+
+    await wrapper.find('div').trigger('mouseleave')
+    expect(onMouseleave).toHaveBeenCalledTimes(1)
+  })
+
+  it('should emit focus and blur', async () => {
+    const onFocus = vi.fn()
+    const onBlur = vi.fn()
+    const wrapper = mount(RadioGroup, {
+      props: { onFocus, onBlur },
+    })
+    await wrapper.find('div').trigger('focus')
+    expect(onFocus).toHaveBeenCalledTimes(1)
+
+    await wrapper.find('div').trigger('blur')
+    expect(onBlur).toHaveBeenCalledTimes(1)
+  })
+
+  // ===================== value is null or undefined =====================
+
+  it('should use defaultValue when value is undefined', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { defaultValue: 'B' },
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+          <Radio value="B">B</Radio>,
+        ],
+      },
+    })
+    expect(wrapper.findAll('label')[1].classes()).toContain(`${prefixCls}-wrapper-checked`)
+  })
+
+  // ===================== Both radio and group onChange =====================
+
+  it('should trigger both radio and group change events', async () => {
+    const onRadioChange = vi.fn()
+    const onGroupChange = vi.fn()
+    const wrapper = mount(RadioGroup, {
+      props: { onChange: onGroupChange },
+      slots: {
+        default: () => [
+          <Radio value="A" onChange={onRadioChange}>A</Radio>,
+          <Radio value="B" onChange={onRadioChange}>B</Radio>,
+        ],
+      },
+    })
+    const inputs = wrapper.findAll('input')
+    await inputs[1].trigger('change')
+    expect(onRadioChange).toHaveBeenCalledTimes(1)
+    expect(onGroupChange).toHaveBeenCalledTimes(1)
+  })
+
+  // ===================== Radio type should not be overridden =====================
+
+  it('should always render input type as radio', () => {
+    const wrapper = mount(RadioGroup, {
+      slots: {
+        default: () => [
+          <Radio value="A" type="custom">A</Radio>,
+        ],
+      },
+    })
+    expect(wrapper.find('input').element.type).toBe('radio')
+  })
+
+  // ===================== only trigger once with options =====================
+
+  it('should only trigger change once when using options', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(RadioGroup, {
+      props: {
+        options: [{ label: 'Bamboo', value: 'Bamboo' }],
+        onChange,
+      },
+    })
+    await wrapper.find('input').trigger('change')
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  // ===================== Snapshot =====================
+
+  it('should match snapshot with options', () => {
+    const wrapper = mount(RadioGroup, {
+      props: {
+        value: 'B',
+        options: [
+          { label: 'A', value: 'A' },
+          { label: 'B', value: 'B' },
+          { label: 'C', value: 'C' },
+        ],
+      },
+    })
+    expect(wrapper.element).toMatchSnapshot()
+  })
+
+  it('should match snapshot with children', () => {
+    const wrapper = mount(RadioGroup, {
+      props: { value: 'A' },
+      slots: {
+        default: () => [
+          <Radio value="A">A</Radio>,
+          <Radio value="B">B</Radio>,
+        ],
+      },
+    })
+    expect(wrapper.element).toMatchSnapshot()
+  })
+})
+
+describe('radio button', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ===================== Basic rendering =====================
+
+  it('should render as button type radio', () => {
+    const wrapper = mount(() => (
+      <RadioGroup>
+        <RadioButton value="A">A</RadioButton>
+      </RadioGroup>
+    ))
+    expect(wrapper.find(`.${prefixCls}-button-wrapper`).exists()).toBe(true)
+  })
+
+  it('should render children', () => {
+    const wrapper = mount(() => (
+      <RadioGroup>
+        <RadioButton value="A">Option A</RadioButton>
+      </RadioGroup>
+    ))
+    expect(wrapper.text()).toContain('Option A')
+  })
+
+  // ===================== Events =====================
+
+  it('should trigger group onChange when button selected', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(() => (
+      <RadioGroup onChange={onChange}>
+        <RadioButton value="A">A</RadioButton>
+        <RadioButton value="B">B</RadioButton>
+      </RadioGroup>
+    ))
+    const inputs = wrapper.findAll('input')
+    await inputs[1].trigger('change')
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('should forward attrs to inner Radio', () => {
+    const wrapper = mount(() => (
+      <RadioGroup>
+        <RadioButton value="A" data-testid="btn-a">A</RadioButton>
+      </RadioGroup>
+    ))
+    expect(wrapper.find('label').attributes('data-testid')).toBe('btn-a')
+  })
+
+  // ===================== Checked in group =====================
+
+  it('should reflect group value', () => {
+    const wrapper = mount(() => (
+      <RadioGroup value="B">
+        <RadioButton value="A">A</RadioButton>
+        <RadioButton value="B">B</RadioButton>
+      </RadioGroup>
+    ))
+    const labels = wrapper.findAll('label')
+    expect(labels[0].classes()).not.toContain(`${prefixCls}-button-wrapper-checked`)
+    expect(labels[1].classes()).toContain(`${prefixCls}-button-wrapper-checked`)
+  })
+
+  // ===================== Disabled =====================
+
+  it('should be disabled when group is disabled', () => {
+    const wrapper = mount(() => (
+      <RadioGroup disabled>
+        <RadioButton value="A">A</RadioButton>
+      </RadioGroup>
+    ))
+    expect(wrapper.find('label').classes()).toContain(`${prefixCls}-button-wrapper-disabled`)
+  })
+
+  // ===================== Size =====================
+
+  it.each(['large', 'small'] as const)('should reflect %s size from group', (size) => {
+    const wrapper = mount(() => (
+      <RadioGroup size={size}>
+        <RadioButton value="A">A</RadioButton>
+      </RadioGroup>
+    ))
+    expect(wrapper.find(`.${groupPrefixCls}`).classes()).toContain(`${groupPrefixCls}-${size}`)
+  })
+
+  // ===================== Solid style =====================
+
+  it('should work with solid buttonStyle', () => {
+    const wrapper = mount(() => (
+      <RadioGroup buttonStyle="solid" value="A">
+        <RadioButton value="A">A</RadioButton>
+        <RadioButton value="B">B</RadioButton>
+      </RadioGroup>
+    ))
+    expect(wrapper.find(`.${groupPrefixCls}`).classes()).toContain(`${groupPrefixCls}-solid`)
+    expect(wrapper.findAll('label')[0].classes()).toContain(`${prefixCls}-button-wrapper-checked`)
+  })
+
+  // ===================== Snapshot =====================
+
+  it('should match snapshot', () => {
+    const wrapper = mount(() => (
+      <RadioGroup value="A">
+        <RadioButton value="A">A</RadioButton>
+        <RadioButton value="B">B</RadioButton>
+        <RadioButton value="C">C</RadioButton>
+      </RadioGroup>
+    ))
+    expect(wrapper.element).toMatchSnapshot()
+  })
+})

--- a/packages/antdv-next/src/radio/tests/__snapshots__/Radio.test.tsx.snap
+++ b/packages/antdv-next/src/radio/tests/__snapshots__/Radio.test.tsx.snap
@@ -1,0 +1,242 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`radio > rtl render > component should be rendered correctly in RTL direction 1`] = `
+<div
+  data-v-app=""
+>
+  <label
+    class="ant-radio-wrapper ant-radio-wrapper-rtl css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <!---->
+  </label>
+</div>
+`;
+
+exports[`radio > rtl render > component should be rendered correctly in RTL direction 2`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-radio-group ant-radio-group-outline ant-radio-group-rtl css-var-root ant-radio-css-var"
+  >
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`radio > rtl render > component should be rendered correctly in RTL direction 3`] = `
+<div
+  data-v-app=""
+>
+  <label
+    class="ant-radio-button-wrapper ant-radio-button-wrapper-rtl css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio-button"
+    >
+      <input
+        class="ant-radio-button-input"
+        type="radio"
+      />
+    </span>
+    <!---->
+  </label>
+</div>
+`;
+
+exports[`radio > should match snapshot 1`] = `
+<label
+  class="ant-radio-wrapper ant-radio-wrapper-checked css-var-root ant-radio-css-var"
+>
+  <span
+    class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+  >
+    <input
+      checked=""
+      class="ant-radio-input"
+      type="radio"
+    />
+  </span>
+  <span
+    class="ant-radio-label"
+  >
+    Option A
+  </span>
+</label>
+`;
+
+exports[`radio button > should match snapshot 1`] = `
+<div
+  class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+>
+  <label
+    class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio-button ant-radio-button-checked"
+      name="v-0"
+    >
+      <input
+        checked=""
+        class="ant-radio-button-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-button-label"
+    >
+      A
+    </span>
+  </label>
+  <label
+    class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio-button"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-button-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-button-label"
+    >
+      B
+    </span>
+  </label>
+  <label
+    class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio-button"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-button-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-button-label"
+    >
+      C
+    </span>
+  </label>
+</div>
+`;
+
+exports[`radio group > should match snapshot with children 1`] = `
+<div
+  class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+>
+  <label
+    class="ant-radio-wrapper ant-radio-wrapper-checked css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+      name="v-0"
+    >
+      <input
+        checked=""
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      A
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      B
+    </span>
+  </label>
+</div>
+`;
+
+exports[`radio group > should match snapshot with options 1`] = `
+<div
+  class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+>
+  <label
+    class="ant-radio-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      A
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper ant-radio-wrapper-checked css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+      name="v-0"
+    >
+      <input
+        checked=""
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      B
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      C
+    </span>
+  </label>
+</div>
+`;

--- a/packages/antdv-next/src/radio/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/radio/tests/__snapshots__/demo.test.tsx.snap
@@ -1,0 +1,2132 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`radio demo > renders _semantic correctly 1`] = `
+<div
+  class="semantic-preview-container"
+  data-v-dfc8ebef=""
+>
+  <div
+    class="ant-row css-var-root semantic-preview-row"
+    data-v-dfc8ebef=""
+  >
+    <div
+      class="ant-col ant-col-16 css-var-root semantic-preview-col"
+      data-v-dfc8ebef=""
+    >
+      <label
+        class="ant-radio-wrapper semantic-mark-root css-var-v-0 ant-radio-css-var"
+      >
+        <span
+          class="ant-radio semantic-mark-icon ant-wave-target semantic-mark-icon ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            type="radio"
+          />
+        </span>
+        <span
+          class="ant-radio-label semantic-mark-label"
+        >
+           Radio 
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-col ant-col-8 css-var-root"
+      data-v-dfc8ebef=""
+    >
+      <ul
+        class="semantic-list"
+        data-v-dfc8ebef=""
+      >
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  root
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Root element with layout styles, cursor styles, disabled text color and other basic container styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  icon
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Icon element with border radius, transition animations, border styles, hover states, focus states and other interactive styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  label
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Label element with padding, text color, disabled states, alignment and other text styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`radio demo > renders basic correctly 1`] = `
+<label
+  class="ant-radio-wrapper css-var-root ant-radio-css-var"
+>
+  <span
+    class="ant-radio ant-wave-target ant-wave-target"
+  >
+    <input
+      class="ant-radio-input"
+      type="radio"
+    />
+  </span>
+  <span
+    class="ant-radio-label"
+  >
+     Radio 
+  </span>
+</label>
+`;
+
+exports[`radio demo > renders disabled correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <label
+          class="ant-radio-wrapper ant-radio-wrapper-disabled css-var-root ant-radio-css-var"
+        >
+          <span
+            class="ant-radio ant-wave-target ant-radio-disabled ant-wave-target"
+          >
+            <input
+              class="ant-radio-input"
+              disabled=""
+              type="radio"
+            />
+          </span>
+          <span
+            class="ant-radio-label"
+          >
+             Disabled 
+          </span>
+        </label>
+      </div>
+      <!---->
+      <div
+        class="ant-space-item"
+      >
+        <label
+          class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-disabled css-var-root ant-radio-css-var"
+        >
+          <span
+            class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled ant-wave-target"
+          >
+            <input
+              checked=""
+              class="ant-radio-input"
+              disabled=""
+              type="radio"
+            />
+          </span>
+          <span
+            class="ant-radio-label"
+          >
+             Disabled 
+          </span>
+        </label>
+      </div>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Toggle disabled 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`radio demo > renders radio-group correctly 1`] = `
+<div
+  class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+>
+  <label
+    class="ant-radio-wrapper option-1 css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center ant-flex-gap-small ant-flex-vertical"
+      >
+        <span
+          aria-label="line-chart"
+          class="anticon anticon-line-chart"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="line-chart"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M888 792H200V168c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v688c0 4.4 3.6 8 8 8h752c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zM305.8 637.7c3.1 3.1 8.1 3.1 11.3 0l138.3-137.6L583 628.5c3.1 3.1 8.2 3.1 11.3 0l275.4-275.3c3.1-3.1 3.1-8.2 0-11.3l-39.6-39.6a8.03 8.03 0 00-11.3 0l-230 229.9L461.4 404a8.03 8.03 0 00-11.3 0L266.3 586.7a8.03 8.03 0 000 11.3l39.5 39.7z"
+            />
+          </svg>
+        </span>
+         LineChat
+      </div>
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper option-2 css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center ant-flex-gap-small ant-flex-vertical"
+      >
+        <span
+          aria-label="dot-chart"
+          class="anticon anticon-dot-chart"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="dot-chart"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M888 792H200V168c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v688c0 4.4 3.6 8 8 8h752c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zM288 604a64 64 0 10128 0 64 64 0 10-128 0zm118-224a48 48 0 1096 0 48 48 0 10-96 0zm158 228a96 96 0 10192 0 96 96 0 10-192 0zm148-314a56 56 0 10112 0 56 56 0 10-112 0z"
+            />
+          </svg>
+        </span>
+         DotChart
+      </div>
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper option-3 css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center ant-flex-gap-small ant-flex-vertical"
+      >
+        <span
+          aria-label="bar-chart"
+          class="anticon anticon-bar-chart"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="bar-chart"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M888 792H200V168c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v688c0 4.4 3.6 8 8 8h752c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zm-600-80h56c4.4 0 8-3.6 8-8V560c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v144c0 4.4 3.6 8 8 8zm152 0h56c4.4 0 8-3.6 8-8V384c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v320c0 4.4 3.6 8 8 8zm152 0h56c4.4 0 8-3.6 8-8V462c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v242c0 4.4 3.6 8 8 8zm152 0h56c4.4 0 8-3.6 8-8V304c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v400c0 4.4 3.6 8 8 8z"
+            />
+          </svg>
+        </span>
+         BarChart
+      </div>
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper option-4 css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center ant-flex-gap-small ant-flex-vertical"
+      >
+        <span
+          aria-label="pie-chart"
+          class="anticon anticon-pie-chart"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="pie-chart"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M864 518H506V160c0-4.4-3.6-8-8-8h-26a398.46 398.46 0 00-282.8 117.1 398.19 398.19 0 00-85.7 127.1A397.61 397.61 0 0072 552a398.46 398.46 0 00117.1 282.8c36.7 36.7 79.5 65.6 127.1 85.7A397.61 397.61 0 00472 952a398.46 398.46 0 00282.8-117.1c36.7-36.7 65.6-79.5 85.7-127.1A397.61 397.61 0 00872 552v-26c0-4.4-3.6-8-8-8zM705.7 787.8A331.59 331.59 0 01470.4 884c-88.1-.4-170.9-34.9-233.2-97.2C174.5 724.1 140 640.7 140 552c0-88.7 34.5-172.1 97.2-234.8 54.6-54.6 124.9-87.9 200.8-95.5V586h364.3c-7.7 76.3-41.3 147-96.6 201.8zM952 462.4l-2.6-28.2c-8.5-92.1-49.4-179-115.2-244.6A399.4 399.4 0 00589 74.6L560.7 72c-4.7-.4-8.7 3.2-8.7 7.9V464c0 4.4 3.6 8 8 8l384-1c4.7 0 8.4-4 8-8.6zm-332.2-58.2V147.6a332.24 332.24 0 01166.4 89.8c45.7 45.6 77 103.6 90 166.1l-256.4.7z"
+            />
+          </svg>
+        </span>
+         PieChart
+      </div>
+    </span>
+  </label>
+</div>
+`;
+
+exports[`radio demo > renders radiobutton correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-0"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Hangzhou 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Shanghai 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Beijing 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Chengdu 
+      </span>
+    </label>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-1"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Hangzhou 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-disabled"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Shanghai 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Beijing 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Chengdu 
+      </span>
+    </label>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked ant-radio-button-disabled"
+        name="v-2"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Hangzhou 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-disabled"
+        name="v-2"
+      >
+        <input
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Shanghai 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-disabled"
+        name="v-2"
+      >
+        <input
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Beijing 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-disabled"
+        name="v-2"
+      >
+        <input
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Chengdu 
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`radio demo > renders radiobutton-solid correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-radio-group ant-radio-group-solid css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-0"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Hangzhou 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Shanghai 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Beijing 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Chengdu 
+      </span>
+    </label>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-solid css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-1"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Hangzhou 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-disabled"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Shanghai 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Beijing 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Chengdu 
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`radio demo > renders radiogroup correctly 1`] = `
+<div
+  class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+>
+  <label
+    class="ant-radio-wrapper ant-radio-wrapper-checked option-1 css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+      name="v-0"
+    >
+      <input
+        checked=""
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center ant-flex-gap-small ant-flex-vertical"
+      >
+        <span
+          aria-label="line-chart"
+          class="anticon anticon-line-chart"
+          role="img"
+          style="font-size: 18px;"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="line-chart"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M888 792H200V168c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v688c0 4.4 3.6 8 8 8h752c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zM305.8 637.7c3.1 3.1 8.1 3.1 11.3 0l138.3-137.6L583 628.5c3.1 3.1 8.2 3.1 11.3 0l275.4-275.3c3.1-3.1 3.1-8.2 0-11.3l-39.6-39.6a8.03 8.03 0 00-11.3 0l-230 229.9L461.4 404a8.03 8.03 0 00-11.3 0L266.3 586.7a8.03 8.03 0 000 11.3l39.5 39.7z"
+            />
+          </svg>
+        </span>
+         LineChat
+      </div>
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper option-2 css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center ant-flex-gap-small ant-flex-vertical"
+      >
+        <span
+          aria-label="dot-chart"
+          class="anticon anticon-dot-chart"
+          role="img"
+          style="font-size: 18px;"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="dot-chart"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M888 792H200V168c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v688c0 4.4 3.6 8 8 8h752c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zM288 604a64 64 0 10128 0 64 64 0 10-128 0zm118-224a48 48 0 1096 0 48 48 0 10-96 0zm158 228a96 96 0 10192 0 96 96 0 10-192 0zm148-314a56 56 0 10112 0 56 56 0 10-112 0z"
+            />
+          </svg>
+        </span>
+         DotChart
+      </div>
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper option-3 css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center ant-flex-gap-small ant-flex-vertical"
+      >
+        <span
+          aria-label="bar-chart"
+          class="anticon anticon-bar-chart"
+          role="img"
+          style="font-size: 18px;"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="bar-chart"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M888 792H200V168c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v688c0 4.4 3.6 8 8 8h752c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zm-600-80h56c4.4 0 8-3.6 8-8V560c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v144c0 4.4 3.6 8 8 8zm152 0h56c4.4 0 8-3.6 8-8V384c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v320c0 4.4 3.6 8 8 8zm152 0h56c4.4 0 8-3.6 8-8V462c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v242c0 4.4 3.6 8 8 8zm152 0h56c4.4 0 8-3.6 8-8V304c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v400c0 4.4 3.6 8 8 8z"
+            />
+          </svg>
+        </span>
+         BarChart
+      </div>
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper option-4 css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center ant-flex-gap-small ant-flex-vertical"
+      >
+        <span
+          aria-label="pie-chart"
+          class="anticon anticon-pie-chart"
+          role="img"
+          style="font-size: 18px;"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="pie-chart"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M864 518H506V160c0-4.4-3.6-8-8-8h-26a398.46 398.46 0 00-282.8 117.1 398.19 398.19 0 00-85.7 127.1A397.61 397.61 0 0072 552a398.46 398.46 0 00117.1 282.8c36.7 36.7 79.5 65.6 127.1 85.7A397.61 397.61 0 00472 952a398.46 398.46 0 00282.8-117.1c36.7-36.7 65.6-79.5 85.7-127.1A397.61 397.61 0 00872 552v-26c0-4.4-3.6-8-8-8zM705.7 787.8A331.59 331.59 0 01470.4 884c-88.1-.4-170.9-34.9-233.2-97.2C174.5 724.1 140 640.7 140 552c0-88.7 34.5-172.1 97.2-234.8 54.6-54.6 124.9-87.9 200.8-95.5V586h364.3c-7.7 76.3-41.3 147-96.6 201.8zM952 462.4l-2.6-28.2c-8.5-92.1-49.4-179-115.2-244.6A399.4 399.4 0 00589 74.6L560.7 72c-4.7-.4-8.7 3.2-8.7 7.9V464c0 4.4 3.6 8 8 8l384-1c4.7 0 8.4-4 8-8.6zm-332.2-58.2V147.6a332.24 332.24 0 01166.4 89.8c45.7 45.6 77 103.6 90 166.1l-256.4.7z"
+            />
+          </svg>
+        </span>
+         PieChart
+      </div>
+    </span>
+  </label>
+</div>
+`;
+
+exports[`radio demo > renders radiogroup-block correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-radio-group ant-radio-group-outline ant-radio-group-block css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-block css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+        name="v-0"
+      >
+        <input
+          checked=""
+          class="ant-radio-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Apple
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper ant-radio-wrapper-block css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-wave-target"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Pear
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper ant-radio-wrapper-block css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-wave-target"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Orange
+      </span>
+    </label>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-solid ant-radio-group-block css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked ant-radio-button-wrapper-block css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-1"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Apple
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-block css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Pear
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-block css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Orange
+      </span>
+    </label>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-outline ant-radio-group-block css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked ant-radio-button-wrapper-block css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-2"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Apple
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-block css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-2"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Pear
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-block css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-2"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Orange
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`radio demo > renders radiogroup-more correctly 1`] = `
+<div
+  class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var ant-radio-group-vertical"
+>
+  <label
+    class="ant-radio-wrapper ant-radio-wrapper-checked css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+      name="v-0"
+    >
+      <input
+        checked=""
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+       Option A 
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+       Option B 
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+       Option C 
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="v-0"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+       More... 
+    </span>
+  </label>
+</div>
+`;
+
+exports[`radio demo > renders radiogroup-options correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-wrapper ant-radio-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+        name="v-0"
+      >
+        <input
+          checked=""
+          class="ant-radio-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Apple
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-wave-target"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Pear
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-wave-target"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Orange
+      </span>
+    </label>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-wrapper ant-radio-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+        name="v-1"
+      >
+        <input
+          checked=""
+          class="ant-radio-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Apple
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-wave-target"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Pear
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper ant-radio-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-radio-disabled ant-wave-target"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Orange
+      </span>
+    </label>
+  </div>
+  <br />
+  <div
+    class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-2"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Apple
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-2"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Pear
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+      title="Orange"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-2"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Orange
+      </span>
+    </label>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-solid css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-3"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Apple
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-3"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Pear
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-disabled"
+        name="v-3"
+      >
+        <input
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+        Orange
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`radio demo > renders radiogroup-with-name correctly 1`] = `
+<div
+  class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+>
+  <label
+    class="ant-radio-wrapper ant-radio-wrapper-checked css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+      name="radiogroup"
+    >
+      <input
+        checked=""
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      A
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="radiogroup"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      B
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="radiogroup"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      C
+    </span>
+  </label>
+  <label
+    class="ant-radio-wrapper css-var-root ant-radio-css-var"
+  >
+    <span
+      class="ant-radio ant-wave-target ant-wave-target"
+      name="radiogroup"
+    >
+      <input
+        class="ant-radio-input"
+        type="radio"
+      />
+    </span>
+    <span
+      class="ant-radio-label"
+    >
+      D
+    </span>
+  </label>
+</div>
+`;
+
+exports[`radio demo > renders size correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-0"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Hangzhou 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Shanghai 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Beijing 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-0"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Chengdu 
+      </span>
+    </label>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+        name="v-1"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Hangzhou 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Shanghai 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Beijing 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button"
+        name="v-1"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Chengdu 
+      </span>
+    </label>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-root ant-radio-css-var"
+  >
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked ant-radio-button-disabled"
+        name="v-2"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Hangzhou 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-disabled"
+        name="v-2"
+      >
+        <input
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Shanghai 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-disabled"
+        name="v-2"
+      >
+        <input
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Beijing 
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-disabled css-var-root ant-radio-css-var"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-disabled"
+        name="v-2"
+      >
+        <input
+          class="ant-radio-button-input"
+          disabled=""
+          type="radio"
+        />
+      </span>
+      <span
+        class="ant-radio-button-label"
+      >
+         Chengdu 
+      </span>
+    </label>
+  </div>
+</div>
+`;

--- a/packages/antdv-next/src/radio/tests/demo.test.tsx
+++ b/packages/antdv-next/src/radio/tests/demo.test.tsx
@@ -1,0 +1,3 @@
+import demoTest from '/@tests/shared/demoTest'
+
+demoTest('radio')


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Test Case
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related Issues

ref #63

### 💡 Background and Solution

Add comprehensive unit tests for Radio component family (Radio, RadioGroup, RadioButton).

**Test coverage (97 tests total):**

**Radio (28 tests):**
- mountTest + rtlTest
- Basic rendering, checked/defaultChecked/disabled/autoFocus
- rootClass, custom class/style/data-* attrs passthrough
- Change event, expose (focus/blur)
- ConfigProvider (size/disabled/direction)
- wrapper-in-form-item integration
- Snapshot

**RadioGroup (39 tests):**
- Options rendering (string/number/object), children rendering
- value/defaultValue controlled/uncontrolled
- disabled (group + option level)
- onChange event (children and options mode)
- name attribute propagation
- optionType='button' mode, buttonStyle='solid'
- size (large/middle/small)
- labelRender slot
- ConfigProvider (size/disabled/direction)
- aria-*/data-* attrs passthrough
- Snapshots (children + options)

**RadioButton (11 tests):**
- Basic rendering, checked/disabled
- RadioGroup with buttonStyle='solid'
- Value selection, size variants
- Attrs passthrough (data-testid)
- Snapshot

**Semantic (7 tests):**
- classes/styles object form (root/icon/label)
- ConfigProvider classes/styles merging
- Partial classes/styles isolation

**Demo (12 tests):**
- Snapshot tests for all radio demos

**Notable findings:**
- VcCheckbox renders `name` on wrapper `<span>`, not on native `<input>` — tests verify correct DOM structure
- Events use `trigger('change')` pattern (VcCheckbox integration)
- radio.tsx L98 `disabled: mergedChecked.value` in mergedProps — potential source issue (checked state used as disabled), does not affect runtime behavior

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add unit tests for Radio, RadioGroup, RadioButton components |
| 🇨🇳 Chinese | 为 Radio、RadioGroup、RadioButton 组件添加单元测试 |