### PR TITLE
test(image): add unit tests

### DIFF
--- a/packages/antdv-next/src/image/tests/Image.semantic.test.tsx
+++ b/packages/antdv-next/src/image/tests/Image.semantic.test.tsx
@@ -1,0 +1,84 @@
+import type { ImageProps } from '..'
+import { describe, expect, it, vi } from 'vitest'
+import Image from '..'
+import ConfigProvider from '../../config-provider'
+import { mount } from '/@tests/utils'
+
+const src = 'https://example.com/test.png'
+
+describe('image.Semantic', () => {
+  // Image semantic slots: root, image, cover
+  // Plus popup: { root, mask, body, footer, actions }
+
+  it('should support classNames and styles for root, image, and cover', () => {
+    const wrapper = mount(Image, {
+      props: {
+        src,
+        classes: { root: 'custom-root', image: 'custom-image', cover: 'custom-cover' },
+        styles: { root: { margin: '10px' }, image: { borderRadius: '8px' } },
+      },
+    })
+
+    const rootEl = wrapper.find('.ant-image')
+    expect(rootEl.classes()).toContain('custom-root')
+    expect(rootEl.attributes('style')).toContain('margin: 10px')
+
+    const imgEl = wrapper.find('img')
+    expect(imgEl.classes()).toContain('custom-image')
+    expect(imgEl.attributes('style')).toContain('border-radius: 8px')
+
+    const coverEl = wrapper.find('.ant-image-cover')
+    expect(coverEl.classes()).toContain('custom-cover')
+  })
+
+  it('should support classNames and styles as functions', async () => {
+    const classNamesFn = vi.fn((info: { props: ImageProps }) => {
+      if (info.props.rootClass === 'special') {
+        return { root: 'fn-special' }
+      }
+      return { root: 'fn-default' }
+    })
+
+    const wrapper = mount(Image, {
+      props: {
+        src,
+        classes: classNamesFn,
+      },
+    })
+
+    expect(classNamesFn).toHaveBeenCalled()
+    expect(wrapper.find('.ant-image').classes()).toContain('fn-default')
+
+    await wrapper.setProps({ rootClass: 'special' })
+    expect(wrapper.find('.ant-image').classes()).toContain('fn-special')
+  })
+
+  it('should merge context and component classNames and styles', () => {
+    const wrapper = mount(ConfigProvider, {
+      props: {
+        image: {
+          classes: { root: 'context-root', image: 'context-image' },
+          styles: { root: { margin: '10px' } },
+        },
+      },
+      slots: {
+        default: () => (
+          <Image
+            src={src}
+            classes={{ root: 'component-root' }}
+            styles={{ root: { padding: '5px' } }}
+          />
+        ),
+      },
+    })
+
+    const rootEl = wrapper.find('.ant-image')
+    expect(rootEl.classes()).toContain('context-root')
+    expect(rootEl.classes()).toContain('component-root')
+    expect(rootEl.attributes('style')).toContain('margin: 10px')
+    expect(rootEl.attributes('style')).toContain('padding: 5px')
+
+    const imgEl = wrapper.find('img')
+    expect(imgEl.classes()).toContain('context-image')
+  })
+})

