### PR TITLE
test(collapse): add unit tests for Collapse component

### DIFF
--- a/packages/antdv-next/src/collapse/tests/Collapse.semantic.test.tsx
+++ b/packages/antdv-next/src/collapse/tests/Collapse.semantic.test.tsx
@@ -1,0 +1,125 @@
+import type { CollapseProps } from '..'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import Collapse from '..'
+import { mount } from '/@tests/utils'
+
+const openItems: CollapseProps['items'] = [
+  { key: '1', label: 'Panel 1', content: h('p', 'Content 1') },
+]
+
+describe('collapse.Semantic', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ==================== static object classes ====================
+  it('supports static object classes on root, header, title, icon', () => {
+    const classes: CollapseProps['classes'] = {
+      root: 'custom-root',
+      header: 'custom-header',
+      title: 'custom-title',
+      icon: 'custom-icon',
+    }
+    const wrapper = mount(Collapse, {
+      props: { items: openItems, classes },
+    })
+
+    expect(wrapper.find('.ant-collapse').classes()).toContain('custom-root')
+    expect(wrapper.find('.ant-collapse-header').classes()).toContain('custom-header')
+    expect(wrapper.find('.ant-collapse-title').classes()).toContain('custom-title')
+    expect(wrapper.find('.ant-collapse-expand-icon').classes()).toContain('custom-icon')
+  })
+
+  it('supports static object classes on body (with open panel)', () => {
+    const classes: CollapseProps['classes'] = { body: 'custom-body' }
+    const wrapper = mount(Collapse, {
+      props: { items: openItems, classes, defaultActiveKey: ['1'] },
+    })
+    expect(wrapper.find('.ant-collapse-body').classes()).toContain('custom-body')
+  })
+
+  // ==================== static object styles ====================
+  it('supports static object styles on root, header, body', () => {
+    const styles: CollapseProps['styles'] = {
+      root: { backgroundColor: 'red' },
+      header: { color: 'blue' },
+      body: { padding: '8px' },
+    }
+    const wrapper = mount(Collapse, {
+      props: { items: openItems, styles, defaultActiveKey: ['1'] },
+    })
+
+    expect(wrapper.find('.ant-collapse').attributes('style')).toContain('background-color: red')
+    expect(wrapper.find('.ant-collapse-header').attributes('style')).toContain('color: blue')
+    expect(wrapper.find('.ant-collapse-body').attributes('style')).toContain('padding: 8px')
+  })
+
+  // ==================== function-based classes ====================
+  it('supports function-based classes', () => {
+    const classes: CollapseProps['classes'] = (info) => {
+      if (info.props.ghost) {
+        return { root: 'ghost-root', header: 'ghost-header' }
+      }
+      return { root: 'normal-root' }
+    }
+
+    const wrapper = mount(Collapse, {
+      props: { items: openItems, classes, ghost: true },
+    })
+
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ghost-root')
+    expect(wrapper.find('.ant-collapse-header').classes()).toContain('ghost-header')
+  })
+
+  it('function-based classes: else branch', () => {
+    const classes: CollapseProps['classes'] = (info) => {
+      if (info.props.ghost) {
+        return { root: 'ghost-root' }
+      }
+      return { root: 'normal-root' }
+    }
+
+    const wrapper = mount(Collapse, {
+      props: { items: openItems, classes, ghost: false },
+    })
+
+    expect(wrapper.find('.ant-collapse').classes()).toContain('normal-root')
+    expect(wrapper.find('.ant-collapse').classes()).not.toContain('ghost-root')
+  })
+
+  // ==================== function-based styles ====================
+  it('supports function-based styles', () => {
+    const styles: CollapseProps['styles'] = (info) => {
+      if (info.props.bordered === false) {
+        return { root: { padding: '0px' } }
+      }
+      return { root: { padding: '8px' } }
+    }
+
+    const wrapper = mount(Collapse, {
+      props: { items: openItems, styles, bordered: false },
+    })
+
+    expect(wrapper.find('.ant-collapse').attributes('style')).toContain('padding: 0px')
+  })
+
+  it('function-based styles: else branch', () => {
+    const styles: CollapseProps['styles'] = (info) => {
+      if (info.props.bordered === false) {
+        return { root: { padding: '0px' } }
+      }
+      return { root: { padding: '8px' } }
+    }
+
+    const wrapper = mount(Collapse, {
+      props: { items: openItems, styles, bordered: true },
+    })
+
+    expect(wrapper.find('.ant-collapse').attributes('style')).toContain('padding: 8px')
+  })
+})

