### PR TITLE
chore(docs): add sponsor qrcode for shiqkuangsan

### DIFF
--- a/docs/src/pages/sponsor/index.vue
+++ b/docs/src/pages/sponsor/index.vue
@@ -62,8 +62,8 @@ const teamMembers = [
     github: 'shiqkuangsan',
     name: 'shiqkuangsan',
     avatar: 'https://avatars.githubusercontent.com/u/18481623?v=4',
-    wxCode: '',
-    alipayCode: '',
+    wxCode: 'wxp://f2f0D7y2n_8NxFIDidgAElzg901GrmtaCaGPELRzYx_EkA8',
+    alipayCode: 'https://qr.alipay.com/fkx16811xjmckbz86jyoa62',
   },
 ]
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [x] Branch merge
- [ ] Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

Add WeChat and Alipay payment QR code links for team member `shiqkuangsan` on the sponsor page, so that the personal sponsor tab shows functional QR codes instead of loading placeholders.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add sponsor QR codes for shiqkuangsan |
| 🇨🇳 Chinese | 为 shiqkuangsan 添加赞助收款二维码 |