### PR TITLE
fix(tour): preserve step-level semantic classes in panelRender

### DIFF
--- a/packages/antdv-next/src/tour/index.tsx
+++ b/packages/antdv-next/src/tour/index.tsx
@@ -146,7 +146,7 @@ const Tour = defineComponent<
             type={type}
             stepProps={{
               ...stepProps,
-              classes: stepProps?.classNames,
+              classes: stepProps?.classes ?? stepProps?.classNames,
             } as any}
             current={stepCurrent}
             indicatorsRender={indicatorsRender}


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

> Discovered during Tour unit test development (ref #63).

### 💡 Background and Solution

> **Problem:** In `Tour/index.tsx` L149, step-level semantic `classes` prop is overwritten to `undefined`:
>
> ```tsx
> stepProps={{
>   ...stepProps,
>   classes: stepProps?.classNames, // always undefined — VcTour doesn't inject classNames
> }}
> ```
>
> `stepProps` from VcTour's `renderPanel` callback already contains the user's `step.classes` (via spread from `vcSteps`), but this line overwrites it with `stepProps?.classNames` which is always `undefined` because VcTour does not add a `classNames` property to step-level callback data.
>
> **Fix:** Use nullish coalescing to preserve user's `step.classes` while keeping `classNames` as fallback for VcTour compatibility:
>
> ```tsx
> classes: stepProps?.classes ?? stepProps?.classNames,
> ```

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tour step-level semantic `classes` prop being overwritten to `undefined` in `panelRender`. |
| 🇨🇳 Chinese | 修复 Tour 步骤级语义化 `classes` 属性在 `panelRender` 中被覆盖为 `undefined` 的问题。 |