--- a/packages/antdv-next/src/collapse/tests/Collapse.test.tsx
+++ b/packages/antdv-next/src/collapse/tests/Collapse.test.tsx
@@ -1,0 +1,409 @@
+import type { CollapseItemType } from '../Collapse'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { h, nextTick, ref } from 'vue'
+import Collapse from '..'
+import ConfigProvider from '../../config-provider'
+import mountTest from '/@tests/shared/mountTest'
+import rtlTest from '/@tests/shared/rtlTest'
+import { mount } from '/@tests/utils'
+
+const basicItems: CollapseItemType[] = [
+  { key: '1', label: 'Panel 1', content: h('p', 'Content 1') },
+  { key: '2', label: 'Panel 2', content: h('p', 'Content 2') },
+]
+
+describe('collapse', () => {
+  mountTest(Collapse)
+  rtlTest(() => h(Collapse))
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ==================== Basic Rendering ====================
+  it('should render correctly with ant-collapse class', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems } })
+    expect(wrapper.find('.ant-collapse').exists()).toBe(true)
+  })
+
+  it('should render items as panels', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems } })
+    expect(wrapper.findAll('.ant-collapse-item').length).toBe(2)
+  })
+
+  // ==================== expandIconPlacement ====================
+  it('should default expandIconPlacement to start', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems } })
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-icon-position-start')
+  })
+
+  it('should support expandIconPlacement=end', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems, expandIconPlacement: 'end' } })
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-icon-position-end')
+  })
+
+  // ==================== bordered ====================
+  it('should have border by default (no borderless class)', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems } })
+    expect(wrapper.find('.ant-collapse').classes()).not.toContain('ant-collapse-borderless')
+  })
+
+  it('should support bordered=false', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems, bordered: false } })
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-borderless')
+  })
+
+  // ==================== ghost ====================
+  it('should support ghost mode', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems, ghost: true } })
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-ghost')
+  })
+
+  it('should not have ghost class when ghost=false', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems, ghost: false } })
+    expect(wrapper.find('.ant-collapse').classes()).not.toContain('ant-collapse-ghost')
+  })
+
+  // ==================== size ====================
+  it('should support size=small', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems, size: 'small' } })
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-small')
+  })
+
+  it('should support size=large', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems, size: 'large' } })
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-large')
+  })
+
+  it('should not add size class when size=middle (default)', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems, size: 'middle' } })
+    expect(wrapper.find('.ant-collapse').classes()).not.toContain('ant-collapse-middle')
+  })
+
+  // ==================== defaultActiveKey / activeKey ====================
+  it('should expand panel with defaultActiveKey', () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems, defaultActiveKey: ['1'] },
+    })
+    const panelItems = wrapper.findAll('.ant-collapse-item')
+    expect(panelItems[0]!.classes()).toContain('ant-collapse-item-active')
+    expect(panelItems[1]!.classes()).not.toContain('ant-collapse-item-active')
+  })
+
+  it('should control active panel via activeKey', () => {
+    const activeKey = ref<string[]>([])
+    const wrapper = mount(() => (
+      <Collapse items={basicItems} activeKey={activeKey.value} />
+    ))
+    expect(wrapper.find('.ant-collapse-item-active').exists()).toBe(false)
+    activeKey.value = ['2']
+    return nextTick().then(() => {
+      const panelItems = wrapper.findAll('.ant-collapse-item')
+      expect(panelItems[1]!.classes()).toContain('ant-collapse-item-active')
+    })
+  })
+
+  // ==================== expand icon ====================
+  it('should render default expand icon with aria-label=collapsed', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems } })
+    const arrow = wrapper.find('.ant-collapse-arrow')
+    expect(arrow.exists()).toBe(true)
+    expect(arrow.attributes('aria-label')).toBe('collapsed')
+  })
+
+  it('should show aria-label=expanded when panel is active', () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems, defaultActiveKey: ['1'] },
+    })
+    const arrow = wrapper.findAll('.ant-collapse-arrow')[0]!
+    expect(arrow.attributes('aria-label')).toBe('expanded')
+  })
+
+  it('should rotate arrow 90deg when active (LTR)', () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems, defaultActiveKey: ['1'] },
+    })
+    // The rotation style is applied to the SVG element inside the arrow span
+    expect(wrapper.find('[style*="rotate(90deg)"]').exists()).toBe(true)
+  })
+
+  it('should rotate arrow -90deg when active (RTL)', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider direction="rtl">
+        <Collapse items={basicItems} defaultActiveKey={['1']} />
+      </ConfigProvider>
+    ))
+    expect(wrapper.find('[style*="rotate(-90deg)"]').exists()).toBe(true)
+  })
+
+  it('should not rotate arrow when inactive', () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems } })
+    expect(wrapper.find('[style*="rotate"]').exists()).toBe(false)
+  })
+
+  it('should support custom expandIcon prop', () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        items: basicItems,
+        expandIcon: () => h('span', { class: 'custom-icon' }, '▶'),
+      },
+    })
+    expect(wrapper.find('.custom-icon').exists()).toBe(true)
+    // Default RightOutlined SVG should not be rendered
+    expect(wrapper.find('[data-icon="right"]').exists()).toBe(false)
+  })
+
+  it('should keep expandIcon class after custom icon', () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        items: basicItems,
+        expandIcon: () => h('span', { class: 'my-icon' }, '▶'),
+      },
+    })
+    // cloneElement merges ant-collapse-arrow onto custom icon
+    expect(wrapper.find('.my-icon').classes()).toContain('ant-collapse-arrow')
+  })
+
+  it('should support expandIcon slot (takes precedence over prop)', () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        items: basicItems,
+        expandIcon: () => h('span', { class: 'prop-icon' }),
+      },
+      slots: {
+        expandIcon: () => h('span', { class: 'slot-icon' }),
+      },
+    })
+    expect(wrapper.find('.slot-icon').exists()).toBe(true)
+    expect(wrapper.find('.prop-icon').exists()).toBe(false)
+  })
+
+  // ==================== labelRender / contentRender ====================
+  it('should support labelRender prop to override item label', () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        items: [{ key: '1', label: 'Original', content: h('p', 'body') }],
+        labelRender: ({ item }) => h('strong', `Custom: ${item.label}`),
+      },
+    })
+    expect(wrapper.find('strong').text()).toBe('Custom: Original')
+  })
+
+  it('should support contentRender prop to override item content', () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        items: [{ key: '1', label: 'Panel', content: h('p', 'Original') }],
+        defaultActiveKey: ['1'],
+        contentRender: () => h('div', { class: 'custom-content' }, 'Custom'),
+      },
+    })
+    expect(wrapper.find('.custom-content').exists()).toBe(true)
+  })
+
+  it('should support labelRender slot (takes precedence over prop)', () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        items: [{ key: '1', label: 'Original', content: h('p', 'body') }],
+        labelRender: () => h('span', { class: 'prop-label' }),
+      },
+      slots: {
+        labelRender: () => h('span', { class: 'slot-label' }),
+      },
+    })
+    expect(wrapper.find('.slot-label').exists()).toBe(true)
+    expect(wrapper.find('.prop-label').exists()).toBe(false)
+  })
+
+  it('should support contentRender slot (takes precedence over prop)', () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        items: [{ key: '1', label: 'Panel', content: h('p', 'body') }],
+        defaultActiveKey: ['1'],
+        contentRender: () => h('div', { class: 'prop-content' }),
+      },
+      slots: {
+        contentRender: () => h('div', { class: 'slot-content' }),
+      },
+    })
+    expect(wrapper.find('.slot-content').exists()).toBe(true)
+    expect(wrapper.find('.prop-content').exists()).toBe(false)
+  })
+
+  // ==================== accordion ====================
+  it('should support accordion mode (only one panel open at a time)', async () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems, accordion: true },
+    })
+    const headers = wrapper.findAll('.ant-collapse-header')
+    await headers[0]!.trigger('click')
+    await headers[1]!.trigger('click')
+    await nextTick()
+    const accordionItems = wrapper.findAll('.ant-collapse-item')
+    expect(accordionItems[0]!.classes()).not.toContain('ant-collapse-item-active')
+    expect(accordionItems[1]!.classes()).toContain('ant-collapse-item-active')
+  })
+
+  // ==================== collapsible ====================
+  it('should support collapsible=disabled', () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems, collapsible: 'disabled' },
+    })
+    const item = wrapper.find('.ant-collapse-item')
+    expect(item.classes()).toContain('ant-collapse-item-disabled')
+    expect(wrapper.find('.ant-collapse-header').attributes('aria-disabled')).toBe('true')
+  })
+
+  // ==================== showArrow (via item + CollapsePanel) ====================
+  it('should hide expand icon when item showArrow=false', () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        items: [{ key: '1', label: 'Panel', content: h('p', 'Body'), showArrow: false }],
+      },
+    })
+    // Arrow icon should not be rendered when showArrow=false
+    const iconWrapper = wrapper.find('.ant-collapse-expand-icon')
+    expect(iconWrapper.exists()).toBe(false)
+  })
+
+  // Note: ant-collapse-no-arrow class is added by antdv-next's CollapsePanel wrapper,
+  // but the items API renders @v-c/collapse's Panel directly (bypassing the wrapper),
+  // so that class never appears in the DOM. No test for it here.
+  it('collapsePanel: showArrow=true (default) renders expand icon', () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        items: [{ key: '1', label: 'Panel', content: h('p', 'Body'), showArrow: true }],
+      },
+    })
+    expect(wrapper.find('.ant-collapse-expand-icon').exists()).toBe(true)
+  })
+
+  // ==================== change emit ====================
+  it('should emit change when panel is toggled', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems, onChange },
+    })
+    await wrapper.find('.ant-collapse-header').trigger('click')
+    expect(onChange).toHaveBeenCalledWith(['1'])
+  })
+
+  it('should emit change via v-on:change', async () => {
+    const wrapper = mount(Collapse, { props: { items: basicItems } })
+    await wrapper.find('.ant-collapse-header').trigger('click')
+    expect(wrapper.emitted('change')).toBeTruthy()
+    expect(wrapper.emitted('change')![0]).toEqual([['1']])
+  })
+
+  // ==================== rootClass ====================
+  it('should support rootClass prop', () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems, rootClass: 'my-collapse' },
+    })
+    expect(wrapper.find('.ant-collapse').classes()).toContain('my-collapse')
+  })
+
+  // ==================== attrs passthrough ====================
+  it('should pass class attr to root element', () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems },
+      attrs: { class: 'extra-class' },
+    })
+    expect(wrapper.find('.ant-collapse').classes()).toContain('extra-class')
+  })
+
+  it('should pass style attr to root element', () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems },
+      attrs: { style: { color: 'red' } },
+    })
+    expect(wrapper.find('.ant-collapse').attributes('style')).toContain('color: red')
+  })
+
+  it('should pass data-* attrs', () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems },
+      attrs: { 'data-testid': 'my-collapse' },
+    })
+    expect(wrapper.find('[data-testid="my-collapse"]').exists()).toBe(true)
+  })
+
+  // ==================== semantic classes/styles ====================
+  it('should apply semantic classes.root', () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems, classes: { root: 'c-root' } },
+    })
+    expect(wrapper.find('.ant-collapse').classes()).toContain('c-root')
+  })
+
+  it('should apply semantic styles.root', () => {
+    const wrapper = mount(Collapse, {
+      props: { items: basicItems, styles: { root: { color: 'red' } } },
+    })
+    expect(wrapper.find('.ant-collapse').attributes('style')).toContain('color: red')
+  })
+
+  // ==================== ConfigProvider ====================
+  it('should inherit size from ConfigProvider', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider componentSize="large">
+        <Collapse items={basicItems} />
+      </ConfigProvider>
+    ))
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-large')
+  })
+
+  it('should prefer component size over ConfigProvider size', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider componentSize="large">
+        <Collapse items={basicItems} size="small" />
+      </ConfigProvider>
+    ))
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-small')
+    expect(wrapper.find('.ant-collapse').classes()).not.toContain('ant-collapse-large')
+  })
+
+  // ==================== RTL ====================
+  it('should add rtl class in RTL direction', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider direction="rtl">
+        <Collapse items={basicItems} />
+      </ConfigProvider>
+    ))
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-rtl')
+  })
+
+  // ==================== dynamic updates ====================
+  it('should update when items prop changes', async () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        items: [{ key: '1', label: 'Panel 1', content: h('p', 'Body') }],
+      },
+    })
+    expect(wrapper.findAll('.ant-collapse-item').length).toBe(1)
+    await wrapper.setProps({
+      items: [
+        { key: '1', label: 'Panel 1', content: h('p', 'Body') },
+        { key: '2', label: 'Panel 2', content: h('p', 'Body 2') },
+      ],
+    })
+    expect(wrapper.findAll('.ant-collapse-item').length).toBe(2)
+  })
+
+  // ==================== snapshot ====================
+  it('should match snapshot', () => {
+    const wrapper = mount(Collapse, {
+      props: {
+        defaultActiveKey: ['1'],
+        items: [
+          { key: '1', label: 'Panel 1', content: h('p', 'Content 1') },
+          { key: '2', label: 'Panel 2', content: h('p', 'Content 2') },
+        ],
+      },
+    })
+    expect(wrapper.element).toMatchSnapshot()
+  })
+})

