### PR TITLE
fix(tooltip): fix incorrect position calculation when arrow is displayed

### DIFF
--- a/packages/antdv-next/src/tooltip/index.tsx
+++ b/packages/antdv-next/src/tooltip/index.tsx
@@ -200,7 +200,7 @@ const InternalTooltip = defineComponent<
         || getPlacements({
           arrowPointAtCenter: mergedArrow?.value?.pointAtCenter ?? false,
           autoAdjustOverflow: autoAdjustOverflow.value,
-          arrowWidth: mergedShowArrow ? token.value.sizePopupArrow : 0,
+          arrowWidth: mergedShowArrow.value ? token.value.sizePopupArrow : 0,
           borderRadius: token.value.borderRadius,
           offset: token.value.marginXXS,
           visibleFirst: true,

--- a/packages/antdv-next/src/tooltip/tests/__snapshots__/tooltip.test.tsx.snap
+++ b/packages/antdv-next/src/tooltip/tests/__snapshots__/tooltip.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`tooltip > support arrow props pass false to hide arrow 1`] = `
   </div>
   <div
     class="ant-tooltip ant-tooltip-css-var css-var-root ant-tooltip-placement-bottom"
-    style="--arrow-x: 0px; --arrow-y: -6px; left: 0px; top: 12px; right: auto; bottom: auto; box-sizing: border-box;"
+    style="--arrow-x: 0px; --arrow-y: -2px; left: 0px; top: 4px; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <!---->
     <div


### PR DESCRIPTION
The condition for displaying the arrow was incorrect, leading to inaccurate position calculation. Access mergedShowArrow as a reactive value.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #229 

### 💡 Background and Solution

The condition for displaying the arrow was incorrect, leading to inaccurate position calculation. Access mergedShowArrow as a reactive value.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix incorrect position calculation when arrow is displayed      |
| 🇨🇳 Chinese |      修复箭头显示时位置计算错误     |
