### PR TITLE
fix(tabs): fix renderTabBar prop variable shadowing

### DIFF
--- a/packages/antdv-next/src/tabs/index.tsx
+++ b/packages/antdv-next/src/tabs/index.tsx
@@ -373,8 +373,8 @@ const InternalTabs = defineComponent<
       }
       let renderTabBar: any | undefined
       if (slots.renderTabBar || props.renderTabBar) {
-        renderTabBar = (props: any, TabNavListComponent: any) => {
-          return getSlotPropsFnRun(slots, props, 'renderTabBar', true, { props, TabNavListComponent })
+        renderTabBar = (tabBarProps: any, TabNavListComponent: any) => {
+          return getSlotPropsFnRun(slots, props, 'renderTabBar', true, { props: tabBarProps, TabNavListComponent })
         }
       }
       let tabBarExtraContent: any


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related Issues

N/A — found during unit test development for Tabs

### 💡 Background and Solution

The `renderTabBar` callback in `packages/antdv-next/src/tabs/index.tsx` L376 declares its first parameter as `props`, which shadows the component's own `props` object in the outer scope:

```tsx
// Before (broken)
renderTabBar = (props: any, TabNavListComponent: any) => {
  return getSlotPropsFnRun(slots, props, 'renderTabBar', true, { props, TabNavListComponent })
}
```

This causes `getSlotPropsFnRun` to look for `renderTabBar` on the callback's tabBar props (passed by VcTabs) instead of the component's props. As a result, prop-based `renderTabBar` never worked — only the slot-based version did.

**Fix:** Rename the callback parameter to `tabBarProps`:

```tsx
// After (fixed)
renderTabBar = (tabBarProps: any, TabNavListComponent: any) => {
  return getSlotPropsFnRun(slots, props, 'renderTabBar', true, { props: tabBarProps, TabNavListComponent })
}
```

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `renderTabBar` prop not working due to variable shadowing in callback |
| 🇨🇳 Chinese | 修复 `renderTabBar` prop 因回调参数变量遮蔽而不生效的问题 |