### PR TITLE
fix(tabs): fix dead onPrevClick/onNextClick deprecation warning

### DIFF
--- a/packages/antdv-next/src/tabs/index.tsx
+++ b/packages/antdv-next/src/tabs/index.tsx
@@ -247,7 +247,7 @@ const InternalTabs = defineComponent<
       warning.deprecated(!popupClassName.value, 'popupClassName', 'classNames.popup')
       warning.deprecated(!tabPosition.value, 'tabPosition', 'tabPlacement')
       warning(
-        !((props as any).onPrevClick || (props as any).onNextClick),
+        !((attrs as any).onPrevClick || (attrs as any).onNextClick),
         'breaking',
         '`onPrevClick` and `onNextClick` has been removed. Please use `onTabScroll` instead.',
       )


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related Issues

N/A — found during unit test development for Tabs

### 💡 Background and Solution

In `packages/antdv-next/src/tabs/index.tsx` L250, the deprecation warning for `onPrevClick`/`onNextClick` checks `(props as any).onPrevClick`, but these event handlers are **not declared in the component's props type**. Vue puts undeclared attributes into `attrs`, not `props`, so `(props as any).onPrevClick` is always `undefined` — making this warning a dead branch that never fires.

```tsx
// Before (dead code — always evaluates to true, never warns)
warning(
  !((props as any).onPrevClick || (props as any).onNextClick),
  'breaking',
  '...',
)

// After (correctly checks attrs)
warning(
  !((attrs as any).onPrevClick || (attrs as any).onNextClick),
  'breaking',
  '...',
)
```

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `onPrevClick`/`onNextClick` deprecation warning never triggering by checking `attrs` instead of `props` |
| 🇨🇳 Chinese | 修复 `onPrevClick`/`onNextClick` 废弃警告因检查 `props` 而非 `attrs` 导致永远不触发的问题 |