### PR TITLE
test(mentions): add unit tests for Mentions component

### DIFF
--- a/packages/antdv-next/src/mentions/tests/Mentions.semantic.test.tsx
+++ b/packages/antdv-next/src/mentions/tests/Mentions.semantic.test.tsx
@@ -1,0 +1,131 @@
+import type { MentionsProps } from '..'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Mentions from '..'
+import ConfigProvider from '../../config-provider'
+import { mount } from '/@tests/utils'
+
+const defaultOptions: MentionsProps['options'] = [
+  { value: 'afc163', label: 'afc163' },
+  { value: 'zombieJ', label: 'zombieJ' },
+]
+
+describe('mentions.Semantic', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('supports static object classes on root', () => {
+    mount(Mentions, {
+      attachTo: document.body,
+      props: {
+        options: defaultOptions,
+        classes: { root: 'custom-root' },
+      },
+    })
+    const root = document.querySelector('.ant-mentions')
+    expect(root?.classList.contains('custom-root')).toBe(true)
+  })
+
+  it('supports static object styles on root', () => {
+    mount(Mentions, {
+      attachTo: document.body,
+      props: {
+        options: defaultOptions,
+        styles: { root: { backgroundColor: 'red' } },
+      },
+    })
+    const root = document.querySelector<HTMLElement>('.ant-mentions')
+    expect(root?.style.backgroundColor).toBe('red')
+  })
+
+  it('supports function-based classes', () => {
+    const classes: MentionsProps['classes'] = (info) => {
+      if (info.props.disabled) {
+        return { root: 'disabled-root' }
+      }
+      return { root: 'enabled-root' }
+    }
+
+    mount(Mentions, {
+      attachTo: document.body,
+      props: {
+        options: defaultOptions,
+        disabled: false,
+        classes,
+      },
+    })
+    const root = document.querySelector('.ant-mentions')
+    expect(root?.classList.contains('enabled-root')).toBe(true)
+  })
+
+  it('supports function-based styles', () => {
+    const styles: MentionsProps['styles'] = (info) => {
+      if (info.props.loading) {
+        return { root: { opacity: '0.5' } }
+      }
+      return { root: { opacity: '1' } }
+    }
+
+    mount(Mentions, {
+      attachTo: document.body,
+      props: {
+        options: defaultOptions,
+        loading: false,
+        styles,
+      },
+    })
+    const root = document.querySelector<HTMLElement>('.ant-mentions')
+    expect(root?.style.opacity).toBe('1')
+  })
+
+  it('configProvider classes merge with component classes', () => {
+    mount({
+      render() {
+        return (
+          <ConfigProvider
+            mentions={{
+              classes: { root: 'cp-root' },
+            }}
+          >
+            <Mentions
+              options={defaultOptions}
+              classes={{ root: 'comp-root' }}
+            />
+          </ConfigProvider>
+        )
+      },
+    }, { attachTo: document.body })
+
+    const root = document.querySelector('.ant-mentions')
+    expect(root?.classList.contains('cp-root')).toBe(true)
+    expect(root?.classList.contains('comp-root')).toBe(true)
+  })
+
+  it('configProvider styles merge with component styles', () => {
+    mount({
+      render() {
+        return (
+          <ConfigProvider
+            mentions={{
+              styles: { root: { margin: '1px' } },
+            }}
+          >
+            <Mentions
+              options={defaultOptions}
+              styles={{ root: { padding: '2px' } }}
+            />
+          </ConfigProvider>
+        )
+      },
+    }, { attachTo: document.body })
+
+    const root = document.querySelector<HTMLElement>('.ant-mentions')
+    expect(root?.style.padding).toBe('2px')
+  })
+})

