### PR TITLE
fix(collapse): use prefixCls.value in CollapsePanel no-arrow class

### DIFF
--- a/packages/antdv-next/src/collapse/CollapsePanel.tsx
+++ b/packages/antdv-next/src/collapse/CollapsePanel.tsx
@@ -30,7 +30,7 @@ const CollapsePanel = defineComponent<CollapsePanelProps>(
       const { showArrow = true } = props
       const collapsePanelClassName = classNames(
         {
-          [`${prefixCls}-no-arrow`]: !showArrow,
+          [`${prefixCls.value}-no-arrow`]: !showArrow,
         },
         (attrs as any).class,
       )


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related Issues

ref #63

### 💡 Background and Solution

**Bug:**
`CollapsePanel.tsx` used `` `${prefixCls}` `` (a Vue `Ref` object) inside a template literal instead of `` `${prefixCls.value}` `` (the resolved string).

This caused the `no-arrow` CSS class to be generated as `[object Object]-no-arrow` instead of the correct `ant-collapse-no-arrow` when `showArrow={false}`.

**Fix:**
Change `${prefixCls}` → `${prefixCls.value}` on the class key template literal.

```tsx
// Before (bug):
[`${prefixCls}-no-arrow`]: !showArrow,

// After (fix):
[`${prefixCls.value}-no-arrow`]: !showArrow,
```

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(collapse): correct no-arrow class generation in CollapsePanel when showArrow=false |
| 🇨🇳 Chinese | fix(collapse): 修复 CollapsePanel showArrow=false 时 no-arrow class 名称错误的问题 |