--- a/packages/antdv-next/src/image/tests/Image.test.tsx
+++ b/packages/antdv-next/src/image/tests/Image.test.tsx
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import Image, { ImagePreviewGroup } from '..'
+import rtlTest from '/@tests/shared/rtlTest'
+import { mount } from '/@tests/utils'
+
+const src = 'https://example.com/test.png'
+
+describe('image', () => {
+  rtlTest(() => h(Image, { src }))
+
+  it('should render basic image', () => {
+    const wrapper = mount(Image, {
+      props: { src },
+    })
+    expect(wrapper.find('.ant-image').exists()).toBe(true)
+    expect(wrapper.find('img').exists()).toBe(true)
+    expect(wrapper.find('img').attributes('src')).toBe(src)
+  })
+
+  it('should render with width and height', () => {
+    const wrapper = mount(Image, {
+      props: { src, width: 200, height: 100 },
+    })
+    const img = wrapper.find('img')
+    expect(img.attributes('width')).toBe('200')
+    expect(img.attributes('height')).toBe('100')
+  })
+
+  it('should render with alt text', () => {
+    const wrapper = mount(() => (
+      <Image src={src} alt="Test Image" />
+    ))
+    // Debug: check what's rendered
+    expect(wrapper.html()).toContain('Test Image')
+  })
+
+  it('should render fallback when provided', () => {
+    const fallbackSrc = 'https://example.com/fallback.png'
+    const wrapper = mount(Image, {
+      props: { src, fallback: fallbackSrc },
+    })
+    expect(wrapper.find('.ant-image').exists()).toBe(true)
+  })
+
+  it('should render fallback via slot', () => {
+    const wrapper = mount(Image, {
+      props: { src },
+      slots: {
+        fallback: () => h('img', { src: 'fallback.png', class: 'custom-fallback' }),
+      },
+    })
+    expect(wrapper.find('.ant-image').exists()).toBe(true)
+  })
+
+  it('should render placeholder via slot', () => {
+    const wrapper = mount(Image, {
+      props: { src },
+      slots: {
+        placeholder: () => h('div', { class: 'custom-placeholder' }, 'Loading...'),
+      },
+    })
+    expect(wrapper.find('.custom-placeholder').exists()).toBe(true)
+  })
+
+  it('should disable preview when preview is false', () => {
+    const wrapper = mount(Image, {
+      props: { src, preview: false },
+    })
+    expect(wrapper.find('.ant-image').exists()).toBe(true)
+    // When preview is disabled, cover overlay should not render
+    expect(wrapper.find('.ant-image-cover').exists()).toBe(false)
+  })
+
+  it('should support preview config object', () => {
+    const wrapper = mount(Image, {
+      props: {
+        src,
+        preview: { src: 'https://example.com/large.png' },
+      },
+    })
+    expect(wrapper.find('.ant-image').exists()).toBe(true)
+  })
+
+  it('should trigger error event on image error', async () => {
+    const onError = vi.fn()
+    const wrapper = mount(Image, {
+      props: { src: 'broken.png', onError },
+    })
+    await wrapper.find('img').trigger('error')
+    expect(onError).toHaveBeenCalled()
+  })
+
+  it('should trigger click event', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(Image, {
+      props: { src, onClick, preview: false },
+    })
+    await wrapper.find('img').trigger('click')
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('should support rootClass', () => {
+    const wrapper = mount(Image, {
+      props: { src, rootClass: 'my-image' },
+    })
+    expect(wrapper.find('.my-image').exists()).toBe(true)
+  })
+
+  it('should match snapshot', () => {
+    const wrapper = mount(() => (
+      <Image src={src} width={200} alt="Test" />
+    ))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('should match snapshot with preview disabled', () => {
+    const wrapper = mount(() => (
+      <Image src={src} preview={false} />
+    ))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('image.PreviewGroup', () => {
+  rtlTest(() => h(ImagePreviewGroup, null, {
+    default: () => h(Image, { src }),
+  }))
+
+  it('should render PreviewGroup with children', () => {
+    const wrapper = mount(ImagePreviewGroup, {
+      slots: {
+        default: () => [
+          h(Image, { key: '1', src }),
+          h(Image, { key: '2', src: 'https://example.com/test2.png' }),
+        ],
+      },
+    })
+    expect(wrapper.findAll('.ant-image').length).toBe(2)
+  })
+
+  it('should support preview config on group', () => {
+    const wrapper = mount(ImagePreviewGroup, {
+      props: {
+        preview: { open: false },
+      },
+      slots: {
+        default: () => h(Image, { src }),
+      },
+    })
+    expect(wrapper.find('.ant-image').exists()).toBe(true)
+  })
+
+  it('should disable preview when preview is false', () => {
+    const wrapper = mount(ImagePreviewGroup, {
+      props: { preview: false },
+      slots: {
+        default: () => h(Image, { src }),
+      },
+    })
+    expect(wrapper.find('.ant-image').exists()).toBe(true)
+  })
+
+  it('should match snapshot', () => {
+    const wrapper = mount(() => (
+      <ImagePreviewGroup>
+        <Image src={src} width={200} />
+        <Image src="https://example.com/test2.png" width={200} />
+      </ImagePreviewGroup>
+    ))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/packages/antdv-next/src/image/tests/__snapshots__/Image.test.tsx.snap
+++ b/packages/antdv-next/src/image/tests/__snapshots__/Image.test.tsx.snap
@@ -1,0 +1,77 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`image > rtl render > component should be rendered correctly in RTL direction 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-image css-var-root ant-image-css-var"
+  >
+    <img
+      class="ant-image-img"
+      src="https://example.com/test.png"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`image > should match snapshot 1`] = `
+"<div alt="Test" class="ant-image css-var-root ant-image-css-var" style="width: 200px;"><img src="https://example.com/test.png" class="ant-image-img" width="200">
+  <!---->
+  <div class="ant-image-cover ant-image-cover-center">
+    <!---->
+  </div>
+</div>"
+`;
+
+exports[`image > should match snapshot with preview disabled 1`] = `
+"<div class="ant-image css-var-root ant-image-css-var"><img src="https://example.com/test.png" class="ant-image-img">
+  <!---->
+  <!---->
+</div>"
+`;
+
+exports[`image.PreviewGroup > rtl render > component should be rendered correctly in RTL direction 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-image css-var-root ant-image-css-var"
+  >
+    <img
+      class="ant-image-img"
+      src="https://example.com/test.png"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+</div>
+`;
+
+exports[`image.PreviewGroup > should match snapshot 1`] = `
+"<div class="ant-image css-var-root ant-image-css-var" style="width: 200px;"><img src="https://example.com/test.png" class="ant-image-img" width="200">
+  <!---->
+  <div class="ant-image-cover ant-image-cover-center">
+    <!---->
+  </div>
+</div>
+<div class="ant-image css-var-root ant-image-css-var" style="width: 200px;"><img src="https://example.com/test2.png" class="ant-image-img" width="200">
+  <!---->
+  <div class="ant-image-cover ant-image-cover-center">
+    <!---->
+  </div>
+</div>"
+`;

--- a/packages/antdv-next/src/image/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/image/tests/__snapshots__/demo.test.tsx.snap
@@ -1,0 +1,1610 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`image demo > renders _semantic correctly 1`] = `
+<div
+  class="semantic-preview-container"
+  data-v-dfc8ebef=""
+>
+  <div
+    class="ant-row css-var-root semantic-preview-row"
+    data-v-dfc8ebef=""
+  >
+    <div
+      class="ant-col ant-col-16 css-var-root semantic-preview-col semantic-preview-col-no-padding"
+      data-v-dfc8ebef=""
+    >
+      <div
+        class="ant-flex css-var-v-0 ant-flex-align-center ant-flex-vertical"
+        style="min-height: 100%; width: 100%;"
+      >
+        <div
+          class="ant-flex css-var-v-0 ant-flex-justify-center"
+          style="padding: 16px; flex: 0 0 auto;"
+        >
+          <div
+            class="ant-image css-var-v-0 ant-image-css-var semantic-mark-root"
+            style="width: 200px;"
+          >
+            <img
+              class="ant-image-img semantic-mark-image"
+              src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+              width="200"
+            />
+            <!---->
+            <div
+              class="ant-image-cover semantic-mark-cover ant-image-cover-center"
+            >
+              <!---->
+            </div>
+          </div>
+          <!---->
+        </div>
+        <div
+          style="flex: 1 1 0%; position: relative; min-height: 500px; width: 100%;"
+        >
+          <!---->
+          <!--teleport start-->
+          <!--teleport end-->
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-col ant-col-8 css-var-root"
+      data-v-dfc8ebef=""
+    >
+      <ul
+        class="semantic-list"
+        data-v-dfc8ebef=""
+      >
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  root
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Root element, sets relative positioning and inline-block layout styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  image
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Image element, sets width, height and vertical alignment styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  cover
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Image hover display prompt element, sets absolute positioning, background color, opacity and transition animation styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup.root
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Preview root element, sets fixed positioning, z-index and background mask styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup.mask
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Preview mask element, sets absolute positioning and semi-transparent background styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup.body
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Preview body element, sets flex layout, center alignment and pointer event styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup.footer
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Preview footer element, sets absolute positioning, center layout and bottom operation area styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup.actions
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Preview actions group element, sets flex layout, background color, border radius and action button styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`image demo > renders basic correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    alt="basic"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders controlled-preview correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div>
+     scaleStep: 0.5 
+    <div
+      class="ant-input-number ant-input-number-mode-input css-var-root ant-input-number-css-var ant-input-number-outlined"
+    >
+      <!---->
+      <!---->
+      <input
+        aria-valuemax="5"
+        aria-valuemin="0.1"
+        aria-valuenow="0.5"
+        autocomplete="off"
+        class="ant-input-number-input"
+        role="spinbutton"
+        step="0.1"
+        value="0.5"
+      />
+      <!---->
+      <!---->
+      <div
+        class="ant-input-number-actions"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="up"
+            class="anticon anticon-up"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="up"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <br />
+  <button
+    class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       show image preview 
+    </span>
+    <!---->
+  </button>
+  <div
+    alt="basic image"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
+      style="display: none;"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders fallback correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    alt="basic image"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px; height: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      height="200"
+      src="error"
+      style="height: 200px;"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders imageRender correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    alt="slot image"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <br />
+  <div
+    alt="preview image"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders mask correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    alt="Default blur"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 100px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+      width="100"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <div
+        class="ant-space ant-space-vertical ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+      >
+        <div
+          class="ant-space-item"
+        >
+           Default blur 
+        </div>
+        <!---->
+      </div>
+    </div>
+  </div>
+  <!---->
+  <div
+    alt="Dimmed mask"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 100px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+      width="100"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <div
+        class="ant-space ant-space-vertical ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+      >
+        <div
+          class="ant-space-item"
+        >
+           Dimmed mask 
+        </div>
+        <!---->
+      </div>
+    </div>
+  </div>
+  <!---->
+  <div
+    alt="No mask"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 100px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
+      width="100"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <div
+        class="ant-space ant-space-vertical ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+      >
+        <div
+          class="ant-space-item"
+        >
+           No mask 
+        </div>
+        <!---->
+      </div>
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders nested correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <button
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+    type="button"
+  >
+    <transition-stub
+      appear="false"
+      css="true"
+      name="ant-btn-loading-icon-motion"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    <span>
+       showModal 
+    </span>
+    <!---->
+  </button>
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders placeholder correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center css-var-root"
+  style="column-gap: 12px; row-gap: 12px;"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      alt="basic image"
+      class="ant-image css-var-root ant-image-css-var"
+      style="width: 200px;"
+    >
+      <img
+        class="ant-image-img"
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?1505705407795"
+        width="200"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-image-placeholder"
+      >
+        <div
+          alt="placeholder image"
+          class="ant-image css-var-root ant-image-css-var"
+          style="width: 200px;"
+        >
+          <img
+            class="ant-image-img"
+            src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
+            width="200"
+          />
+          <!---->
+          <!---->
+        </div>
+        <!---->
+      </div>
+      <div
+        class="ant-image-cover ant-image-cover-center"
+      >
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="ant-btn-loading-icon-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <span>
+         Reload 
+      </span>
+      <!---->
+    </button>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders preview-group correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    alt="svg image"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <div
+    alt="svg image"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders preview-group-visible correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    alt="webp image"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders previewSrc correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    alt="basic image"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders style-class correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-gap-middle"
+>
+  <div
+    alt="示例图片"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 160px; padding: 4px; border-radius: 8px; overflow: hidden;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+      style="border-radius: 4px;"
+      width="160"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <div
+    alt="示例图片"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 160px; border: 2px solid rgb(165, 148, 249); border-radius: 8px; padding: 4px; transition: all 0.3s ease;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+      style="border-radius: 4px; filter: grayscale(50%);"
+      width="160"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`image demo > renders toolbarRender correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    alt="image-0"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <div
+    alt="image-1"
+    class="ant-image css-var-root ant-image-css-var"
+    style="width: 200px;"
+  >
+    <img
+      class="ant-image-img"
+      src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
+      width="200"
+    />
+    <!---->
+    <div
+      class="ant-image-cover ant-image-cover-center"
+    >
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+</div>
+`;

--- a/packages/antdv-next/src/image/tests/demo.test.tsx
+++ b/packages/antdv-next/src/image/tests/demo.test.tsx
@@ -1,0 +1,13 @@
+import { afterAll, beforeAll } from 'vitest'
+import demoTest from '/@tests/shared/demoTest'
+import { resetMockDate, setMockDate } from '/@tests/utils'
+
+beforeAll(() => {
+  setMockDate('2017-09-18T03:30:07.795Z')
+})
+
+afterAll(() => {
+  resetMockDate()
+})
+
+demoTest('image')


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for Image and ImagePreviewGroup components
- **Image.test.tsx** (19 tests): basic rendering, width/height, alt text, fallback (prop/slot), placeholder slot, preview disabled/config, error/click events, rootClass, PreviewGroup children/config/disabled, snapshots
- **Image.semantic.test.tsx** (3 tests): classNames/styles for root/image/cover slots, function form with reactive props, ConfigProvider merge
- **demo.test.tsx** (13 tests): all demo snapshot tests with mocked Date to fix flaky placeholder timestamp

## Test plan
- [x] All 35 tests pass: `pnpm vitest run packages/antdv-next/src/image/tests/`
- [x] rtlTest included in both Image and PreviewGroup describe blocks
- [x] All semantic slots (root, image, cover) covered with assertions
- [x] Function form semantic tests verify reactivity via setProps
- [x] ConfigProvider merge test for image
- [x] Date.now() mocked in demo.test.tsx to prevent flaky placeholder demo snapshot