### PR TITLE
fix(slider): correct tabindex prop name to tabIndex (camelCase)

### DIFF
--- a/packages/antdv-next/src/slider/index.tsx
+++ b/packages/antdv-next/src/slider/index.tsx
@@ -104,7 +104,7 @@ export interface SliderBaseProps {
   // onBlur?: FocusEventHandler<HTMLDivElement>;
 
   // Accessibility
-  tabindex?: SliderProps['tabIndex']
+  tabIndex?: SliderProps['tabIndex']
   ariaLabelForHandle?: SliderProps['ariaLabelForHandle']
   ariaLabelledByForHandle?: SliderProps['ariaLabelledByForHandle']
   ariaRequired?: SliderProps['ariaRequired']


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

Found during unit test development for #63.

### 💡 Background and Solution

`SliderBaseProps` declared `tabindex` (all lowercase), but VcSlider (`@v-c/slider`) expects `tabIndex` (camelCase).

Vue only auto-normalizes **kebab-case** (`tab-index` → `tabIndex`), NOT all-lowercase (`tabindex` stays as-is). This caused custom `tabIndex` values to never reach VcSlider's handle elements.

**Fix**: Rename `tabindex` → `tabIndex` in `SliderBaseProps` interface (line 107).

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Slider `tabIndex` prop not being forwarded to handle elements due to incorrect casing. |
| 🇨🇳 Chinese | 修复 Slider 组件 `tabIndex` 属性因大小写错误无法传递到滑块手柄元素的问题。 |