### PR TITLE
fix(descriptions): render id prop on root element

### DIFF
--- a/packages/antdv-next/src/descriptions/index.tsx
+++ b/packages/antdv-next/src/descriptions/index.tsx
@@ -189,6 +189,7 @@ const Descriptions = defineComponent<
             hashId.value,
             cssVarCls.value,
           )}
+          id={props.id}
           style={[contextStyle, mergedStyles.value.root, (attrs as any).style]}
           {...omit(attrs, ['class', 'style'])}
         >

--- a/packages/antdv-next/src/descriptions/tests/Descriptions.test.tsx
+++ b/packages/antdv-next/src/descriptions/tests/Descriptions.test.tsx
@@ -277,6 +277,13 @@ describe('descriptions', () => {
   })
 
   // ==================== Attrs Passthrough ====================
+  it('renders id prop on root element', () => {
+    const wrapper = mount(Descriptions, {
+      props: { id: 'my-desc', items: basicItems },
+    })
+    expect(wrapper.find('.ant-descriptions').attributes('id')).toBe('my-desc')
+  })
+
   it('passes data-* attributes to root', () => {
     const wrapper = mount(Descriptions, {
       attrs: {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix (non-breaking change which fixes an issue)

### 🔗 Related Issues

> Found during unit test development for #63

### 💡 Background and Solution

**Problem:**

`Descriptions` declares `id` as a prop but never uses it in the render function. With `inheritAttrs: false`, Vue routes `id="..."` into `props.id` (not `attrs`), and the `attrs` spread on the root element does not include it. As a result, the `id` attribute is silently dropped.

**Root cause flow:**
```
<ADescriptions id="my-desc" />
  → Vue: id is declared in props → props.id = "my-desc"
  → render: spreads attrs (id is NOT in attrs)
  → DOM output: no id attribute ❌
```

**Fix:** Explicitly bind `id={props.id}` on the root `<div>`.

Same pattern already used in `Card` and `Alert`.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(descriptions): `id` prop declared but never rendered due to `inheritAttrs: false`; bind `props.id` explicitly on root element |
| 🇨🇳 Chinese | 修复 Descriptions 组件 `id` prop 因 `inheritAttrs: false` 导致不渲染到根元素的问题 |