--- a/packages/antdv-next/src/collapse/tests/__snapshots__/Collapse.test.tsx.snap
+++ b/packages/antdv-next/src/collapse/tests/__snapshots__/Collapse.test.tsx.snap
@@ -1,0 +1,129 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`collapse > rtl render > component should be rendered correctly in RTL direction 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-collapse ant-collapse-icon-position-start ant-collapse-rtl css-var-root"
+  />
+</div>
+`;
+
+exports[`collapse > should match snapshot 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+>
+  <div
+    class="ant-collapse-item ant-collapse-item-active"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="expanded"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="transform: rotate(90deg);"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        Panel 1
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <div
+        class="ant-collapse-panel ant-collapse-panel-active"
+      >
+        <div
+          class="ant-collapse-body"
+        >
+          <p>
+            Content 1
+          </p>
+        </div>
+      </div>
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        Panel 2
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+</div>
+`;

--- a/packages/antdv-next/src/collapse/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/collapse/tests/__snapshots__/demo.test.tsx.snap
@@ -1,0 +1,2910 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`collapse demo > renders _semantic correctly 1`] = `
+<div
+  class="semantic-preview-container"
+  data-v-dfc8ebef=""
+>
+  <div
+    class="ant-row css-var-root semantic-preview-row"
+    data-v-dfc8ebef=""
+  >
+    <div
+      class="ant-col ant-col-16 css-var-root semantic-preview-col"
+      data-v-dfc8ebef=""
+    >
+      <div
+        style="position: absolute; inset: 0; margin: 32px;"
+      >
+        <div
+          class="ant-collapse ant-collapse-icon-position-start css-var-v-0 semantic-mark-root"
+        >
+          <div
+            class="ant-collapse-item ant-collapse-item-active"
+          >
+            <div
+              aria-disabled="false"
+              aria-expanded="true"
+              class="ant-collapse-header semantic-mark-header"
+              role="button"
+              tabindex="0"
+            >
+              <div
+                class="ant-collapse-expand-icon semantic-mark-icon"
+              >
+                <span
+                  aria-label="expanded"
+                  class="anticon anticon-right ant-collapse-arrow"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="right"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    style="transform: rotate(90deg);"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                class="ant-collapse-title semantic-mark-title"
+              >
+                This is panel header
+              </span>
+              <!---->
+            </div>
+            <transition-stub
+              appear="false"
+              css="true"
+              name="ant-motion-collapse"
+              persisted="false"
+            >
+              <div
+                class="ant-collapse-panel ant-collapse-panel-active"
+              >
+                <div
+                  class="ant-collapse-body semantic-mark-body"
+                >
+                  This is panel body
+                </div>
+              </div>
+            </transition-stub>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-col ant-col-8 css-var-root"
+      data-v-dfc8ebef=""
+    >
+      <ul
+        class="semantic-list"
+        data-v-dfc8ebef=""
+      >
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  root
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Root element with border, border-radius, background color and container styles that control the overall layout and appearance of collapse panels
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  header
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Header element with flex layout, padding, color, line-height, cursor style, transition animations and other interactive styles for panel headers
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  icon
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Icon element with font size, transition animations, rotation transforms and other styles and animations for expand/collapse arrows
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  title
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Title element with flex auto layout and margin styles for title text layout and typography
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  body
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Body element with padding, color, background color and other styles for panel content area display
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`collapse demo > renders accordion correctly 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+  role="tablist"
+>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="tab"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 1
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="tab"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 2
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="tab"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 3
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+</div>
+`;
+
+exports[`collapse demo > renders basic correctly 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+>
+  <div
+    class="ant-collapse-item ant-collapse-item-active"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="expanded"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="transform: rotate(90deg);"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 1
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <div
+        class="ant-collapse-panel ant-collapse-panel-active"
+      >
+        <div
+          class="ant-collapse-body"
+        >
+          <p>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+          </p>
+        </div>
+      </div>
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 2
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 3
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+</div>
+`;
+
+exports[`collapse demo > renders borderless correctly 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-position-start ant-collapse-borderless css-var-root"
+>
+  <div
+    class="ant-collapse-item ant-collapse-item-active"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="expanded"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="transform: rotate(90deg);"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 1
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <div
+        class="ant-collapse-panel ant-collapse-panel-active"
+      >
+        <div
+          class="ant-collapse-body"
+        >
+          <p
+            style="padding-inline-start: 24px;"
+          >
+            A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.
+          </p>
+        </div>
+      </div>
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 2
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 3
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+</div>
+`;
+
+exports[`collapse demo > renders collapsible correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-large ant-space-gap-col-large css-var-root"
+  style="width: 100%;"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-collapse ant-collapse-icon-position-start css-var-root"
+    >
+      <div
+        class="ant-collapse-item ant-collapse-item-active"
+        content="[object Object]"
+      >
+        <div
+          class="ant-collapse-header ant-collapse-collapsible-header"
+        >
+          <div
+            aria-disabled="false"
+            aria-expanded="true"
+            class="ant-collapse-expand-icon"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              aria-label="expanded"
+              class="anticon anticon-right ant-collapse-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                style="transform: rotate(90deg);"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                />
+              </svg>
+            </span>
+          </div>
+          <span
+            aria-disabled="false"
+            aria-expanded="true"
+            class="ant-collapse-title"
+            role="button"
+            tabindex="0"
+          >
+            This panel can be collapsed by clicking text or icon
+          </span>
+          <!---->
+        </div>
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-motion-collapse"
+          persisted="false"
+        >
+          <div
+            class="ant-collapse-panel ant-collapse-panel-active"
+          >
+            <div
+              class="ant-collapse-body"
+            >
+              <p>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+              </p>
+            </div>
+          </div>
+        </transition-stub>
+      </div>
+    </div>
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-collapse ant-collapse-icon-position-start css-var-root"
+    >
+      <div
+        class="ant-collapse-item ant-collapse-item-active"
+        content="[object Object]"
+      >
+        <div
+          class="ant-collapse-header ant-collapse-collapsible-icon"
+        >
+          <div
+            aria-disabled="false"
+            aria-expanded="true"
+            class="ant-collapse-expand-icon"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              aria-label="expanded"
+              class="anticon anticon-right ant-collapse-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                style="transform: rotate(90deg);"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                />
+              </svg>
+            </span>
+          </div>
+          <span
+            class="ant-collapse-title"
+          >
+            This panel can only be collapsed by clicking icon
+          </span>
+          <!---->
+        </div>
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-motion-collapse"
+          persisted="false"
+        >
+          <div
+            class="ant-collapse-panel ant-collapse-panel-active"
+          >
+            <div
+              class="ant-collapse-body"
+            >
+              <p>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+              </p>
+            </div>
+          </div>
+        </transition-stub>
+      </div>
+    </div>
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-collapse ant-collapse-icon-position-start css-var-root"
+    >
+      <div
+        class="ant-collapse-item ant-collapse-item-disabled"
+        content="[object Object]"
+      >
+        <div
+          aria-disabled="true"
+          aria-expanded="false"
+          class="ant-collapse-header ant-collapse-collapsible-disabled"
+          role="button"
+          tabindex="-1"
+        >
+          <div
+            class="ant-collapse-expand-icon"
+          >
+            <span
+              aria-label="collapsed"
+              class="anticon anticon-right ant-collapse-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                />
+              </svg>
+            </span>
+          </div>
+          <span
+            class="ant-collapse-title"
+          >
+            This panel can't be collapsed
+          </span>
+          <!---->
+        </div>
+        <transition-stub
+          appear="false"
+          css="true"
+          name="ant-motion-collapse"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+      </div>
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`collapse demo > renders custom correctly 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-position-start ant-collapse-borderless css-var-root"
+  style="background: rgb(255, 255, 255);"
+>
+  <div
+    class="ant-collapse-item ant-collapse-item-active"
+    content="[object Object]"
+    style="margin-bottom: 24px; border: medium;"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="caret-right"
+          class="anticon anticon-caret-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="caret-right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="transform: rotate(90deg);"
+            viewBox="0 0 1024 1024"
+            width="1em"
+          >
+            <path
+              d="M715.8 493.5L335 165.1c-14.2-12.2-35-1.2-35 18.5v656.8c0 19.7 20.8 30.7 35 18.5l380.8-328.4c10.9-9.4 10.9-27.6 0-37z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 1
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <div
+        class="ant-collapse-panel ant-collapse-panel-active"
+      >
+        <div
+          class="ant-collapse-body"
+        >
+          <p>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+          </p>
+        </div>
+      </div>
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+    style="margin-bottom: 24px; border: medium;"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="caret-right"
+          class="anticon anticon-caret-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="caret-right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 1024 1024"
+            width="1em"
+          >
+            <path
+              d="M715.8 493.5L335 165.1c-14.2-12.2-35-1.2-35 18.5v656.8c0 19.7 20.8 30.7 35 18.5l380.8-328.4c10.9-9.4 10.9-27.6 0-37z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 2
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+    style="margin-bottom: 24px; border: medium;"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="caret-right"
+          class="anticon anticon-caret-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="caret-right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 1024 1024"
+            width="1em"
+          >
+            <path
+              d="M715.8 493.5L335 165.1c-14.2-12.2-35-1.2-35 18.5v656.8c0 19.7 20.8 30.7 35 18.5l380.8-328.4c10.9-9.4 10.9-27.6 0-37z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 3
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+</div>
+`;
+
+exports[`collapse demo > renders extra correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-collapse ant-collapse-icon-position-start css-var-root"
+  >
+    <div
+      class="ant-collapse-item ant-collapse-item-active"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="true"
+        class="ant-collapse-header"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="expanded"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              style="transform: rotate(90deg);"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is panel header 1
+        </span>
+        <div
+          class="ant-collapse-extra"
+        >
+          <span
+            aria-label="setting"
+            class="anticon anticon-setting"
+            role="img"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="setting"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <div
+          class="ant-collapse-panel ant-collapse-panel-active"
+        >
+          <div
+            class="ant-collapse-body"
+          >
+            <div>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+            </div>
+          </div>
+        </div>
+      </transition-stub>
+    </div>
+    <div
+      class="ant-collapse-item"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="collapsed"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is panel header 2
+        </span>
+        <div
+          class="ant-collapse-extra"
+        >
+          <span
+            aria-label="setting"
+            class="anticon anticon-setting"
+            role="img"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="setting"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+    </div>
+    <div
+      class="ant-collapse-item"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="collapsed"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is panel header 3
+        </span>
+        <div
+          class="ant-collapse-extra"
+        >
+          <span
+            aria-label="setting"
+            class="anticon anticon-setting"
+            role="img"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="setting"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+    </div>
+  </div>
+  <br />
+  <span>
+    Expand Icon Placement: 
+  </span>
+  <!---->
+  <div
+    class="ant-select ant-select-outlined css-var-root ant-select-css-var ant-select-single ant-select-show-arrow"
+    style="margin: 0px 8px;"
+  >
+    <!---->
+    <div
+      class="ant-select-content ant-select-content-has-value"
+      title="start"
+    >
+      start
+      <input
+        aria-autocomplete="list"
+        aria-controls="test-id_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="test-id_list"
+        autocomplete="off"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="search"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+      <!---->
+    </div>
+    <!---->
+    <!---->
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`collapse demo > renders ghost correctly 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost css-var-root"
+>
+  <div
+    class="ant-collapse-item ant-collapse-item-active"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="expanded"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="transform: rotate(90deg);"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 1
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <div
+        class="ant-collapse-panel ant-collapse-panel-active"
+      >
+        <div
+          class="ant-collapse-body"
+        >
+          <p>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+          </p>
+        </div>
+      </div>
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 2
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 3
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+</div>
+`;
+
+exports[`collapse demo > renders mix correctly 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 1
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 2
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header 3
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+</div>
+`;
+
+exports[`collapse demo > renders noarrow correctly 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+>
+  <div
+    class="ant-collapse-item ant-collapse-item-active"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="expanded"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="transform: rotate(90deg);"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header with arrow icon
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <div
+        class="ant-collapse-panel ant-collapse-panel-active"
+      >
+        <div
+          class="ant-collapse-body"
+        >
+          <p>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+          </p>
+        </div>
+      </div>
+    </transition-stub>
+  </div>
+  <div
+    class="ant-collapse-item"
+    content="[object Object]"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <!---->
+      <span
+        class="ant-collapse-title"
+      >
+        This is panel header with no arrow icon
+      </span>
+      <!---->
+    </div>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-motion-collapse"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+  </div>
+</div>
+`;
+
+exports[`collapse demo > renders size correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-divider css-var-root ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+       Default Size 
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-collapse ant-collapse-icon-position-start css-var-root"
+  >
+    <div
+      class="ant-collapse-item"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="collapsed"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is default size panel header
+        </span>
+        <!---->
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+    </div>
+  </div>
+  <div
+    class="ant-divider css-var-root ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+       Small Size 
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-collapse ant-collapse-icon-position-start ant-collapse-small css-var-root"
+  >
+    <div
+      class="ant-collapse-item"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="collapsed"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is small size panel header
+        </span>
+        <!---->
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+    </div>
+  </div>
+  <div
+    class="ant-divider css-var-root ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+       Large Size 
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-collapse ant-collapse-icon-position-start ant-collapse-large css-var-root"
+  >
+    <div
+      class="ant-collapse-item"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="collapsed"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is large size panel header
+        </span>
+        <!---->
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`collapse demo > renders style-class correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-collapse ant-collapse-icon-position-start css-var-root demo-collapse-root"
+    style="background-color: rgb(250, 250, 250); border: 1px solid rgb(224, 224, 224); border-radius: 8px;"
+  >
+    <div
+      class="ant-collapse-item ant-collapse-item-active"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="true"
+        class="ant-collapse-header"
+        role="button"
+        style="background-color: rgb(240, 240, 240); padding: 12px 16px; color: rgb(20, 20, 20);"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="expanded"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              style="transform: rotate(90deg);"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is panel header 1
+        </span>
+        <!---->
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <div
+          class="ant-collapse-panel ant-collapse-panel-active"
+        >
+          <div
+            class="ant-collapse-body"
+          >
+            <p>
+              A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.
+            </p>
+          </div>
+        </div>
+      </transition-stub>
+    </div>
+    <div
+      class="ant-collapse-item"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        style="background-color: rgb(240, 240, 240); padding: 12px 16px; color: rgb(20, 20, 20);"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="collapsed"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is panel header 2
+        </span>
+        <!---->
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+    </div>
+    <div
+      class="ant-collapse-item"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        style="background-color: rgb(240, 240, 240); padding: 12px 16px; color: rgb(20, 20, 20);"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="collapsed"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is panel header 3
+        </span>
+        <!---->
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+    </div>
+  </div>
+  <div
+    class="ant-collapse ant-collapse-icon-position-start ant-collapse-large css-var-root demo-collapse-root"
+    style="background-color: rgb(255, 255, 255); border: 1px solid rgb(105, 111, 199); border-radius: 8px;"
+  >
+    <div
+      class="ant-collapse-item"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        style="background-color: rgb(245, 239, 255); padding: 12px 16px; color: rgb(20, 20, 20);"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="collapsed"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is panel header 1
+        </span>
+        <!---->
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+    </div>
+    <div
+      class="ant-collapse-item ant-collapse-item-active"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="true"
+        class="ant-collapse-header"
+        role="button"
+        style="background-color: rgb(245, 239, 255); padding: 12px 16px; color: rgb(20, 20, 20);"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="expanded"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              style="transform: rotate(90deg);"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is panel header 2
+        </span>
+        <!---->
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <div
+          class="ant-collapse-panel ant-collapse-panel-active"
+        >
+          <div
+            class="ant-collapse-body"
+          >
+            <p>
+              A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.
+            </p>
+          </div>
+        </div>
+      </transition-stub>
+    </div>
+    <div
+      class="ant-collapse-item"
+      content="[object Object]"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        style="background-color: rgb(245, 239, 255); padding: 12px 16px; color: rgb(20, 20, 20);"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="collapsed"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-title"
+        >
+          This is panel header 3
+        </span>
+        <!---->
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-motion-collapse"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/antdv-next/src/collapse/tests/demo.test.tsx
+++ b/packages/antdv-next/src/collapse/tests/demo.test.tsx
@@ -1,0 +1,3 @@
+import demoTest from '/@tests/shared/demoTest'
+
+demoTest('collapse')


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Test Case

### 🔗 Related Issues

ref #63

### 💡 Background and Solution

Add unit tests for the `Collapse` component following the project's test conventions.

**Test files:**
- `Collapse.test.tsx` — 44 tests covering:
  - Basic rendering (`ant-collapse` class, panel count)
  - `expandIconPlacement` (start/end)
  - `bordered`, `ghost`, `size` props
  - `defaultActiveKey` / `activeKey` control
  - Expand icon (aria-label, LTR/RTL rotation, custom prop & slot, `null` expandIcon)
  - `labelRender` / `contentRender` (prop and slot precedence)
  - `accordion` mode
  - `collapsible=disabled`
  - `showArrow=false` via items API
  - `change` emit
  - `rootClass`, attrs passthrough (`class`, `style`, `data-*`)
  - Semantic `classes` / `styles` (root)
  - ConfigProvider `componentSize` inheritance and override
  - RTL direction class
  - Dynamic `items` prop update
  - Snapshot

- `Collapse.semantic.test.tsx` — 7 tests for `classes` and `styles` as both static object and function forms (root, header, title, icon, body)

- `demo.test.tsx` — snapshot tests for all 12 collapse demos

**Note:** `ant-collapse-no-arrow` class (from `CollapsePanel.tsx`) is intentionally not tested. The `items` API renders `@v-c/collapse`'s Panel directly, bypassing the antdv-next `CollapsePanel` wrapper, so the class never appears in the DOM.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | test(collapse): add unit tests (51 tests across 3 files) |
| 🇨🇳 Chinese | test(collapse): 新增单元测试（3 个测试文件，共 51 个测试） |