### PR TITLE
fix(skeleton): Synchronise the DOM element styles of the skeleton.but…

### DIFF
--- a/packages/antdv-next/src/skeleton/Button.tsx
+++ b/packages/antdv-next/src/skeleton/Button.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'vue'
 import type { SkeletonElementProps } from './Element'
 import { classNames } from '@v-c/util'
 import { omit } from 'es-toolkit'
@@ -20,7 +21,7 @@ const SkeletonButton = defineComponent<SkeletonButtonProps>(
     const [hashId, cssVarCls] = useStyle(prefixCls)
 
     return () => {
-      const { active, rootClass, block, size } = props
+      const { active, rootClass, block, size, shape, classes, styles } = props
       const cls = classNames(
         prefixCls.value,
         `${prefixCls.value}-element`,
@@ -33,13 +34,14 @@ const SkeletonButton = defineComponent<SkeletonButtonProps>(
         hashId.value,
         cssVarCls.value,
       )
-      const otherProps = omit(props, ['prefixCls'])
       return (
-        <div class={cls} {...omit(attrs, ['class'])}>
+        <div class={cls} style={styles?.root} {...omit(attrs as any, ['class', 'style'])}>
           <Element
             prefixCls={`${prefixCls.value}-button`}
             size={size}
-            {...otherProps}
+            shape={shape}
+            class={classes?.content}
+            style={{ ...(styles?.content as CSSProperties), ...(attrs.style as CSSProperties) }}
           />
         </div>
       )

--- a/packages/antdv-next/src/skeleton/Element.tsx
+++ b/packages/antdv-next/src/skeleton/Element.tsx
@@ -1,17 +1,32 @@
+import type { CSSProperties } from 'vue'
 import type { ComponentBaseProps } from '../config-provider/context.ts'
 import { classNames } from '@v-c/util'
 import { defineComponent } from 'vue'
+import { getAttrStyleAndClass } from '../_util/hooks/useMergeSemantic'
+
+export interface ElementSemanticClassNames {
+  root?: string
+  content?: string
+}
+
+export interface ElementSemanticStyles {
+  root?: CSSProperties
+  content?: CSSProperties
+}
 
 export interface SkeletonElementProps extends ComponentBaseProps {
   size?: 'large' | 'small' | 'default' | number
   shape?: 'circle' | 'square' | 'round' | 'default'
   active?: boolean
+  classes?: ElementSemanticClassNames
+  styles?: ElementSemanticStyles
 }
 
 const Element = defineComponent<SkeletonElementProps>(
-  (props) => {
+  (props, { attrs }) => {
     return () => {
       const { prefixCls, size, shape } = props
+      const { className, style } = getAttrStyleAndClass(attrs)
       const sizeCls = classNames({
         [`${prefixCls}-lg`]: size === 'large',
         [`${prefixCls}-sm`]: size === 'small',
@@ -31,12 +46,13 @@ const Element = defineComponent<SkeletonElementProps>(
         : {}
       return (
         <span
-          class={classNames(prefixCls, sizeCls, shapeCls)}
-          style={[sizeStyle]}
+          class={classNames(prefixCls, sizeCls, shapeCls, className)}
+          style={[sizeStyle, style]}
         />
       )
     }
   },
+  { inheritAttrs: false },
 )
 
 export default Element

--- a/packages/antdv-next/src/skeleton/tests/Button.test.tsx
+++ b/packages/antdv-next/src/skeleton/tests/Button.test.tsx
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+import { SkeletonButton } from '..'
+import mountTest from '/@tests/shared/mountTest'
+import rtlTest from '/@tests/shared/rtlTest'
+import { mount } from '/@tests/utils'
+
+describe('skeleton.button', () => {
+  mountTest(SkeletonButton)
+  rtlTest(() => h(SkeletonButton))
+
+  // ==================== Basic Rendering ====================
+
+  it('should render skeleton button by default', () => {
+    const wrapper = mount(SkeletonButton)
+    expect(wrapper.find('.ant-skeleton').exists()).toBe(true)
+    expect(wrapper.find('.ant-skeleton-element').exists()).toBe(true)
+    expect(wrapper.find('.ant-skeleton-button').exists()).toBe(true)
+  })
+
+  // ==================== active ====================
+
+  it('should render active class when active=true', () => {
+    const wrapper = mount(SkeletonButton, { props: { active: true } })
+    expect(wrapper.find('.ant-skeleton-active').exists()).toBe(true)
+  })
+
+  it('should not render active class by default', () => {
+    const wrapper = mount(SkeletonButton)
+    expect(wrapper.find('.ant-skeleton-active').exists()).toBe(false)
+  })
+
+  // ==================== block ====================
+
+  it('should render block class when block=true', () => {
+    const wrapper = mount(SkeletonButton, { props: { block: true } })
+    expect(wrapper.find('.ant-skeleton-block').exists()).toBe(true)
+  })
+
+  it('should not render block class by default', () => {
+    const wrapper = mount(SkeletonButton)
+    expect(wrapper.find('.ant-skeleton-block').exists()).toBe(false)
+  })
+
+  // ==================== size ====================
+
+  describe('size', () => {
+    it('should render large size class when size=large', () => {
+      const wrapper = mount(SkeletonButton, { props: { size: 'large' } })
+      expect(wrapper.find('.ant-skeleton-button-lg').exists()).toBe(true)
+    })
+
+    it('should render small size class when size=small', () => {
+      const wrapper = mount(SkeletonButton, { props: { size: 'small' } })
+      expect(wrapper.find('.ant-skeleton-button-sm').exists()).toBe(true)
+    })
+
+    it('should not render size class when size=default', () => {
+      const wrapper = mount(SkeletonButton, { props: { size: 'default' } })
+      expect(wrapper.find('.ant-skeleton-button-lg').exists()).toBe(false)
+      expect(wrapper.find('.ant-skeleton-button-sm').exists()).toBe(false)
+    })
+  })
+
+  // ==================== shape ====================
+
+  describe('shape', () => {
+    it('should render circle shape class when shape=circle', () => {
+      const wrapper = mount(SkeletonButton, { props: { shape: 'circle' } })
+      expect(wrapper.find('.ant-skeleton-button-circle').exists()).toBe(true)
+    })
+
+    it('should render square shape class when shape=square', () => {
+      const wrapper = mount(SkeletonButton, { props: { shape: 'square' } })
+      expect(wrapper.find('.ant-skeleton-button-square').exists()).toBe(true)
+    })
+
+    it('should render round shape class when shape=round', () => {
+      const wrapper = mount(SkeletonButton, { props: { shape: 'round' } })
+      expect(wrapper.find('.ant-skeleton-button-round').exists()).toBe(true)
+    })
+
+    it('should not render any shape class when shape=default', () => {
+      const wrapper = mount(SkeletonButton, { props: { shape: 'default' } })
+      const btn = wrapper.find('.ant-skeleton-button')
+      expect(btn.classes()).not.toContain('ant-skeleton-button-circle')
+      expect(btn.classes()).not.toContain('ant-skeleton-button-square')
+      expect(btn.classes()).not.toContain('ant-skeleton-button-round')
+    })
+  })
+
+  // ==================== rootClass ====================
+
+  it('should apply rootClass to root element', () => {
+    const wrapper = mount(SkeletonButton, { props: { rootClass: 'my-root' } })
+    expect(wrapper.find('.ant-skeleton').classes()).toContain('my-root')
+  })
+
+  // ==================== classes ====================
+
+  it('should apply classes.content to inner button element', () => {
+    const wrapper = mount(SkeletonButton, {
+      props: { classes: { content: 'my-content' } },
+    })
+    expect(wrapper.find('.ant-skeleton-button').classes()).toContain('my-content')
+  })
+
+  // ==================== styles ====================
+
+  it('should apply styles.root to root element', () => {
+    const wrapper = mount(SkeletonButton, {
+      props: { styles: { root: { padding: '10px' } } },
+    })
+    expect(wrapper.find('.ant-skeleton').attributes('style')).toContain('padding: 10px')
+  })
+
+  it('should apply styles.content to inner button element', () => {
+    const wrapper = mount(SkeletonButton, {
+      props: { styles: { content: { color: 'red' } } },
+    })
+    const style = wrapper.find('.ant-skeleton-button').attributes('style')
+    expect(style).toContain('color: red')
+  })
+
+  // ==================== attrs passthrough ====================
+
+  it('should pass attrs.class to root element', () => {
+    const wrapper = mount(SkeletonButton, {
+      attrs: { class: 'extra-class' },
+    })
+    expect(wrapper.find('.ant-skeleton').classes()).toContain('extra-class')
+  })
+
+  it('should pass attrs.style to inner button element', () => {
+    const wrapper = mount(SkeletonButton, {
+      attrs: { style: { border: '1px solid red' } },
+    })
+    const style = wrapper.find('.ant-skeleton-button').attributes('style')
+    expect(style).toContain('border: 1px solid red')
+  })
+
+  it('should pass extra attrs to root element', () => {
+    const wrapper = mount(SkeletonButton, {
+      attrs: { 'data-testid': 'skeleton-btn' },
+    })
+    expect(wrapper.find('.ant-skeleton').attributes('data-testid')).toBe('skeleton-btn')
+  })
+})


### PR DESCRIPTION
## 📝 Description
修复 Vue 版本 SkeletonButton 与 React 版本的 DOM 接口不一致问题

## 🔄 Changes Made
- [x] 添加 `classNames` 和 `styles` 属性支持
- [x] 修复 `style` 属性未传递给 Element 的问题
- [x] 更新单元测试

## ✅ Checklist
- [x] 代码通过 ESLint 检查
- [x] 单元测试全部通过
- [x] 添加/更新了相关测试用

## 🧪 Testing Steps
1. 运行 `npm test -- SkeletonButton`
2. 检查控制台无警告
3. 验证样式正确应用