### PR TITLE
fix(tree): relax treeData type to accept custom data nodes

### DIFF
--- a/packages/antdv-next/src/tree/DirectoryTree.tsx
+++ b/packages/antdv-next/src/tree/DirectoryTree.tsx
@@ -41,7 +41,7 @@ function getTreeData({ treeData, children }: DirectoryTreeProps & { children: an
 }
 
 const DirectoryTree = defineComponent<
-  DirectoryTreeProps,
+  DirectoryTreeProps<BasicDataNode>,
   DirectoryTreeEmits,
   string,
   SlotsType<DirectoryTreeSlots>

--- a/packages/antdv-next/src/tree/Tree.tsx
+++ b/packages/antdv-next/src/tree/Tree.tsx
@@ -269,7 +269,7 @@ const defaults = {
 } as any
 
 const Tree = defineComponent<
-  TreeProps,
+  TreeProps<BasicDataNode>,
   TreeEmits,
   string,
   SlotsType<TreeSlots>

--- a/packages/antdv-next/src/tree/tests/type.test.tsx
+++ b/packages/antdv-next/src/tree/tests/type.test.tsx
@@ -44,7 +44,6 @@ describe('tree.TypeScript', () => {
       ],
     }
 
-    // @ts-expect-error: Tree not support generic
     const wrapper = mount(Tree, { props })
     expect(wrapper.exists()).toBeTruthy()
   })
@@ -68,7 +67,6 @@ describe('tree.TypeScript', () => {
       ],
     }
 
-    // @ts-expect-error: Tree not support generic
     const wrapper = mount(DirectoryTree, { props })
     expect(wrapper.exists()).toBeTruthy()
   })


### PR DESCRIPTION
## Summary

Fixes #251

- Change `Tree` and `DirectoryTree` `defineComponent` generic from `DataNode` to `BasicDataNode`, so that `treeData` accepts custom node types without requiring a `key` field when using `fieldNames`
- Remove `@ts-expect-error` in type tests since generic types now pass correctly

### Before
```vue
<!-- TS error: Property 'key' is missing -->
<Tree :tree-data="customData" :field-names="{ key: 'id' }" />
```

### After
```vue
<!-- No error, BasicDataNode accepts any fields -->
<Tree :tree-data="customData" :field-names="{ key: 'id' }" />
```

### Changed files
| File | Change |
|------|--------|
| `src/tree/Tree.tsx` | `TreeProps` → `TreeProps<BasicDataNode>` |
| `src/tree/DirectoryTree.tsx` | `DirectoryTreeProps` → `DirectoryTreeProps<BasicDataNode>` |
| `src/tree/tests/type.test.tsx` | Remove 2 `@ts-expect-error` comments |

## Test plan
- [x] All existing Tree tests pass (type, unit, directory, demo, semantic, util, dropIndicator)
- [x] `type.test.tsx` generic tests now pass without `@ts-expect-error`