### PR TITLE
fix(a11y): apply prefers-reduced-motion to Radio and Segmented

### DIFF
--- a/packages/antdv-next/src/radio/style/index.ts
+++ b/packages/antdv-next/src/radio/style/index.ts
@@ -3,6 +3,7 @@ import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/inte
 
 import { unit } from '@antdv-next/cssinjs'
 import { genFocusOutline, resetComponent } from '../../style'
+import { genNoMotionStyle } from '../../style/motion'
 import { genStyleHooks, mergeToken } from '../../theme/internal'
 
 // ============================== Tokens ==============================
@@ -223,6 +224,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         border: `${unit(lineWidth)} ${lineType} ${colorBorder}`,
         borderRadius: '50%',
         transition: `all ${motionDurationMid}`,
+        ...genNoMotionStyle(),
 
         // Dot
         '&:after': {
@@ -238,6 +240,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
           transformOrigin: '50% 50%',
           opacity: 0,
           transition: `all ${motionDurationSlow} ${motionEaseInOutCirc}`,
+          ...genNoMotionStyle(),
         },
 
         // Wrapper > Radio > input
@@ -361,6 +364,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
       transition: [`color`, `background-color`, `box-shadow`]
         .map(prop => `${prop} ${motionDurationMid}`)
         .join(','),
+      ...genNoMotionStyle(),
 
       a: {
         color: buttonColor,

--- a/packages/antdv-next/src/segmented/style/index.ts
+++ b/packages/antdv-next/src/segmented/style/index.ts
@@ -3,6 +3,7 @@ import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/inte
 
 import { unit } from '@antdv-next/cssinjs'
 import { genFocusOutline, genFocusStyle, resetComponent, textEllipsis } from '../../style'
+import { genNoMotionStyle } from '../../style/motion'
 import { genStyleHooks, mergeToken } from '../../theme/internal'
 
 export interface ComponentToken {
@@ -103,6 +104,7 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken, CSSObject> = (token) => {
       background: token.trackBg,
       borderRadius: token.borderRadius,
       transition: `all ${motionDurationMid}`,
+      ...genNoMotionStyle(),
       ...genFocusStyle(token),
 
       [`${componentCls}-group`]: {
@@ -147,6 +149,7 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken, CSSObject> = (token) => {
         textAlign: 'center',
         cursor: 'pointer',
         transition: `color ${motionDurationMid}`,
+        ...genNoMotionStyle(),
         borderRadius: token.borderRadiusSM,
         // Fix Safari render bug
         // https://github.com/ant-design/ant-design/issues/45250
@@ -175,6 +178,7 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken, CSSObject> = (token) => {
           transition: ['opacity', 'background-color']
             .map(prop => `${prop} ${motionDurationMid}`)
             .join(', '),
+          ...genNoMotionStyle(),
         },
 
         [`&:not(${componentCls}-item-selected):not(${componentCls}-item-disabled)`]: {
@@ -268,6 +272,7 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken, CSSObject> = (token) => {
         transition: [`transform`, `width`]
           .map(prop => `${prop} ${motionDurationSlow} ${motionEaseInOut}`)
           .join(', '),
+        ...genNoMotionStyle(),
       },
 
       [`&${componentCls}-shape-round`]: {


### PR DESCRIPTION
## 背景

antdv-next 已在 Button、Checkbox、Switch 中应用了 `prefers-reduced-motion` 无障碍处理（对应 ant-design#56902），本 PR 补齐 Radio 和 Segmented 组件。

## 改动

为 Radio 和 Segmented 组件的所有 `transition` 属性后添加 `...genNoMotionStyle()`，当用户在操作系统中开启「减少动态效果」时，相关过渡动画自动禁用。

**Radio**（3 处）：
- 单选框圆形本体
- 圆点 `:after` 元素
- Radio Button Wrapper

**Segmented**（4 处）：
- 容器根元素
- 选项 item
- 选项 item `::after` 伪元素
- `thumb-motion-appear` 滑块动画

## 关联

closes #268 (item #9)