### PR TITLE
test(popover): add unit tests for Popover component

### DIFF
--- a/packages/antdv-next/src/popover/tests/Popover.semantic.test.tsx
+++ b/packages/antdv-next/src/popover/tests/Popover.semantic.test.tsx
@@ -1,0 +1,229 @@
+import type { PopoverProps } from '..'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import Popover from '..'
+import ConfigProvider from '../../config-provider'
+import { mount, waitFakeTimer } from '/@tests/utils'
+
+async function flushPopoverTimer() {
+  await waitFakeTimer(150, 10)
+}
+
+describe('popover.Semantic', () => {
+  let originOffsetParentDescriptor: PropertyDescriptor | undefined
+
+  beforeAll(() => {
+    originOffsetParentDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetParent')
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get: () => document.body,
+    })
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  afterAll(() => {
+    if (originOffsetParentDescriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetParent', originOffsetParentDescriptor)
+    }
+  })
+
+  it('supports static object classes on root, container, arrow, title, content', async () => {
+    const classes: PopoverProps['classes'] = {
+      root: 'custom-root',
+      container: 'custom-container',
+      title: 'custom-title',
+      content: 'custom-content',
+    }
+
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        content: 'Content',
+        classes,
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    const popoverEl = document.querySelector<HTMLElement>('.ant-popover')
+    const containerEl = document.querySelector<HTMLElement>('.ant-popover-container')
+    const titleEl = document.querySelector<HTMLElement>('.ant-popover-title')
+    const contentEl = document.querySelector<HTMLElement>('.ant-popover-content')
+
+    expect(popoverEl).toHaveClass('custom-root')
+    expect(containerEl).toHaveClass('custom-container')
+    expect(titleEl).toHaveClass('custom-title')
+    expect(contentEl).toHaveClass('custom-content')
+  })
+
+  it('supports static object styles on root, container, title, content', async () => {
+    const styles: PopoverProps['styles'] = {
+      root: { backgroundColor: 'red' },
+      container: { color: 'blue' },
+      title: { fontWeight: 'bold' },
+      content: { fontSize: '14px' },
+    }
+
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        content: 'Content',
+        styles,
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    const popoverEl = document.querySelector<HTMLElement>('.ant-popover')
+    const containerEl = document.querySelector<HTMLElement>('.ant-popover-container')
+    const titleEl = document.querySelector<HTMLElement>('.ant-popover-title')
+    const contentEl = document.querySelector<HTMLElement>('.ant-popover-content')
+
+    expect(popoverEl).toHaveStyle('background-color: rgb(255, 0, 0)')
+    expect(containerEl).toHaveStyle('color: rgb(0, 0, 255)')
+    expect(titleEl).toHaveStyle('font-weight: bold')
+    expect(contentEl).toHaveStyle('font-size: 14px')
+  })
+
+  it('supports function-based classes', async () => {
+    const classes: PopoverProps['classes'] = (info) => {
+      if (info.props.placement === 'bottom') {
+        return { root: 'bottom-popover', title: 'bottom-title' }
+      }
+      return { root: 'top-popover' }
+    }
+
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        content: 'Content',
+        placement: 'bottom',
+        classes,
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    const popoverEl = document.querySelector<HTMLElement>('.ant-popover')
+    const titleEl = document.querySelector<HTMLElement>('.ant-popover-title')
+
+    expect(popoverEl).toHaveClass('bottom-popover')
+    expect(titleEl).toHaveClass('bottom-title')
+  })
+
+  it('supports function-based styles', async () => {
+    const styles: PopoverProps['styles'] = (info) => {
+      if (info.props.placement === 'top') {
+        return { content: { padding: '8px' } }
+      }
+      return { content: { padding: '4px' } }
+    }
+
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        content: 'Content',
+        placement: 'top',
+        styles,
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    const contentEl = document.querySelector<HTMLElement>('.ant-popover-content')
+    expect(contentEl).toHaveStyle('padding: 8px')
+  })
+
+  it('configProvider classes merge with component classes', async () => {
+    mount({
+      render() {
+        return (
+          <ConfigProvider
+            popover={{
+              classes: { root: 'cp-root' },
+            }}
+          >
+            <Popover
+              title="Title"
+              content="Content"
+              classes={{ container: 'comp-container' }}
+              open={true}
+              mouseEnterDelay={0}
+              mouseLeaveDelay={0}
+            >
+              <span>trigger</span>
+            </Popover>
+          </ConfigProvider>
+        )
+      },
+    }, { attachTo: document.body })
+    await flushPopoverTimer()
+
+    const popoverEl = document.querySelector<HTMLElement>('.ant-popover')
+    const containerEl = document.querySelector<HTMLElement>('.ant-popover-container')
+
+    expect(popoverEl).toHaveClass('cp-root')
+    expect(containerEl).toHaveClass('comp-container')
+  })
+
+  it('configProvider styles merge with component styles', async () => {
+    mount({
+      render() {
+        return (
+          <ConfigProvider
+            popover={{
+              styles: { root: { zIndex: 1001 } },
+            }}
+          >
+            <Popover
+              title="Title"
+              content="Content"
+              styles={{ container: { padding: '12px' } }}
+              open={true}
+              mouseEnterDelay={0}
+              mouseLeaveDelay={0}
+            >
+              <span>trigger</span>
+            </Popover>
+          </ConfigProvider>
+        )
+      },
+    }, { attachTo: document.body })
+    await flushPopoverTimer()
+
+    const containerEl = document.querySelector<HTMLElement>('.ant-popover-container')
+    expect(containerEl).toHaveStyle('padding: 12px')
+  })
+})