--- a/packages/antdv-next/src/mentions/tests/Mentions.test.tsx
+++ b/packages/antdv-next/src/mentions/tests/Mentions.test.tsx
@@ -1,0 +1,606 @@
+import type { MentionsProps } from '..'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { h, ref } from 'vue'
+import Mentions from '..'
+import ConfigProvider from '../../config-provider'
+import { useFormItemInputContextProvider } from '../../form/context'
+import mountTest from '/@tests/shared/mountTest'
+import rtlTest from '/@tests/shared/rtlTest'
+import { mount, waitFakeTimer } from '/@tests/utils'
+
+const defaultOptions: MentionsProps['options'] = [
+  { value: 'afc163', label: 'afc163' },
+  { value: 'zombieJ', label: 'zombieJ' },
+  { value: 'yesmeck', label: 'yesmeck' },
+]
+
+async function flushMentionsTimer() {
+  await waitFakeTimer(150, 10)
+}
+
+describe('mentions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  mountTest(Mentions)
+  rtlTest(() => h(Mentions))
+
+  // === Basic Rendering ===
+
+  it('renders correctly with textarea', () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions },
+    })
+    expect(wrapper.find('textarea').exists()).toBe(true)
+    expect(document.querySelector('.ant-mentions')).toBeTruthy()
+  })
+
+  // === Size ===
+
+  describe('size', () => {
+    it('renders small size', () => {
+      mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions, size: 'small' },
+      })
+      const root = document.querySelector('.ant-mentions')
+      expect(root?.className).toContain('ant-mentions-sm')
+    })
+
+    it('renders large size', () => {
+      mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions, size: 'large' },
+      })
+      const root = document.querySelector('.ant-mentions')
+      expect(root?.className).toContain('ant-mentions-lg')
+    })
+
+    it('renders default size without sm/lg class', () => {
+      mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions },
+      })
+      const root = document.querySelector('.ant-mentions')
+      expect(root?.className).not.toContain('ant-mentions-sm')
+      expect(root?.className).not.toContain('ant-mentions-lg')
+    })
+  })
+
+  // === Variant ===
+
+  describe('variant', () => {
+    it('renders outlined variant by default', () => {
+      mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions },
+      })
+      expect(document.querySelector('.ant-mentions-outlined')).toBeTruthy()
+    })
+
+    it.each(['filled', 'borderless', 'underlined'] as const)(
+      'renders %s variant',
+      (variant) => {
+        mount(Mentions, {
+          attachTo: document.body,
+          props: { options: defaultOptions, variant },
+        })
+        expect(document.querySelector(`.ant-mentions-${variant}`)).toBeTruthy()
+      },
+    )
+  })
+
+  // === Status ===
+
+  describe('status', () => {
+    it.each(['error', 'warning'] as const)(
+      'renders %s status',
+      (status) => {
+        mount(Mentions, {
+          attachTo: document.body,
+          props: { options: defaultOptions, status },
+        })
+        expect(document.querySelector(`.ant-mentions-status-${status}`)).toBeTruthy()
+      },
+    )
+  })
+
+  // === Disabled ===
+
+  describe('disabled', () => {
+    it('renders disabled state', () => {
+      mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions, disabled: true },
+      })
+      expect(document.querySelector('.ant-mentions-disabled')).toBeTruthy()
+      expect(document.querySelector('textarea')?.disabled).toBe(true)
+    })
+
+    it('inherits disabled from DisabledContext', () => {
+      mount({
+        render() {
+          return (
+            <ConfigProvider componentDisabled={true}>
+              <Mentions options={defaultOptions} />
+            </ConfigProvider>
+          )
+        },
+      }, { attachTo: document.body })
+      expect(document.querySelector('textarea')?.disabled).toBe(true)
+    })
+  })
+
+  // === Focus / Blur ===
+
+  describe('focus and blur', () => {
+    it('emits focus event', async () => {
+      const wrapper = mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions },
+      })
+      await wrapper.find('textarea').trigger('focus')
+      await flushMentionsTimer()
+      expect(wrapper.emitted('focus')).toBeTruthy()
+    })
+
+    it('emits blur event', async () => {
+      const wrapper = mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions },
+      })
+      await wrapper.find('textarea').trigger('focus')
+      await flushMentionsTimer()
+      await wrapper.find('textarea').trigger('blur')
+      // VcMentions delays blur with setTimeout(0)
+      await flushMentionsTimer()
+      expect(wrapper.emitted('blur')).toBeTruthy()
+    })
+
+    it('toggles focused class on focus/blur', async () => {
+      mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions },
+      })
+      const textarea = document.querySelector('textarea')!
+      textarea.dispatchEvent(new FocusEvent('focus'))
+      await flushMentionsTimer()
+      expect(document.querySelector('.ant-mentions-focused')).toBeTruthy()
+
+      textarea.dispatchEvent(new FocusEvent('blur'))
+      await flushMentionsTimer()
+      expect(document.querySelector('.ant-mentions-focused')).toBeFalsy()
+    })
+  })
+
+  // === Change ===
+
+  it('emits change and update:value on input', async () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions },
+    })
+    const textarea = wrapper.find('textarea')
+    await textarea.setValue('hello')
+    await flushMentionsTimer()
+
+    const changeEvents = wrapper.emitted('change')
+    const updateEvents = wrapper.emitted('update:value')
+    expect(changeEvents).toBeDefined()
+    expect(updateEvents).toBeDefined()
+    expect(changeEvents?.[0]?.[0]).toBe('hello')
+    expect(updateEvents?.[0]?.[0]).toBe('hello')
+  })
+
+  // === getMentions static method ===
+
+  describe('getMentions', () => {
+    it('parses mentions with default prefix @', () => {
+      const mentions = Mentions.getMentions('@light @test')
+      expect(mentions).toEqual([
+        { prefix: '@', value: 'light' },
+        { prefix: '@', value: 'test' },
+      ])
+    })
+
+    it('parses mentions with multiple prefixes', () => {
+      const mentions = Mentions.getMentions('@light #bamboo cat', {
+        prefix: ['@', '#'],
+      })
+      expect(mentions).toEqual([
+        { prefix: '@', value: 'light' },
+        { prefix: '#', value: 'bamboo' },
+      ])
+    })
+
+    it('parses mentions with custom split', () => {
+      const mentions = Mentions.getMentions('@light,@test', { split: ',' })
+      expect(mentions).toEqual([
+        { prefix: '@', value: 'light' },
+        { prefix: '@', value: 'test' },
+      ])
+    })
+
+    it('returns empty array for no mentions', () => {
+      const mentions = Mentions.getMentions('hello world')
+      expect(mentions).toEqual([])
+    })
+
+    it('filters out empty values', () => {
+      const mentions = Mentions.getMentions('@ @test')
+      expect(mentions).toEqual([
+        { prefix: '@', value: 'test' },
+      ])
+    })
+
+    it('handles empty string', () => {
+      const mentions = Mentions.getMentions('')
+      expect(mentions).toEqual([])
+    })
+  })
+
+  // === AllowClear ===
+
+  describe('allowClear', () => {
+    it('shows clear button when allowClear and has value', async () => {
+      mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions, allowClear: true, value: 'test' },
+      })
+      await flushMentionsTimer()
+      expect(document.querySelector('.ant-mentions-clear-icon')).toBeTruthy()
+    })
+
+    it('does not show clear button when allowClear is false', () => {
+      mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions, value: 'test' },
+      })
+      expect(document.querySelector('.ant-mentions-clear-icon')).toBeFalsy()
+    })
+
+    it('clears value on clear click', async () => {
+      const wrapper = mount(Mentions, {
+        attachTo: document.body,
+        props: { options: defaultOptions, allowClear: true, value: 'test' },
+      })
+      await flushMentionsTimer()
+      const clearIcon = document.querySelector('.ant-mentions-clear-icon')
+      expect(clearIcon).toBeTruthy()
+      clearIcon!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await flushMentionsTimer()
+
+      const changeEvents = wrapper.emitted('change')
+      expect(changeEvents).toBeDefined()
+      const lastEvent = changeEvents?.[changeEvents.length - 1]
+      expect(lastEvent?.[0]).toBe('')
+    })
+
+    it('supports custom clearIcon', async () => {
+      mount(Mentions, {
+        attachTo: document.body,
+        props: {
+          options: defaultOptions,
+          allowClear: { clearIcon: <span class="custom-clear">X</span> },
+          value: 'test',
+        },
+      })
+      await flushMentionsTimer()
+      expect(document.querySelector('.custom-clear')).toBeTruthy()
+    })
+  })
+
+  // === Loading ===
+
+  it('renders without error when loading', () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions, loading: true },
+    })
+    expect(wrapper.find('textarea').exists()).toBe(true)
+  })
+
+  // === NotFoundContent ===
+
+  it('accepts custom notFoundContent', () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: {
+        options: defaultOptions,
+        notFoundContent: 'No data found',
+      },
+    })
+    expect(wrapper.find('textarea').exists()).toBe(true)
+  })
+
+  // === Options without label (value fallback) ===
+
+  it('falls back to option.value when label is not provided', () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: {
+        options: [
+          { value: 'no-label-option' },
+        ],
+      },
+    })
+    expect(wrapper.find('textarea').exists()).toBe(true)
+  })
+
+  // === Form hasFeedback ===
+
+  it('appends feedbackIcon to suffix when hasFeedback is true', () => {
+    mount({
+      setup() {
+        useFormItemInputContextProvider(ref({
+          hasFeedback: true,
+          feedbackIcon: <span class="feedback-icon">✓</span>,
+          status: 'success',
+        }))
+        return () => <Mentions options={defaultOptions} />
+      },
+    }, { attachTo: document.body })
+    expect(document.querySelector('.feedback-icon')).toBeTruthy()
+  })
+
+  it('does not append feedbackIcon when hasFeedback is false', () => {
+    mount({
+      setup() {
+        useFormItemInputContextProvider(ref({
+          hasFeedback: false,
+          feedbackIcon: <span class="no-feedback-icon">✗</span>,
+        }))
+        return () => <Mentions options={defaultOptions} />
+      },
+    }, { attachTo: document.body })
+    expect(document.querySelector('.no-feedback-icon')).toBeFalsy()
+  })
+
+  // === Suffix Slot ===
+
+  it('renders suffix slot content', () => {
+    mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions },
+      slots: {
+        suffix: () => <span class="custom-suffix">suffix</span>,
+      },
+    })
+    expect(document.querySelector('.custom-suffix')).toBeTruthy()
+  })
+
+  // === rootClass ===
+
+  it('applies rootClass to root element', () => {
+    mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions, rootClass: 'my-mentions' },
+    })
+    const root = document.querySelector('.ant-mentions')
+    expect(root?.className).toContain('my-mentions')
+  })
+
+  // === RTL ===
+
+  it('renders RTL direction', () => {
+    mount({
+      render() {
+        return (
+          <ConfigProvider direction="rtl">
+            <Mentions options={defaultOptions} />
+          </ConfigProvider>
+        )
+      },
+    }, { attachTo: document.body })
+    expect(document.querySelector('.ant-mentions-rtl')).toBeTruthy()
+  })
+
+  // === ConfigProvider ===
+
+  describe('configProvider', () => {
+    it('uses custom prefixCls', () => {
+      mount({
+        render() {
+          return (
+            <ConfigProvider prefixCls="custom">
+              <Mentions options={defaultOptions} />
+            </ConfigProvider>
+          )
+        },
+      }, { attachTo: document.body })
+      expect(document.querySelector('.custom-mentions')).toBeTruthy()
+    })
+
+    it('uses ConfigProvider size', () => {
+      mount({
+        render() {
+          return (
+            <ConfigProvider componentSize="small">
+              <Mentions options={defaultOptions} />
+            </ConfigProvider>
+          )
+        },
+      }, { attachTo: document.body })
+      const allElements = document.querySelectorAll('[class*="ant-mentions"]')
+      const hasSmClass = Array.from(allElements).some(el => el.className.includes('ant-mentions-sm'))
+      expect(hasSmClass).toBe(true)
+    })
+  })
+
+  // === Expose ===
+
+  it('exposes focus and blur methods', () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions },
+    })
+    const vm = wrapper.vm as any
+    expect(typeof vm.focus).toBe('function')
+    expect(typeof vm.blur).toBe('function')
+  })
+
+  // === Placeholder ===
+
+  it('renders placeholder on textarea', () => {
+    mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions, placeholder: 'Type @ to mention' },
+    })
+    expect(document.querySelector('textarea')?.getAttribute('placeholder')).toBe('Type @ to mention')
+  })
+
+  // === ReadOnly ===
+
+  it('renders readonly textarea', () => {
+    mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions, readOnly: true },
+    })
+    expect(document.querySelector('textarea')?.readOnly).toBe(true)
+  })
+
+  // === Option export ===
+
+  it('exports Option component', () => {
+    expect(Mentions.Option).toBeTruthy()
+  })
+
+  // === install ===
+
+  it('has install method', () => {
+    expect(typeof Mentions.install).toBe('function')
+  })
+
+  // === Slot children (Mentions.Option) ===
+
+  it('renders with slot children (deprecated Mentions.Option pattern)', () => {
+    const { Option } = Mentions
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      slots: {
+        default: () => [
+          <Option value="afc163">afc163</Option>,
+          <Option value="zombieJ">zombieJ</Option>,
+        ],
+      },
+    })
+    expect(wrapper.find('textarea').exists()).toBe(true)
+  })
+
+  // === labelRender ===
+
+  it('supports labelRender prop', () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: {
+        options: defaultOptions,
+        labelRender: ({ option }: { option: any }) => <span>{option.value.toUpperCase()}</span>,
+      },
+    })
+    expect(wrapper.find('textarea').exists()).toBe(true)
+  })
+
+  it('supports labelRender slot', () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions },
+      slots: {
+        labelRender: ({ option }: any) => <span>{option.value.toUpperCase()}</span>,
+      },
+    })
+    expect(wrapper.find('textarea').exists()).toBe(true)
+  })
+
+  // === PurePanel ===
+
+  it('renders PurePanel', () => {
+    const PurePanel = (Mentions as any)._InternalPanelDoNotUseOrYouWillBeFired
+    expect(PurePanel).toBeTruthy()
+    const wrapper = mount(PurePanel, { attachTo: document.body })
+    expect(wrapper.element).toBeTruthy()
+  })
+
+  // === Attrs passthrough ===
+
+  it('passes data attributes through', () => {
+    mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions },
+      attrs: {
+        'data-testid': 'mentions-input',
+      },
+    })
+    expect(document.querySelector('[data-testid="mentions-input"]')).toBeTruthy()
+  })
+
+  // === Dynamic props update ===
+
+  it('updates size dynamically', async () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions, size: 'small' },
+    })
+    expect(document.querySelector('.ant-mentions')?.className).toContain('ant-mentions-sm')
+
+    await wrapper.setProps({ size: 'large' })
+    expect(document.querySelector('.ant-mentions')?.className).not.toContain('ant-mentions-sm')
+    expect(document.querySelector('.ant-mentions')?.className).toContain('ant-mentions-lg')
+  })
+
+  it('updates disabled dynamically', async () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions, disabled: false },
+    })
+    expect(document.querySelector('textarea')?.disabled).toBe(false)
+
+    await wrapper.setProps({ disabled: true })
+    expect(document.querySelector('textarea')?.disabled).toBe(true)
+    expect(document.querySelector('.ant-mentions-disabled')).toBeTruthy()
+  })
+
+  it('updates variant dynamically', async () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions, variant: 'outlined' },
+    })
+    expect(document.querySelector('.ant-mentions-outlined')).toBeTruthy()
+
+    await wrapper.setProps({ variant: 'filled' })
+    expect(document.querySelector('.ant-mentions-outlined')).toBeFalsy()
+    expect(document.querySelector('.ant-mentions-filled')).toBeTruthy()
+  })
+
+  // === Snapshot ===
+
+  it('matches snapshot', () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: { options: defaultOptions },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('matches snapshot with features', () => {
+    const wrapper = mount(Mentions, {
+      attachTo: document.body,
+      props: {
+        options: defaultOptions,
+        size: 'large',
+        allowClear: true,
+        value: 'hello',
+        rootClass: 'snap-root',
+        status: 'error',
+      },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/packages/antdv-next/src/mentions/tests/__snapshots__/Mentions.test.tsx.snap
+++ b/packages/antdv-next/src/mentions/tests/__snapshots__/Mentions.test.tsx.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`mentions > matches snapshot 1`] = `
+"<div class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"><textarea rows="1" class="vc-textarea" value=""></textarea>
+  <!---->
+</div>"
+`;
+
+exports[`mentions > matches snapshot with features 1`] = `
+"<span class="ant-mentions-affix-wrapper ant-mentions-outlined ant-mentions-status-error ant-mentions ant-mentions-lg snap-root css-var-root ant-mentions-css-var ant-mentions-has-suffix"><!----><textarea rows="1" class="vc-textarea" value="hello"></textarea><!----><span class="ant-mentions-suffix"><button type="button" tabindex="-1" class="ant-mentions-clear-icon"><span role="img" aria-label="close-circle" class="anticon anticon-close-circle"><svg data-icon="close-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" fill-rule="evenodd" viewBox="64 64 896 896" focusable="false"><path d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"></path></svg></span></button>
+<!----></span></span>"
+`;
+
+exports[`mentions > rtl render > component should be rendered correctly in RTL direction 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-mentions ant-mentions-rtl css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+</div>
+`;

--- a/packages/antdv-next/src/mentions/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/mentions/tests/__snapshots__/demo.test.tsx.snap
@@ -1,0 +1,1275 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`mentions demo > renders _semantic correctly 1`] = `
+<div
+  class="semantic-preview-container"
+  data-v-dfc8ebef=""
+>
+  <div
+    class="ant-row css-var-root semantic-preview-row"
+    data-v-dfc8ebef=""
+  >
+    <div
+      class="ant-col ant-col-16 css-var-root semantic-preview-col"
+      data-v-dfc8ebef=""
+    >
+      <div
+        style="position: absolute; height: 200px;"
+      >
+        <span
+          class="ant-mentions-affix-wrapper ant-mentions-outlined ant-mentions semantic-mark-root css-var-v-0 ant-mentions-css-var ant-mentions-has-suffix"
+          style="width: 100%;"
+        >
+          <!---->
+          <textarea
+            class="vc-textarea semantic-mark-textarea"
+            open=""
+            rows="1"
+            value="Hi, @"
+          />
+          <!---->
+          <span
+            class="ant-mentions-suffix semantic-mark-suffix"
+          >
+            <button
+              class="ant-mentions-clear-icon"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                aria-label="close-circle"
+                class="anticon anticon-close-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close-circle"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <!---->
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="ant-col ant-col-8 css-var-root"
+      data-v-dfc8ebef=""
+    >
+      <ul
+        class="semantic-list"
+        data-v-dfc8ebef=""
+      >
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  root
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Root element, set inline flex layout, relative positioning, padding and border styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  textarea
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Textarea element, set font, line height, text input and background styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  suffix
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Suffix element with layout and styling for suffix content like clear button, etc.
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-root"
+                  data-v-dfc8ebef=""
+                >
+                  1.0.0
+                  <!---->
+                  <!---->
+                  <!---->
+                </span>
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Popup element, set absolute positioning, z-index, background color, border radius, shadow and dropdown options styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`mentions demo > renders allow-clear correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <span
+    class="ant-mentions-affix-wrapper ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var ant-mentions-has-suffix"
+  >
+    <!---->
+    <textarea
+      class="vc-textarea"
+      rows="1"
+      value="hello world"
+    />
+    <!---->
+    <span
+      class="ant-mentions-suffix"
+    >
+      <button
+        class="ant-mentions-clear-icon"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
+      <!---->
+    </span>
+  </span>
+  <span
+    class="ant-mentions-affix-wrapper ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var ant-mentions-has-suffix"
+  >
+    <!---->
+    <textarea
+      class="vc-textarea"
+      rows="1"
+      value="hello world"
+    />
+    <!---->
+    <span
+      class="ant-mentions-suffix"
+    >
+      <button
+        class="ant-mentions-clear-icon"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="close-square"
+          class="anticon anticon-close-square"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-square"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M880 112c17.7 0 32 14.3 32 32v736c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V144c0-17.7 14.3-32 32-32zM639.98 338.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
+      <!---->
+    </span>
+  </span>
+  <span
+    class="ant-mentions-affix-wrapper ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var ant-mentions-has-suffix"
+  >
+    <!---->
+    <textarea
+      class="vc-textarea"
+      rows="3"
+      value="hello world"
+    />
+    <!---->
+    <span
+      class="ant-mentions-suffix"
+    >
+      <button
+        class="ant-mentions-clear-icon"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
+      <!---->
+    </span>
+  </span>
+</div>
+`;
+
+exports[`mentions demo > renders async correctly 1`] = `
+<div
+  class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+  style="width: 100%;"
+>
+  <textarea
+    class="vc-textarea"
+    rows="1"
+    value=""
+  />
+  <!---->
+</div>
+`;
+
+exports[`mentions demo > renders auto-size correctly 1`] = `
+<div
+  class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+  style="width: 100%;"
+>
+  <textarea
+    class="vc-textarea"
+    rows="1"
+    value=""
+  />
+  <!---->
+</div>
+`;
+
+exports[`mentions demo > renders autosize-textarea-debug correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-large ant-flex-vertical"
+>
+  <div
+    class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="can resize"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+  <div
+    class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+    style="resize: none;"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="disable resize"
+      rows="1"
+      style="resize: none;"
+      value=""
+    />
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`mentions demo > renders basic correctly 1`] = `
+<div
+  class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+  style="width: 100%;"
+>
+  <textarea
+    class="vc-textarea"
+    rows="1"
+    value="@afc163"
+  />
+  <!---->
+</div>
+`;
+
+exports[`mentions demo > renders component-token correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-mentions css-var-v-0 ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-v-0 ant-mentions-css-var"
+    style="width: 100%;"
+  >
+    <textarea
+      class="vc-textarea"
+      rows="1"
+      value="@"
+    />
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`mentions demo > renders form correctly 1`] = `
+<form
+  class="ant-form ant-form-horizontal css-var-root ant-form-css-var"
+>
+  <div
+    class="ant-form-item css-var-root ant-form-css-var ant-form-item-horizontal"
+  >
+    <div
+      class="ant-row css-var-root ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-col-6 css-var-root ant-form-item-label"
+      >
+        <label
+          class=""
+          title="Top coders"
+        >
+          Top coders
+        </label>
+      </div>
+      <div
+        class="ant-col ant-col-16 css-var-root ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+            >
+              <textarea
+                class="vc-textarea"
+                id="coders"
+                rows="1"
+                value=""
+              />
+              <!---->
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item-additional"
+        >
+          <transition-stub
+            appear="true"
+            css="true"
+            enteractiveclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare "
+            enterfromclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare ant-form-show-help-enter-start"
+            entertoclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-active ant-form-show-help-enter-active"
+            leaveactiveclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+            leavefromclass="ant-form-show-help ant-form-show-help-leave"
+            leavetoclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+            name="ant-form-show-help"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <!---->
+        </div>
+      </div>
+      <!---->
+    </div>
+    <!---->
+  </div>
+  <div
+    class="ant-form-item css-var-root ant-form-css-var ant-form-item-horizontal"
+  >
+    <div
+      class="ant-row css-var-root ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-col-6 css-var-root ant-form-item-label"
+      >
+        <label
+          class="ant-form-item-required"
+          title="Bio"
+        >
+          Bio
+        </label>
+      </div>
+      <div
+        class="ant-col ant-col-16 css-var-root ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+            >
+              <textarea
+                class="vc-textarea"
+                id="bio"
+                placeholder="You can use @ to ref user here"
+                rows="3"
+                value=""
+              />
+              <!---->
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item-additional"
+        >
+          <transition-stub
+            appear="true"
+            css="true"
+            enteractiveclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare "
+            enterfromclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare ant-form-show-help-enter-start"
+            entertoclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-active ant-form-show-help-enter-active"
+            leaveactiveclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+            leavefromclass="ant-form-show-help ant-form-show-help-leave"
+            leavetoclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+            name="ant-form-show-help"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <!---->
+        </div>
+      </div>
+      <!---->
+    </div>
+    <!---->
+  </div>
+  <div
+    class="ant-form-item css-var-root ant-form-css-var ant-form-item-horizontal"
+  >
+    <div
+      class="ant-row css-var-root ant-form-item-row"
+    >
+      <!---->
+      <div
+        class="ant-col ant-col-16 ant-col-offset-6 css-var-root ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+              style="flex-wrap: wrap;"
+            >
+              <div
+                class="ant-space-item"
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+                  type="submit"
+                >
+                  <transition-stub
+                    appear="false"
+                    css="true"
+                    name="ant-btn-loading-icon-motion"
+                    persisted="false"
+                  >
+                    <!---->
+                  </transition-stub>
+                  <span>
+                     Submit 
+                  </span>
+                  <!---->
+                </button>
+              </div>
+              <!---->
+              <div
+                class="ant-space-item"
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+                  type="button"
+                >
+                  <transition-stub
+                    appear="false"
+                    css="true"
+                    name="ant-btn-loading-icon-motion"
+                    persisted="false"
+                  >
+                    <!---->
+                  </transition-stub>
+                  <span>
+                     Reset 
+                  </span>
+                  <!---->
+                </button>
+              </div>
+              <!---->
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item-additional"
+        >
+          <transition-stub
+            appear="true"
+            css="true"
+            enteractiveclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare "
+            enterfromclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare ant-form-show-help-enter-start"
+            entertoclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-active ant-form-show-help-enter-active"
+            leaveactiveclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+            leavefromclass="ant-form-show-help ant-form-show-help-leave"
+            leavetoclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+            name="ant-form-show-help"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <!---->
+        </div>
+      </div>
+      <!---->
+    </div>
+    <!---->
+  </div>
+</form>
+`;
+
+exports[`mentions demo > renders placement correctly 1`] = `
+<div
+  class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+  style="width: 100%;"
+>
+  <textarea
+    class="vc-textarea"
+    rows="1"
+    value=""
+  />
+  <!---->
+</div>
+`;
+
+exports[`mentions demo > renders prefix correctly 1`] = `
+<div
+  class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+  style="width: 100%;"
+>
+  <textarea
+    class="vc-textarea"
+    placeholder="input @ to mention people, # to mention tag"
+    rows="1"
+    value=""
+  />
+  <!---->
+</div>
+`;
+
+exports[`mentions demo > renders readonly correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-mentions ant-mentions-disabled css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+    style="width: 100%;"
+  >
+    <textarea
+      class="vc-textarea vc-textarea-disabled"
+      disabled=""
+      placeholder="this is disabled Mentions"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+  <div
+    class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+    style="width: 100%;"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="this is readOnly Mentions"
+      readonly=""
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`mentions demo > renders render-panel correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    options="[object Object],[object Object]"
+    style="padding-bottom: 0px; position: relative; min-width: 0px;"
+    value="@"
+  >
+    <div
+      class="ant-mentions css-var-v-0 ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-v-0 ant-mentions-css-var"
+      style="width: 100%; margin: 0px;"
+    >
+      <textarea
+        class="vc-textarea"
+        open="true"
+        rows="1"
+        value="@"
+      />
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`mentions demo > renders size correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-mentions ant-mentions-lg css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions ant-mentions-lg css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="large size"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+  <div
+    class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="default size"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+  <div
+    class="ant-mentions ant-mentions-sm css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions ant-mentions-sm css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="small size"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`mentions demo > renders status correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions-status-error ant-mentions css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      rows="1"
+      value="@afc163"
+    />
+    <!---->
+  </div>
+  <div
+    class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions-status-warning ant-mentions css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      rows="1"
+      value="@afc163"
+    />
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`mentions demo > renders style-class correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+  data-v-a0b778f7=""
+>
+  <div
+    class="ant-mentions mentions-demo-root css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions mentions-demo-root css-var-root ant-mentions-css-var"
+    data-v-a0b778f7=""
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="Object"
+      rows="2"
+      style="resize: vertical; font-size: 14px; font-weight: 200;"
+      value=""
+    />
+    <!---->
+  </div>
+  <div
+    class="ant-mentions mentions-demo-root css-var-root ant-mentions-css-var ant-mentions-filled ant-mentions mentions-demo-root css-var-root ant-mentions-css-var"
+    data-v-a0b778f7=""
+    style="border: 1px solid rgb(114, 46, 209);"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="Function"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`mentions demo > renders variant correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-outlined ant-mentions css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="Outlined"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+  <div
+    class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-filled ant-mentions css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="Filled"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+  <div
+    class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-borderless ant-mentions css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="Borderless"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+  <div
+    class="ant-mentions css-var-root ant-mentions-css-var ant-mentions-underlined ant-mentions css-var-root ant-mentions-css-var"
+  >
+    <textarea
+      class="vc-textarea"
+      placeholder="Underlined"
+      rows="1"
+      value=""
+    />
+    <!---->
+  </div>
+</div>
+`;

--- a/packages/antdv-next/src/mentions/tests/demo.test.tsx
+++ b/packages/antdv-next/src/mentions/tests/demo.test.tsx
@@ -1,0 +1,3 @@
+import demoTest from '/@tests/shared/demoTest'
+
+demoTest('mentions')


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Test Case
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related Issues

ref #63

### 💡 Background and Solution

Add comprehensive unit tests for the **Mentions** component, covering 75 test cases across 3 test files:

- **Mentions.test.tsx** (53 tests): props/emits validation, size/variant/status, disabled, focus/blur, change events, `getMentions` static method, allowClear, loading, notFoundContent, options without label, Form hasFeedback integration, suffix slot, rootClass, RTL, ConfigProvider (prefixCls/size), expose, placeholder, readOnly, Option export, install, slot children (deprecated), labelRender (prop/slot), PurePanel, attrs passthrough, dynamic updates, snapshots
- **Mentions.semantic.test.tsx** (6 tests): semantic DOM class/style passthrough with static objects, functions, and ConfigProvider merge
- **demo.test.tsx** (16 tests): snapshot tests for all 16 demo examples

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add unit tests for Mentions component (75 test cases) |
| 🇨🇳 Chinese | 为 Mentions 组件添加单元测试（75 个测试用例） |