### PR TITLE
fix(image): cover slot not rendered when preview mask is configured

### DIFF
--- a/packages/antdv-next/src/image/index.tsx
+++ b/packages/antdv-next/src/image/index.tsx
@@ -250,8 +250,8 @@ const Image = defineComponent<
       if (slots?.imageRender) {
         mergedPreviewConfig.value.imageRender = slots.imageRender
       }
-      if ((mergedPreviewConfig.value?.mask || typeof mergedPreviewConfig.value?.mask === 'boolean') && !mergedPreviewConfig.value.cover) {
-        mergedPreviewConfig.value.cover = slots?.cover?.()
+      if (slots?.cover && (mergedPreviewConfig.value?.mask || typeof mergedPreviewConfig.value?.mask === 'boolean')) {
+        mergedPreviewConfig.value.cover = slots.cover()
       }
       // ============================== Render ==============================
       return (


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

> Image preview mask demo: `#cover` slot content not displayed on hover.

### 💡 Background and Solution

> **Problem:** When using `<a-image :preview="{ mask: true }">` with a `<template #cover>` slot, the cover content is never rendered.
>
> **Root cause:** In `useMergedPreviewConfig`, `defaultCover = ref(true)` sets `cover` to `true` before the slot injection logic runs. The original condition `!mergedPreviewConfig.value.cover` evaluates to `false` (since `!true === false`), so `slots.cover()` is never called.
>
> **Fix:** Prioritize the `#cover` slot over `defaultCover` — when `slots.cover` exists and mask is configured, always use the slot content. This aligns with the "slot takes priority over prop" convention used throughout antdv-next.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Image `#cover` slot not rendering when `preview.mask` is configured. |
| 🇨🇳 Chinese | 修复 Image 组件在配置 `preview.mask` 时 `#cover` 插槽内容不渲染的问题。 |