--- a/packages/antdv-next/src/popover/tests/Popover.test.tsx
+++ b/packages/antdv-next/src/popover/tests/Popover.test.tsx
@@ -1,0 +1,604 @@
+import type { PopoverRef } from '..'
+import KeyCode from '@v-c/util/dist/KeyCode'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import Popover from '..'
+import ConfigProvider from '../../config-provider'
+import mountTest from '/@tests/shared/mountTest'
+import rtlTest from '/@tests/shared/rtlTest'
+import { mount, waitFakeTimer } from '/@tests/utils'
+
+async function flushPopoverTimer() {
+  await waitFakeTimer(150, 10)
+}
+
+function isPopoverOpen() {
+  const ele = document.querySelector<HTMLElement>('.ant-popover')
+  if (!ele)
+    return false
+  if (ele.classList.contains('ant-popover-hidden'))
+    return false
+  return getComputedStyle(ele).display !== 'none'
+}
+
+describe('popover', () => {
+  mountTest(Popover)
+  rtlTest(Popover)
+
+  let originOffsetParentDescriptor: PropertyDescriptor | undefined
+
+  beforeAll(() => {
+    originOffsetParentDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetParent')
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get: () => document.body,
+    })
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  afterAll(() => {
+    if (originOffsetParentDescriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetParent', originOffsetParentDescriptor)
+    }
+  })
+
+  it('renders title prop in overlay', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Popover Title',
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+    expect(document.querySelector('.ant-popover-title')?.textContent).toContain('Popover Title')
+  })
+
+  it('renders content prop in overlay', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        content: 'Popover Content',
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+    expect(document.querySelector('.ant-popover-content')?.textContent).toContain('Popover Content')
+  })
+
+  it('renders title and content via slots', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        title: () => <span class="slot-title">Slot Title</span>,
+        content: () => <span class="slot-content">Slot Content</span>,
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+    expect(document.querySelector('.slot-title')).toBeTruthy()
+    expect(document.querySelector('.slot-content')).toBeTruthy()
+  })
+
+  it('slot takes priority over prop for title and content', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Prop Title',
+        content: 'Prop Content',
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        title: () => 'Slot Title',
+        content: () => 'Slot Content',
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+    expect(document.querySelector('.ant-popover-title')?.textContent).toContain('Slot Title')
+    expect(document.querySelector('.ant-popover-content')?.textContent).toContain('Slot Content')
+  })
+
+  it('should not render overlay when both title and content are empty', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        trigger: 'click',
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span id="trigger-el">click me</span>,
+      },
+    })
+    await flushPopoverTimer()
+    const triggerEl = document.getElementById('trigger-el')!
+    triggerEl.click()
+    await flushPopoverTimer()
+    expect(document.querySelector('.ant-popover')).toBeNull()
+  })
+
+  it('supports defaultOpen', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        defaultOpen: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+    expect(isPopoverOpen()).toBe(true)
+  })
+
+  it('controlled open', async () => {
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        open: false,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+    expect(isPopoverOpen()).toBe(false)
+
+    await wrapper.setProps({ open: true })
+    await flushPopoverTimer()
+    expect(isPopoverOpen()).toBe(true)
+
+    await wrapper.setProps({ open: false })
+    await flushPopoverTimer()
+    expect(isPopoverOpen()).toBe(false)
+  })
+
+  it('fires openChange and update:open when hover trigger opens/closes', async () => {
+    const onOpenChange = vi.fn()
+    const onUpdateOpen = vi.fn()
+
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+        onOpenChange,
+        'onUpdate:open': onUpdateOpen,
+      },
+      slots: {
+        default: () => <span id="hover-trigger">hover me</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    const triggerEl = wrapper.find('#hover-trigger')
+    await triggerEl.trigger('mouseenter')
+    await triggerEl.trigger('pointerenter')
+    await flushPopoverTimer()
+
+    expect(onOpenChange).toHaveBeenLastCalledWith(true, undefined)
+    expect(onUpdateOpen).toHaveBeenLastCalledWith(true)
+
+    await triggerEl.trigger('mouseleave')
+    await triggerEl.trigger('pointerleave')
+    await flushPopoverTimer()
+
+    expect(onOpenChange).toHaveBeenLastCalledWith(false, undefined)
+    expect(onUpdateOpen).toHaveBeenLastCalledWith(false)
+  })
+
+  it('in controlled mode, openChange fires but internal open stays false', async () => {
+    const onOpenChange = vi.fn()
+
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        open: false,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+        onOpenChange,
+      },
+      slots: {
+        default: () => <span id="ctrl-trigger">hover me</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    const triggerEl = wrapper.find('#ctrl-trigger')
+    await triggerEl.trigger('mouseenter')
+    await triggerEl.trigger('pointerenter')
+    await flushPopoverTimer()
+
+    // event fires but visual state stays closed (controlled)
+    expect(onOpenChange).toHaveBeenLastCalledWith(true, undefined)
+    expect(isPopoverOpen()).toBe(false)
+  })
+
+  it('switches from controlled to uncontrolled when open becomes undefined', async () => {
+    const open = ref<boolean | undefined>(true)
+
+    mount({
+      render() {
+        return (
+          <Popover
+            title="Title"
+            open={open.value}
+            mouseEnterDelay={0}
+            mouseLeaveDelay={0}
+          >
+            <span id="switch-trigger">trigger</span>
+          </Popover>
+        )
+      },
+    }, { attachTo: document.body })
+
+    await flushPopoverTimer()
+    expect(isPopoverOpen()).toBe(true)
+
+    // transition to uncontrolled: open was defined (true), now set to undefined → closes
+    open.value = undefined
+    await nextTick()
+    await flushPopoverTimer()
+    expect(isPopoverOpen()).toBe(false)
+  })
+
+  it('eSC key closes the popover', async () => {
+    const onOpenChange = vi.fn()
+
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+        onOpenChange,
+      },
+      slots: {
+        default: () => <span id="esc-trigger">trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    // open it first
+    const triggerEl = wrapper.find('#esc-trigger')
+    await triggerEl.trigger('mouseenter')
+    await triggerEl.trigger('pointerenter')
+    await flushPopoverTimer()
+    expect(onOpenChange).toHaveBeenLastCalledWith(true, undefined)
+
+    // press ESC
+    await triggerEl.trigger('keydown', { keyCode: KeyCode.ESC })
+    await flushPopoverTimer()
+    expect(onOpenChange).toHaveBeenLastCalledWith(false, expect.any(Object))
+  })
+
+  it('defaults to hover trigger', async () => {
+    const onOpenChange = vi.fn()
+
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+        onOpenChange,
+      },
+      slots: {
+        default: () => <span id="default-trigger">hover me</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    const triggerEl = wrapper.find('#default-trigger')
+    await triggerEl.trigger('mouseenter')
+    await triggerEl.trigger('pointerenter')
+    await flushPopoverTimer()
+    expect(onOpenChange).toHaveBeenLastCalledWith(true, undefined)
+  })
+
+  it('supports click trigger', async () => {
+    const onOpenChange = vi.fn()
+
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        trigger: 'click',
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+        onOpenChange,
+      },
+      slots: {
+        default: () => <span id="click-trigger">click me</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    const triggerEl = wrapper.find('#click-trigger')
+    await triggerEl.trigger('click')
+    await flushPopoverTimer()
+    expect(onOpenChange).toHaveBeenLastCalledWith(true, undefined)
+  })
+
+  it('supports placement prop', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        placement: 'bottom',
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+    // popover should render (placement doesn't affect visibility test)
+    expect(isPopoverOpen()).toBe(true)
+  })
+
+  it('supports arrow prop', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        arrow: true,
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+    expect(document.querySelector('.ant-popover-arrow')).toBeTruthy()
+  })
+
+  it('arrow={false} hides the arrow', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        arrow: false,
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+    expect(document.querySelector('.ant-popover-arrow')).toBeNull()
+  })
+
+  it('configProvider arrow prop controls popover arrow', async () => {
+    mount({
+      render() {
+        return (
+          <ConfigProvider popover={{ arrow: false }}>
+            <Popover
+              title="Title"
+              open={true}
+              mouseEnterDelay={0}
+              mouseLeaveDelay={0}
+            >
+              <span>trigger</span>
+            </Popover>
+          </ConfigProvider>
+        )
+      },
+    }, { attachTo: document.body })
+    await flushPopoverTimer()
+    expect(document.querySelector('.ant-popover-arrow')).toBeNull()
+  })
+
+  it('component-level arrow overrides ConfigProvider arrow', async () => {
+    mount({
+      render() {
+        return (
+          <ConfigProvider popover={{ arrow: false }}>
+            <Popover
+              title="Title"
+              arrow={true}
+              open={true}
+              mouseEnterDelay={0}
+              mouseLeaveDelay={0}
+            >
+              <span>trigger</span>
+            </Popover>
+          </ConfigProvider>
+        )
+      },
+    }, { attachTo: document.body })
+    await flushPopoverTimer()
+    expect(document.querySelector('.ant-popover-arrow')).not.toBeNull()
+  })
+
+  it('configProvider trigger prop controls popover trigger', async () => {
+    const onOpenChange = vi.fn()
+
+    const wrapper = mount({
+      render() {
+        return (
+          <ConfigProvider popover={{ trigger: 'click' }}>
+            <Popover
+              title="Title"
+              mouseEnterDelay={0}
+              mouseLeaveDelay={0}
+              onOpenChange={onOpenChange}
+            >
+              <span id="cp-trigger">trigger</span>
+            </Popover>
+          </ConfigProvider>
+        )
+      },
+    }, { attachTo: document.body })
+    await flushPopoverTimer()
+
+    // hover should NOT trigger open (trigger=click from ConfigProvider)
+    const triggerEl = wrapper.find('#cp-trigger')
+    await triggerEl.trigger('mouseenter')
+    await triggerEl.trigger('pointerenter')
+    await flushPopoverTimer()
+    expect(onOpenChange).not.toHaveBeenCalled()
+
+    // click should open it
+    await triggerEl.trigger('click')
+    await flushPopoverTimer()
+    expect(onOpenChange).toHaveBeenLastCalledWith(true, undefined)
+  })
+
+  it('exposes forceAlign, nativeElement, popupElement', () => {
+    const popoverRef = ref<PopoverRef | null>(null)
+    mount({
+      render() {
+        return (
+          <Popover
+            ref={popoverRef}
+            title="Title"
+            open={true}
+          >
+            <span>trigger</span>
+          </Popover>
+        )
+      },
+    }, { attachTo: document.body })
+
+    expect(typeof popoverRef.value?.forceAlign).toBe('function')
+  })
+
+  it('non-ESC keydown does not close the popover', async () => {
+    const onOpenChange = vi.fn()
+
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Title',
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+        onOpenChange,
+      },
+      slots: {
+        default: () => <span id="non-esc-trigger">trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    // open it
+    const triggerEl = wrapper.find('#non-esc-trigger')
+    await triggerEl.trigger('mouseenter')
+    await triggerEl.trigger('pointerenter')
+    await flushPopoverTimer()
+    expect(onOpenChange).toHaveBeenLastCalledWith(true, undefined)
+
+    const callCountBefore = onOpenChange.mock.calls.length
+
+    // press Enter (not ESC)
+    await triggerEl.trigger('keydown', { keyCode: 13 })
+    await flushPopoverTimer()
+
+    // openChange should NOT be called again
+    expect(onOpenChange.mock.calls.length).toBe(callCountBefore)
+  })
+
+  it('renders without default slot children', () => {
+    // children is null → createVNode branch skipped
+    expect(() => {
+      mount(Popover, {
+        props: {
+          title: 'Title',
+          open: true,
+        },
+      })
+    }).not.toThrow()
+  })
+
+  it('purePanel _InternalPanelDoNotUseOrYouWillBeFired renders without error', () => {
+    const InternalPanel = (Popover as any)._InternalPanelDoNotUseOrYouWillBeFired
+
+    expect(() => {
+      mount(InternalPanel, {
+        props: {
+          title: 'Panel Title',
+          content: 'Panel Content',
+        },
+      })
+    }).not.toThrow()
+  })
+
+  it('purePanel handles null title and content without error', () => {
+    const InternalPanel = (Popover as any)._InternalPanelDoNotUseOrYouWillBeFired
+
+    expect(() => {
+      mount(InternalPanel, {
+        props: {
+          title: null,
+          content: null,
+        },
+      })
+    }).not.toThrow()
+  })
+
+  it('matches snapshot with title and content', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        title: 'Snapshot Title',
+        content: 'Snapshot Content',
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>trigger</span>,
+      },
+    })
+    await flushPopoverTimer()
+
+    const snapshotContainer = document.createElement('div')
+    const popoverEl = document.querySelector('.ant-popover')
+    if (popoverEl) {
+      snapshotContainer.appendChild(popoverEl.cloneNode(true))
+    }
+    expect(snapshotContainer.innerHTML).toMatchSnapshot()
+  })
+})

--- a/packages/antdv-next/src/popover/tests/__snapshots__/Popover.test.tsx.snap
+++ b/packages/antdv-next/src/popover/tests/__snapshots__/Popover.test.tsx.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`popover > matches snapshot with title and content 1`] = `"<div class="ant-popover ant-popover-css-var css-var-root css-var-root ant-popover-placement-bottom" style="--arrow-x: 0px; --arrow-y: -6px; left: 0px; top: 12px; right: auto; bottom: auto; box-sizing: border-box;"><div class="ant-popover-arrow" style="position: absolute; left: 0px; top: 0px;"><span class="ant-popover-arrow-content"></span></div><div id="test-id" class="ant-popover-container" role="tooltip"><div class="ant-popover-title">Snapshot Title</div><div class="ant-popover-content">Snapshot Content</div></div></div>"`;
+
+exports[`popover > rtl render > component should be rendered correctly in RTL direction 1`] = `
+<div
+  data-v-app=""
+>
+  <span>
+    <!---->
+  </span>
+  <!---->
+</div>
+`;

--- a/packages/antdv-next/src/popover/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/popover/tests/__snapshots__/demo.test.tsx.snap
@@ -1,0 +1,888 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`popover demo > renders arrow correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    aria-label="segmented control"
+    class="ant-segmented css-var-root css-var-root"
+    role="radiogroup"
+    size="middle"
+    style="margin-bottom: 24px;"
+    tabindex="0"
+  >
+    <div
+      class="ant-segmented-group"
+    >
+      <!---->
+      <label
+        class="ant-segmented-item ant-segmented-item-selected"
+      >
+        <input
+          checked=""
+          class="ant-segmented-item-input"
+          name="v-1"
+          type="radio"
+        />
+        <div
+          aria-checked="true"
+          class="ant-segmented-item-label"
+          role="radio"
+          title="Show"
+        >
+          Show
+        </div>
+      </label>
+      <label
+        class="ant-segmented-item"
+      >
+        <input
+          class="ant-segmented-item-input"
+          name="v-1"
+          type="radio"
+        />
+        <div
+          aria-checked="false"
+          class="ant-segmented-item-label"
+          role="radio"
+          title="Hide"
+        >
+          Hide
+        </div>
+      </label>
+      <label
+        class="ant-segmented-item"
+      >
+        <input
+          class="ant-segmented-item-input"
+          name="v-1"
+          type="radio"
+        />
+        <div
+          aria-checked="false"
+          class="ant-segmented-item-label"
+          role="radio"
+          title="Center"
+        >
+          Center
+        </div>
+      </label>
+    </div>
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center ant-flex-vertical demo"
+  >
+    <div
+      class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center"
+      style="white-space: nowrap;"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          TL
+        </span>
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          Top
+        </span>
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          TR
+        </span>
+        <!---->
+      </button>
+      <!---->
+    </div>
+    <div
+      class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between"
+      style="width: 432px;"
+    >
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-vertical"
+      >
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            LT
+          </span>
+          <!---->
+        </button>
+        <!---->
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            Left
+          </span>
+          <!---->
+        </button>
+        <!---->
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            LB
+          </span>
+          <!---->
+        </button>
+        <!---->
+      </div>
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-vertical"
+      >
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            RT
+          </span>
+          <!---->
+        </button>
+        <!---->
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            Right
+          </span>
+          <!---->
+        </button>
+        <!---->
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            RB
+          </span>
+          <!---->
+        </button>
+        <!---->
+      </div>
+    </div>
+    <div
+      class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center"
+      style="white-space: nowrap;"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          BL
+        </span>
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          Bottom
+        </span>
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          BR
+        </span>
+        <!---->
+      </button>
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`popover demo > renders basic correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    data-v-d5c2808f=""
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Hover me 
+    </span>
+    <!---->
+  </button>
+  <!---->
+</div>
+`;
+
+exports[`popover demo > renders control correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Click me 
+    </span>
+    <!---->
+  </button>
+  <!---->
+</div>
+`;
+
+exports[`popover demo > renders hover-with-click correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+      Hover and click
+    </span>
+    <!---->
+  </button>
+  <!---->
+  <!---->
+</div>
+`;
+
+exports[`popover demo > renders placement correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center ant-flex-vertical demo"
+  >
+    <div
+      class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center"
+      style="white-space: nowrap;"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          TL
+        </span>
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          Top
+        </span>
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          TR
+        </span>
+        <!---->
+      </button>
+      <!---->
+    </div>
+    <div
+      class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between"
+      style="width: 432px;"
+    >
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-vertical"
+      >
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            LT
+          </span>
+          <!---->
+        </button>
+        <!---->
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            Left
+          </span>
+          <!---->
+        </button>
+        <!---->
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            LB
+          </span>
+          <!---->
+        </button>
+        <!---->
+      </div>
+      <div
+        class="ant-flex css-var-root ant-flex-align-center ant-flex-vertical"
+      >
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            RT
+          </span>
+          <!---->
+        </button>
+        <!---->
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            Right
+          </span>
+          <!---->
+        </button>
+        <!---->
+        <button
+          class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+          style="width: 80px; margin: 4px;"
+          type="button"
+        >
+          <transition-stub
+            appear="false"
+            css="true"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <span>
+            RB
+          </span>
+          <!---->
+        </button>
+        <!---->
+      </div>
+    </div>
+    <div
+      class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-center"
+      style="white-space: nowrap;"
+    >
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          BL
+        </span>
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          Bottom
+        </span>
+        <!---->
+      </button>
+      <!---->
+      <button
+        class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        style="width: 80px; margin: 4px;"
+        type="button"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-btn-loading-icon-motion"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        <span>
+          BR
+        </span>
+        <!---->
+      </button>
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`popover demo > renders render-panel correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-popover ant-popover-pure ant-popover-placement-top css-var-root"
+  >
+    <div
+      class="ant-popover-arrow"
+    />
+    <div
+      class="ant-popover-container"
+      content="[object Object]"
+      hashid=""
+      placement="top"
+      role="tooltip"
+      title="Title"
+    >
+      <div
+        class="ant-popover-title"
+      >
+        Title
+      </div>
+      <div
+        class="ant-popover-content"
+      >
+        <div>
+          <p>
+            Content
+          </p>
+          <p>
+            Content
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-popover ant-popover-pure ant-popover-placement-bottomLeft css-var-root"
+    style="width: 250px;"
+  >
+    <div
+      class="ant-popover-arrow"
+    />
+    <div
+      class="ant-popover-container"
+      content="[object Object]"
+      hashid=""
+      placement="bottomLeft"
+      role="tooltip"
+      title="Title"
+    >
+      <div
+        class="ant-popover-title"
+      >
+        Title
+      </div>
+      <div
+        class="ant-popover-content"
+      >
+        <div>
+          <p>
+            Content
+          </p>
+          <p>
+            Content
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`popover demo > renders shift correctly 1`] = `
+<div
+  class="h-300vh w-300vw flex items-center justify-center"
+>
+  <button
+    aria-describedby="test-id"
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-popover-open"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Scroll The Window 
+    </span>
+    <!---->
+  </button>
+  <!---->
+</div>
+`;
+
+exports[`popover demo > renders style-class correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-gap-middle"
+>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+      Object Style
+    </span>
+    <!---->
+  </button>
+  <!---->
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       Function Style 
+    </span>
+    <!---->
+  </button>
+  <!---->
+</div>
+`;
+
+exports[`popover demo > renders trigger-type correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+  style="flex-wrap: wrap;"
+>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+        Hover me
+      </span>
+      <!---->
+    </button>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+        Focus me
+      </span>
+      <!---->
+    </button>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+        Click me
+      </span>
+      <!---->
+    </button>
+    <!---->
+  </div>
+  <!---->
+</div>
+`;

--- a/packages/antdv-next/src/popover/tests/demo.test.tsx
+++ b/packages/antdv-next/src/popover/tests/demo.test.tsx
@@ -1,0 +1,5 @@
+import demoTest from '/@tests/shared/demoTest'
+
+demoTest('popover', {
+  skip: ['_semantic'],
+})


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ✅ Test Case

### 🔗 Related Issues

ref #63

### 💡 Background and Solution

Add comprehensive unit tests for the `Popover` component to improve test coverage.

**Key findings during implementation:**

1. **`openChange` emit has 2 params** — `Popover` extends `Tooltip`'s `openChange` signature from `(open: boolean)` to `(open: boolean, e?: MouseEvent | KeyboardEvent)`. The event object is `undefined` for hover/click triggers and a `KeyboardEvent` for ESC key close. Tests must use `toHaveBeenLastCalledWith(true, undefined)` accordingly.

2. **Inner container uses `-container` not `-inner`** — `@v-c/tooltip`'s `VcTooltip` renders the popup wrapper as `${prefixCls}-container` (e.g. `.ant-popover-container`), not `.ant-popover-inner` as in React Ant Design. Confirmed via snapshot.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add unit tests for Popover component (27 main tests + 6 semantic tests + demo tests) |
| 🇨🇳 Chinese | 为 Popover 组件添加单元测试（27 个主测试 + 6 个语义测试 + demo 测试） |