### PR TITLE
test(time-picker): add unit tests

### DIFF
--- a/packages/antdv-next/src/time-picker/tests/TimePicker.semantic.test.tsx
+++ b/packages/antdv-next/src/time-picker/tests/TimePicker.semantic.test.tsx
@@ -1,0 +1,165 @@
+import type { TimePickerProps } from '..'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import TimePicker from '..'
+import ConfigProvider from '../../config-provider'
+import { mount } from '/@tests/utils'
+
+const { RangePicker } = TimePicker
+
+describe('time-picker.semantic', () => {
+  // ====================== Classes as Object ======================
+  it('should support semantic classes and styles for single picker', async () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        open: true,
+        prefix: 'prefix',
+        classes: {
+          root: 'tp-root',
+          prefix: 'tp-prefix',
+          input: 'tp-input',
+          suffix: 'tp-suffix',
+          popup: {
+            root: 'tp-popup-root',
+            content: 'tp-popup-content',
+            item: 'tp-popup-item',
+          },
+        },
+        styles: {
+          root: { backgroundColor: 'rgb(255, 0, 0)' },
+          prefix: { color: 'rgb(0, 128, 0)' },
+          input: { color: 'rgb(0, 0, 255)' },
+          suffix: { fontSize: '20px' },
+          popup: {
+            root: { backgroundColor: 'rgb(200, 200, 200)' },
+            content: { backgroundColor: 'rgb(240, 240, 255)' },
+            item: { backgroundColor: 'rgb(255, 255, 240)' },
+          },
+        },
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    // Root
+    const root = wrapper.find('.ant-picker')
+    expect(root.classes()).toContain('tp-root')
+    expect((root.element as HTMLElement).style.backgroundColor).toBe('rgb(255, 0, 0)')
+
+    // Prefix
+    const prefix = wrapper.find('.ant-picker-prefix')
+    expect(prefix.classes()).toContain('tp-prefix')
+    expect((prefix.element as HTMLElement).style.color).toBe('rgb(0, 128, 0)')
+
+    // Input
+    const input = wrapper.find('.ant-picker-input input')
+    expect(input.classes()).toContain('tp-input')
+    expect((input.element as HTMLInputElement).style.color).toBe('rgb(0, 0, 255)')
+
+    // Suffix
+    const suffix = wrapper.find('.ant-picker-suffix')
+    expect(suffix.classes()).toContain('tp-suffix')
+    expect((suffix.element as HTMLElement).style.fontSize).toBe('20px')
+
+    // Popup
+    const popup = document.querySelector('.ant-picker-dropdown') as HTMLElement | null
+    expect(popup).toBeTruthy()
+    expect(popup?.classList.contains('tp-popup-root')).toBe(true)
+    expect(popup?.style.backgroundColor).toBe('rgb(200, 200, 200)')
+
+    // Popup content
+    const content = document.querySelector('.ant-picker-content')
+    expect(content?.classList.contains('tp-popup-content')).toBe(true)
+
+    // Popup item
+    const item = document.querySelector('.ant-picker-time-panel-cell')
+    expect(item?.classList.contains('tp-popup-item')).toBe(true)
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  // ====================== Classes as Function ======================
+  it('should support semantic classes as function', () => {
+    const classesFn = vi.fn((info: { props: TimePickerProps }) => ({
+      root: info.props.disabled ? 'tp-disabled-root' : 'tp-enabled-root',
+      suffix: `tp-size-${info.props.size ?? 'middle'}`,
+    }))
+
+    const stylesFn = vi.fn((info: { props: TimePickerProps }) => ({
+      root: { fontSize: info.props.size === 'large' ? '18px' : '14px' },
+    }))
+
+    const wrapper = mount(TimePicker, {
+      props: {
+        classes: classesFn as any,
+        styles: stylesFn as any,
+        size: 'large',
+      },
+    })
+
+    expect(classesFn).toHaveBeenCalled()
+    expect(stylesFn).toHaveBeenCalled()
+
+    const root = wrapper.find('.ant-picker')
+    expect(root.classes()).toContain('tp-enabled-root')
+    expect((root.element as HTMLElement).style.fontSize).toBe('18px')
+
+    const suffix = wrapper.find('.ant-picker-suffix')
+    expect(suffix.classes()).toContain('tp-size-large')
+  })
+
+  // ====================== ConfigProvider Merging ======================
+  it('should merge ConfigProvider and component classes', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider
+        timePicker={{
+          classes: { root: 'ctx-root' },
+          styles: { root: { margin: '1px' } },
+        }}
+      >
+        <TimePicker
+          classes={{ root: 'comp-root' }}
+          styles={{ root: { padding: '2px' } }}
+        />
+      </ConfigProvider>
+    ))
+
+    const root = wrapper.find('.ant-picker')
+    expect(root.classes()).toContain('ctx-root')
+    expect(root.classes()).toContain('comp-root')
+    expect((root.element as HTMLElement).style.margin).toBe('1px')
+    expect((root.element as HTMLElement).style.padding).toBe('2px')
+  })
+
+  // ====================== RangePicker Semantic ======================
+  it('should support semantic classes for range picker', async () => {
+    const wrapper = mount(RangePicker, {
+      props: {
+        open: true,
+        classes: {
+          root: 'range-root',
+          input: 'range-input',
+          popup: { root: 'range-popup-root' },
+        },
+        styles: {
+          root: { borderWidth: '2px' },
+        },
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(wrapper.find('.ant-picker-range').classes()).toContain('range-root')
+    expect((wrapper.find('.ant-picker-range').element as HTMLElement).style.borderWidth).toBe('2px')
+    expect(wrapper.findAll('.ant-picker-input input')[0]?.classes()).toContain('range-input')
+
+    const popup = document.querySelector('.ant-picker-dropdown') as HTMLElement | null
+    expect(popup?.classList.contains('range-popup-root')).toBe(true)
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+})

--- a/packages/antdv-next/src/time-picker/tests/TimePicker.test.tsx
+++ b/packages/antdv-next/src/time-picker/tests/TimePicker.test.tsx
@@ -1,0 +1,613 @@
+import dayjs from 'dayjs'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
+import MockDate from 'mockdate'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import TimePicker from '..'
+import { resetWarned } from '../../_util/warning'
+import ConfigProvider from '../../config-provider'
+import { mount } from '/@tests/utils'
+
+dayjs.extend(customParseFormat)
+
+const { RangePicker } = TimePicker
+
+describe('time-picker', () => {
+  beforeEach(() => {
+    MockDate.set(dayjs('2020-01-01T00:00:00Z').valueOf())
+  })
+
+  afterEach(() => {
+    MockDate.reset()
+  })
+
+  // ====================== Basic Rendering ======================
+  it('should render correctly', () => {
+    const wrapper = mount(TimePicker)
+    expect(wrapper.find('.ant-picker').exists()).toBe(true)
+  })
+
+  it('should have default placeholder', () => {
+    const wrapper = mount(TimePicker)
+    expect(wrapper.find('input').attributes('placeholder')).toBe('Select time')
+  })
+
+  it('should support custom placeholder', () => {
+    const wrapper = mount(TimePicker, {
+      props: { placeholder: 'Pick a time' },
+    })
+    expect(wrapper.find('input').attributes('placeholder')).toBe('Pick a time')
+  })
+
+  // ====================== Size ======================
+  it('should support size=large', () => {
+    const wrapper = mount(TimePicker, {
+      props: { size: 'large' },
+    })
+    expect(wrapper.find('.ant-picker-large').exists()).toBe(true)
+  })
+
+  it('should support size=small', () => {
+    const wrapper = mount(TimePicker, {
+      props: { size: 'small' },
+    })
+    expect(wrapper.find('.ant-picker-small').exists()).toBe(true)
+  })
+
+  // ====================== Disabled ======================
+  it('should support disabled', () => {
+    const wrapper = mount(TimePicker, {
+      props: { disabled: true },
+    })
+    expect(wrapper.find('.ant-picker-disabled').exists()).toBe(true)
+    expect(wrapper.find('input').attributes('disabled')).toBeDefined()
+  })
+
+  // ====================== Status ======================
+  it('should support status=error', () => {
+    const wrapper = mount(TimePicker, {
+      props: { status: 'error' },
+    })
+    expect(wrapper.find('.ant-picker-status-error').exists()).toBe(true)
+  })
+
+  it('should support status=warning', () => {
+    const wrapper = mount(TimePicker, {
+      props: { status: 'warning' },
+    })
+    expect(wrapper.find('.ant-picker-status-warning').exists()).toBe(true)
+  })
+
+  // ====================== Value & Format ======================
+  it('should display value', () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        value: dayjs('12:30:00', 'HH:mm:ss'),
+        format: 'HH:mm:ss',
+      },
+    })
+    expect(wrapper.find('input').element.value).toBe('12:30:00')
+  })
+
+  it('should support defaultValue', () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        defaultValue: dayjs('08:15:00', 'HH:mm:ss'),
+        format: 'HH:mm:ss',
+      },
+    })
+    expect(wrapper.find('input').element.value).toBe('08:15:00')
+  })
+
+  it('should support custom format', () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        value: dayjs('14:30:00', 'HH:mm:ss'),
+        format: 'HH:mm',
+      },
+    })
+    expect(wrapper.find('input').element.value).toBe('14:30')
+  })
+
+  // ====================== AllowClear ======================
+  it('should show clear icon when value exists', () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        value: dayjs('12:00:00', 'HH:mm:ss'),
+      },
+    })
+    expect(wrapper.find('.ant-picker-clear').exists()).toBe(true)
+  })
+
+  it('should hide clear icon when allowClear=false', () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        value: dayjs('12:00:00', 'HH:mm:ss'),
+        allowClear: false,
+      },
+    })
+    expect(wrapper.find('.ant-picker-clear').exists()).toBe(false)
+  })
+
+  it('should support custom clear icon', () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        value: dayjs('12:00:00', 'HH:mm:ss'),
+        allowClear: { clearIcon: <span data-testid="custom-clear">x</span> },
+      },
+    })
+    expect(wrapper.find('[data-testid="custom-clear"]').exists()).toBe(true)
+  })
+
+  // ====================== Open / Popup ======================
+  it('should open popup when open=true', async () => {
+    const wrapper = mount(TimePicker, {
+      props: { open: true },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(document.querySelector('.ant-picker-dropdown')).toBeTruthy()
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  it('should render time columns in popup', async () => {
+    const wrapper = mount(TimePicker, {
+      props: { open: true },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    const columns = document.querySelectorAll('.ant-picker-time-panel-column')
+    // Default: hour, minute, second
+    expect(columns.length).toBe(3)
+    expect(columns[0]?.querySelectorAll('.ant-picker-time-panel-cell').length).toBe(24)
+    expect(columns[1]?.querySelectorAll('.ant-picker-time-panel-cell').length).toBe(60)
+    expect(columns[2]?.querySelectorAll('.ant-picker-time-panel-cell').length).toBe(60)
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  it('should support showHour/showMinute/showSecond', async () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        open: true,
+        showHour: true,
+        showMinute: true,
+        showSecond: false,
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    const columns = document.querySelectorAll('.ant-picker-time-panel-column')
+    expect(columns.length).toBe(2)
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  it('should support use12Hours', async () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        open: true,
+        use12Hours: true,
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    const columns = document.querySelectorAll('.ant-picker-time-panel-column')
+    // 12-hour mode: hour(12), minute(60), second(60), AM/PM(2)
+    expect(columns.length).toBe(4)
+    expect(columns[0]?.querySelectorAll('.ant-picker-time-panel-cell').length).toBe(12)
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  // ====================== Events ======================
+  it('should support controlled open prop', async () => {
+    const open = ref(false)
+    const wrapper = mount(() => (
+      <TimePicker open={open.value} />
+    ), {
+      attachTo: document.body,
+    })
+
+    expect(document.querySelector('.ant-picker-dropdown')).toBeFalsy()
+
+    open.value = true
+    await nextTick()
+    expect(document.querySelector('.ant-picker-dropdown')).toBeTruthy()
+
+    open.value = false
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  it('should emit focus and blur', async () => {
+    const onFocus = vi.fn()
+    const onBlur = vi.fn()
+    const wrapper = mount(TimePicker, {
+      props: { onFocus, onBlur },
+      attachTo: document.body,
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+    expect(onFocus).toHaveBeenCalled()
+
+    await input.trigger('blur')
+    await nextTick()
+    expect(onBlur).toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  // ====================== RenderExtraFooter / Addon ======================
+  it('should support renderExtraFooter slot', async () => {
+    const wrapper = mount(TimePicker, {
+      props: { open: true },
+      slots: {
+        renderExtraFooter: () => <span class="custom-footer">Extra</span>,
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(document.querySelector('.custom-footer')).toBeTruthy()
+    expect(document.querySelector('.custom-footer')?.textContent).toBe('Extra')
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  it('should support renderExtraFooter as prop', async () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        open: true,
+        renderExtraFooter: () => <span class="prop-footer">PropFooter</span>,
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(document.querySelector('.prop-footer')).toBeTruthy()
+    expect(document.querySelector('.prop-footer')?.textContent).toBe('PropFooter')
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  it('should support addon prop (deprecated)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    resetWarned()
+
+    const wrapper = mount(TimePicker, {
+      props: { open: true, addon: () => <span class="addon-prop">AddonProp</span> },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(document.querySelector('.addon-prop')).toBeTruthy()
+
+    errSpy.mockRestore()
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  it('should support addon as slot (deprecated)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    resetWarned()
+
+    const wrapper = mount(TimePicker, {
+      props: { open: true },
+      slots: {
+        addon: () => <span class="addon-slot">AddonSlot</span>,
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(document.querySelector('.addon-slot')).toBeTruthy()
+
+    errSpy.mockRestore()
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  it('should prioritize renderExtraFooter slot over addon', async () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        open: true,
+        addon: () => <span class="addon-content">Addon</span>,
+      },
+      slots: {
+        renderExtraFooter: () => <span class="footer-slot">FooterSlot</span>,
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    // renderExtraFooter slot wins
+    expect(document.querySelector('.footer-slot')).toBeTruthy()
+    expect(document.querySelector('.addon-content')).toBeFalsy()
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  // ====================== Expose ======================
+  it('should expose focus and blur methods', async () => {
+    const wrapper = mount(TimePicker, {
+      attachTo: document.body,
+    })
+
+    const vm = wrapper.vm as any
+    expect(typeof vm.focus).toBe('function')
+    expect(typeof vm.blur).toBe('function')
+
+    wrapper.unmount()
+  })
+
+  // ====================== Variant / Bordered ======================
+  it('should support variant=filled', () => {
+    const wrapper = mount(TimePicker, {
+      props: { variant: 'filled' },
+    })
+    expect(wrapper.find('.ant-picker-filled').exists()).toBe(true)
+  })
+
+  it('should support variant=borderless', () => {
+    const wrapper = mount(TimePicker, {
+      props: { variant: 'borderless' },
+    })
+    expect(wrapper.find('.ant-picker-borderless').exists()).toBe(true)
+  })
+
+  it('should support bordered=false (deprecated)', () => {
+    const wrapper = mount(TimePicker, {
+      props: { bordered: false },
+    })
+    expect(wrapper.find('.ant-picker-borderless').exists()).toBe(true)
+  })
+
+  // ====================== Deprecated popupClassName ======================
+  it('should apply deprecated popupClassName', async () => {
+    resetWarned()
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const wrapper = mount(TimePicker, {
+      props: { open: true, popupClassName: 'legacy-popup' },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(document.querySelector('.legacy-popup')).toBeTruthy()
+
+    errSpy.mockRestore()
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    wrapper.unmount()
+  })
+
+  // ====================== Suffix Icon ======================
+  it('should support suffixIcon slot', () => {
+    const wrapper = mount(TimePicker, {
+      slots: {
+        suffixIcon: () => <span data-testid="custom-suffix">icon</span>,
+      },
+    })
+    expect(wrapper.find('[data-testid="custom-suffix"]').exists()).toBe(true)
+  })
+
+  // ====================== ID Passthrough ======================
+  it('should pass id to input', () => {
+    const wrapper = mount(TimePicker, {
+      props: { id: 'my-time-picker' },
+    })
+    expect(wrapper.find('input').attributes('id')).toBe('my-time-picker')
+  })
+
+  // ====================== RTL ======================
+  it('should render correctly in RTL direction', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider direction="rtl">
+        <TimePicker />
+      </ConfigProvider>
+    ))
+    expect(wrapper.find('.ant-picker-rtl').exists()).toBe(true)
+  })
+
+  // ====================== ConfigProvider Size ======================
+  it('should inherit size from ConfigProvider', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider componentSize="large">
+        <TimePicker />
+      </ConfigProvider>
+    ))
+    expect(wrapper.find('.ant-picker-large').exists()).toBe(true)
+  })
+
+  // ====================== Snapshot ======================
+  it('should match snapshot', () => {
+    const wrapper = mount(TimePicker, {
+      props: {
+        value: dayjs('12:30:00', 'HH:mm:ss'),
+        format: 'HH:mm:ss',
+      },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  // ====================== RangePicker ======================
+  describe('range-picker', () => {
+    it('should render correctly', () => {
+      const wrapper = mount(RangePicker)
+      expect(wrapper.find('.ant-picker-range').exists()).toBe(true)
+    })
+
+    it('should have default placeholders', () => {
+      const wrapper = mount(RangePicker)
+      const inputs = wrapper.findAll('input')
+      expect(inputs[0]?.attributes('placeholder')).toBe('Start time')
+      expect(inputs[1]?.attributes('placeholder')).toBe('End time')
+    })
+
+    it('should support disabled', () => {
+      const wrapper = mount(RangePicker, {
+        props: { disabled: true },
+      })
+      expect(wrapper.find('.ant-picker-disabled').exists()).toBe(true)
+    })
+
+    it('should support size variants', () => {
+      const wrapper = mount(RangePicker, {
+        props: { size: 'small' },
+      })
+      expect(wrapper.find('.ant-picker-small').exists()).toBe(true)
+    })
+
+    it('should support status=error', () => {
+      const wrapper = mount(RangePicker, {
+        props: { status: 'error' },
+      })
+      expect(wrapper.find('.ant-picker-status-error').exists()).toBe(true)
+    })
+
+    it('should display range values', () => {
+      const wrapper = mount(RangePicker, {
+        props: {
+          value: [dayjs('08:00:00', 'HH:mm:ss'), dayjs('18:00:00', 'HH:mm:ss')],
+          format: 'HH:mm:ss',
+        },
+      })
+      const inputs = wrapper.findAll('input')
+      expect(inputs[0]?.element.value).toBe('08:00:00')
+      expect(inputs[1]?.element.value).toBe('18:00:00')
+    })
+
+    it('should open popup when open=true', async () => {
+      const wrapper = mount(RangePicker, {
+        props: { open: true },
+        attachTo: document.body,
+      })
+      await nextTick()
+
+      expect(document.querySelector('.ant-picker-dropdown')).toBeTruthy()
+
+      await wrapper.setProps({ open: false })
+      await nextTick()
+      wrapper.unmount()
+    })
+
+    it('should support controlled open', async () => {
+      const onOpenChange = vi.fn()
+      const open = ref(false)
+      const wrapper = mount(() => (
+        <RangePicker
+          open={open.value}
+          onOpenChange={(v: boolean) => {
+            open.value = v
+            onOpenChange(v)
+          }}
+        />
+      ), {
+        attachTo: document.body,
+      })
+
+      open.value = true
+      await nextTick()
+      // Verify open state applies
+      expect(document.querySelector('.ant-picker-dropdown')).toBeTruthy()
+
+      open.value = false
+      await nextTick()
+      wrapper.unmount()
+    })
+
+    it('should support variant=filled', () => {
+      const wrapper = mount(RangePicker, {
+        props: { variant: 'filled' },
+      })
+      expect(wrapper.find('.ant-picker-filled').exists()).toBe(true)
+    })
+
+    it('should render correctly in RTL', () => {
+      const wrapper = mount(() => (
+        <ConfigProvider direction="rtl">
+          <RangePicker />
+        </ConfigProvider>
+      ))
+      expect(wrapper.find('.ant-picker-rtl').exists()).toBe(true)
+    })
+
+    it('should apply deprecated popupClassName', async () => {
+      resetWarned()
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const wrapper = mount(RangePicker, {
+        props: { open: true, popupClassName: 'legacy-range-popup' },
+        attachTo: document.body,
+      })
+      await nextTick()
+
+      expect(document.querySelector('.legacy-range-popup')).toBeTruthy()
+
+      errSpy.mockRestore()
+      await wrapper.setProps({ open: false })
+      await nextTick()
+      wrapper.unmount()
+    })
+
+    it('should expose focus and blur methods', async () => {
+      const wrapper = mount(RangePicker, {
+        attachTo: document.body,
+      })
+
+      const vm = wrapper.vm as any
+      expect(typeof vm.focus).toBe('function')
+      expect(typeof vm.blur).toBe('function')
+
+      wrapper.unmount()
+    })
+
+    it('should support status=warning', () => {
+      const wrapper = mount(RangePicker, {
+        props: { status: 'warning' },
+      })
+      expect(wrapper.find('.ant-picker-status-warning').exists()).toBe(true)
+    })
+
+    it('should support variant=borderless', () => {
+      const wrapper = mount(RangePicker, {
+        props: { variant: 'borderless' },
+      })
+      expect(wrapper.find('.ant-picker-borderless').exists()).toBe(true)
+    })
+
+    it('should match snapshot', () => {
+      const wrapper = mount(RangePicker, {
+        props: {
+          value: [dayjs('08:00:00', 'HH:mm:ss'), dayjs('18:00:00', 'HH:mm:ss')],
+          format: 'HH:mm:ss',
+        },
+      })
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/antdv-next/src/time-picker/tests/__snapshots__/TimePicker.test.tsx.snap
+++ b/packages/antdv-next/src/time-picker/tests/__snapshots__/TimePicker.test.tsx.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`time-picker > range-picker > should match snapshot 1`] = `
+"<div class="ant-picker ant-picker-range ant-picker-outlined css-var-root ant-picker-css-var">
+  <!---->
+  <div class="ant-picker-input ant-picker-input-start"><input aria-invalid="false" class="ant-picker-input-start" data-range="start" size="10" placeholder="Start time" value="08:00:00">
+    <!---->
+    <!---->
+  </div>
+  <div class="ant-picker-range-separator"><span aria-label="to" class="ant-picker-separator"><span role="img" aria-label="swap-right" class="anticon anticon-swap-right"><svg data-icon="swap-right" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="0 0 1024 1024" focusable="false"><path d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"></path></svg></span></span></div>
+  <div class="ant-picker-input ant-picker-input-end"><input aria-invalid="false" class="ant-picker-input-end" data-range="end" size="10" placeholder="End time" value="18:00:00">
+    <!---->
+    <!---->
+  </div>
+  <div class="ant-picker-active-bar" style="position: absolute; width: 0px;"></div><span class="ant-picker-suffix"><span role="img" aria-label="clock-circle" class="anticon anticon-clock-circle"><svg data-icon="clock-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896" focusable="false"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"></path></svg></span>
+  <!----></span><span role="button" class="ant-picker-clear"><span role="img" aria-label="close-circle" class="anticon anticon-close-circle"><svg data-icon="close-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" fill-rule="evenodd" viewBox="64 64 896 896" focusable="false"><path d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"></path></svg></span></span>
+</div>"
+`;
+
+exports[`time-picker > should match snapshot 1`] = `
+"<div class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var">
+  <!---->
+  <div class="ant-picker-input"><input aria-invalid="false" aria-required="false" size="10" placeholder="Select time" value="12:30:00"><span class="ant-picker-suffix"><span role="img" aria-label="clock-circle" class="anticon anticon-clock-circle"><svg data-icon="clock-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896" focusable="false"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"></path></svg></span>
+    <!----></span><span role="button" class="ant-picker-clear"><span role="img" aria-label="close-circle" class="anticon anticon-close-circle"><svg data-icon="close-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" fill-rule="evenodd" viewBox="64 64 896 896" focusable="false"><path d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"></path></svg></span></span>
+  </div>
+</div>"
+`;

--- a/packages/antdv-next/src/time-picker/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/time-picker/tests/__snapshots__/demo.test.tsx.snap
@@ -1,0 +1,3703 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`time-picker demo > renders _semantic correctly 1`] = `
+<div
+  class="semantic-preview-container"
+  data-v-dfc8ebef=""
+>
+  <div
+    class="ant-row css-var-root semantic-preview-row"
+    data-v-dfc8ebef=""
+  >
+    <div
+      class="ant-col ant-col-16 css-var-root semantic-preview-col"
+      data-v-dfc8ebef=""
+    >
+      <div
+        class="ant-flex css-var-v-0 ant-flex-align-center ant-flex-gap-middle ant-flex-vertical"
+        style="align-self: flex-start;"
+      >
+        <div
+          aria-label="segmented control"
+          class="ant-segmented css-var-v-0 css-var-v-0"
+          role="radiogroup"
+          size="middle"
+          tabindex="0"
+        >
+          <div
+            class="ant-segmented-group"
+          >
+            <!---->
+            <label
+              class="ant-segmented-item ant-segmented-item-selected"
+            >
+              <input
+                checked=""
+                class="ant-segmented-item-input"
+                name="v-1"
+                type="radio"
+              />
+              <div
+                aria-checked="true"
+                class="ant-segmented-item-label"
+                role="radio"
+                title="Single"
+              >
+                Single
+              </div>
+            </label>
+            <label
+              class="ant-segmented-item"
+            >
+              <input
+                class="ant-segmented-item-input"
+                name="v-1"
+                type="radio"
+              />
+              <div
+                aria-checked="false"
+                class="ant-segmented-item-label"
+                role="radio"
+                title="Multiple"
+              >
+                Multiple
+              </div>
+            </label>
+          </div>
+        </div>
+        <div
+          class="ant-picker ant-picker-outlined css-var-v-0 ant-picker-css-var semantic-mark-root"
+        >
+          <!---->
+          <div
+            class="ant-picker-input"
+          >
+            <input
+              aria-invalid="false"
+              aria-required="false"
+              class="semantic-mark-input"
+              placeholder="Select time"
+              size="10"
+              value=""
+            />
+            <span
+              class="ant-picker-suffix semantic-mark-suffix"
+            >
+              <span
+                aria-label="clock-circle"
+                class="anticon anticon-clock-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="clock-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                  />
+                  <path
+                    d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+                  />
+                </svg>
+              </span>
+              <!---->
+            </span>
+            <!---->
+          </div>
+        </div>
+        <!---->
+      </div>
+    </div>
+    <div
+      class="ant-col ant-col-8 css-var-root"
+      data-v-dfc8ebef=""
+    >
+      <ul
+        class="semantic-list"
+        data-v-dfc8ebef=""
+      >
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  root
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for time picker container
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  prefix
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Prefix element with flex layout and margin styles for prefix content layout
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  input
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  suffix
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup.root
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Popup element
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup.container
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Container element, set background color, padding, border radius, shadow, border and content display styles
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup.content
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Popup content element with width, border, cell and other content display styles for time list
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup.item
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for time cells
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+        <li
+          class="semantic-list-item"
+          data-v-dfc8ebef=""
+        >
+          <div
+            class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            data-v-dfc8ebef=""
+          >
+            <div
+              class="ant-flex css-var-root ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+              data-v-dfc8ebef=""
+            >
+              <!-- Title + Version -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <h5
+                  class="ant-typography css-var-root"
+                  style="margin: 0px;"
+                >
+                  popup.footer
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </h5>
+                <!--v-if-->
+              </div>
+              <!-- Pin + Sample -->
+              <div
+                class="ant-flex css-var-root ant-flex-align-center ant-flex-gap-small"
+                data-v-dfc8ebef=""
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <button
+                  class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  data-v-dfc8ebef=""
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      data-v-dfc8ebef=""
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <!---->
+                  <!---->
+                </button>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-root"
+              style="margin: 0px; font-size: 12px;"
+            >
+              Popup footer element with layout styles for bottom operation area including confirm/cancel buttons
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`time-picker demo > renders 12hours correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+  style="flex-wrap: wrap;"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="12"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="11"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="10"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders addon correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        placeholder="Select time"
+        size="10"
+        value=""
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders basic correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        placeholder="Select time"
+        size="10"
+        value=""
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders change-on-scroll correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        placeholder="Select time"
+        size="10"
+        value=""
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders colored-popup correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        placeholder="Select time"
+        size="10"
+        value=""
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders disabled correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-picker ant-picker-disabled ant-picker-outlined css-var-root ant-picker-css-var"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        disabled=""
+        placeholder="Select time"
+        size="10"
+        value="12:08:23"
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders hide-column correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        placeholder="Select time"
+        size="10"
+        value="12:08"
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <span
+        class="ant-picker-clear"
+        role="button"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders interval-options correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        placeholder="Select time"
+        size="10"
+        value=""
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders need-confirm correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        placeholder="Select time"
+        size="10"
+        value=""
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders range-picker correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-picker ant-picker-range ant-picker-outlined css-var-root ant-picker-css-var"
+  >
+    <!---->
+    <div
+      class="ant-picker-input ant-picker-input-start"
+    >
+      <input
+        aria-invalid="false"
+        class="ant-picker-input-start"
+        data-range="start"
+        placeholder="Start time"
+        size="10"
+        value="12:08:23"
+      />
+      <!---->
+      <!---->
+    </div>
+    <div
+      class="ant-picker-range-separator"
+    >
+      <span
+        aria-label="to"
+        class="ant-picker-separator"
+      >
+        <span
+          aria-label="swap-right"
+          class="anticon anticon-swap-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="swap-right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 1024 1024"
+            width="1em"
+          >
+            <path
+              d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+    <div
+      class="ant-picker-input ant-picker-input-end"
+    >
+      <input
+        aria-invalid="false"
+        class="ant-picker-input-end"
+        data-range="end"
+        placeholder="End time"
+        size="10"
+        value="12:08:23"
+      />
+      <!---->
+      <!---->
+    </div>
+    <div
+      class="ant-picker-active-bar"
+      style="position: absolute; width: 0px;"
+    />
+    <span
+      class="ant-picker-suffix"
+    >
+      <span
+        aria-label="clock-circle"
+        class="anticon anticon-clock-circle"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="clock-circle"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+          />
+          <path
+            d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+          />
+        </svg>
+      </span>
+      <!---->
+    </span>
+    <span
+      class="ant-picker-clear"
+      role="button"
+    >
+      <span
+        aria-label="close-circle"
+        class="anticon anticon-close-circle"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close-circle"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+          />
+        </svg>
+      </span>
+    </span>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders render-panel correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    style="padding-bottom: 0px; position: relative; min-width: 0px;"
+  >
+    <div
+      class="ant-picker ant-picker-outlined css-var-v-0 ant-picker-css-var"
+      style="margin: 0px;"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="10"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`time-picker demo > renders size correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+  style="flex-wrap: wrap;"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-large ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="10"
+          value="12:08:23"
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <span
+          class="ant-picker-clear"
+          role="button"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-circle"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="10"
+          value="12:08:23"
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <span
+          class="ant-picker-clear"
+          role="button"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-circle"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-small ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="10"
+          value="12:08:23"
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <span
+          class="ant-picker-clear"
+          role="button"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-circle"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders status correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-outlined ant-picker-status-error css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="10"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-outlined ant-picker-status-warning css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="10"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-range ant-picker-outlined ant-picker-status-error css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input ant-picker-input-start"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-start"
+          data-range="start"
+          placeholder="Start time"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-range-separator"
+      >
+        <span
+          aria-label="to"
+          class="ant-picker-separator"
+        >
+          <span
+            aria-label="swap-right"
+            class="anticon anticon-swap-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="swap-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-picker-input ant-picker-input-end"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-end"
+          data-range="end"
+          placeholder="End time"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-active-bar"
+        style="position: absolute; width: 0px;"
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-range ant-picker-outlined ant-picker-status-warning css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input ant-picker-input-start"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-start"
+          data-range="start"
+          placeholder="Start time"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-range-separator"
+      >
+        <span
+          aria-label="to"
+          class="ant-picker-separator"
+        >
+          <span
+            aria-label="swap-right"
+            class="anticon anticon-swap-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="swap-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-picker-input ant-picker-input-end"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-end"
+          data-range="end"
+          placeholder="End time"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-active-bar"
+        style="position: absolute; width: 0px;"
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+    <!---->
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders style-class correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+  data-v-854379e5=""
+>
+  <div
+    class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var custom-timepicker-root"
+    style="border-color: rgb(217, 217, 217);"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        placeholder="Object"
+        size="10"
+        value=""
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <div
+    class="ant-picker ant-picker-large ant-picker-outlined css-var-root ant-picker-css-var custom-timepicker-root"
+    style="border-color: rgb(114, 46, 209);"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        placeholder="Function"
+        size="10"
+        value=""
+      />
+      <span
+        class="ant-picker-suffix"
+        style="color: rgb(114, 46, 209);"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders suffix correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical css-var-root"
+  style="column-gap: 12px; row-gap: 12px;"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="10"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="smile"
+            class="anticon anticon-smile"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="smile"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+              />
+            </svg>
+          </span>
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Select time"
+          size="10"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-picker ant-picker-range ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input ant-picker-input-start"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-start"
+          data-range="start"
+          placeholder="Start time"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-range-separator"
+      >
+        <span
+          aria-label="to"
+          class="ant-picker-separator"
+        >
+          <span
+            aria-label="swap-right"
+            class="anticon anticon-swap-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="swap-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-picker-input ant-picker-input-end"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-end"
+          data-range="end"
+          placeholder="End time"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-active-bar"
+        style="position: absolute; width: 0px;"
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+    <!---->
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders value correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+  >
+    <!---->
+    <div
+      class="ant-picker-input"
+    >
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        placeholder="Select time"
+        size="10"
+        value=""
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders value-format correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical css-var-root"
+  style="column-gap: 12px; row-gap: 12px;"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+        >
+          <!---->
+          <div
+            class="ant-picker-input"
+          >
+            <input
+              aria-invalid="false"
+              aria-required="false"
+              placeholder="Select time"
+              size="10"
+              value="12:08:23"
+            />
+            <span
+              class="ant-picker-suffix"
+            >
+              <span
+                aria-label="clock-circle"
+                class="anticon anticon-clock-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="clock-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                  />
+                  <path
+                    d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+                  />
+                </svg>
+              </span>
+              <!---->
+            </span>
+            <span
+              class="ant-picker-clear"
+              role="button"
+            >
+              <span
+                aria-label="close-circle"
+                class="anticon anticon-close-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close-circle"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+        <!---->
+      </div>
+      <!---->
+      <div
+        class="ant-space-item"
+      >
+        <span>
+          value: 12:08:23
+        </span>
+      </div>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class="ant-picker ant-picker-range ant-picker-outlined css-var-root ant-picker-css-var"
+        >
+          <!---->
+          <div
+            class="ant-picker-input ant-picker-input-start"
+          >
+            <input
+              aria-invalid="false"
+              class="ant-picker-input-start"
+              data-range="start"
+              placeholder="Start time"
+              size="10"
+              value="09:30:00"
+            />
+            <!---->
+            <!---->
+          </div>
+          <div
+            class="ant-picker-range-separator"
+          >
+            <span
+              aria-label="to"
+              class="ant-picker-separator"
+            >
+              <span
+                aria-label="swap-right"
+                class="anticon anticon-swap-right"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="swap-right"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+          <div
+            class="ant-picker-input ant-picker-input-end"
+          >
+            <input
+              aria-invalid="false"
+              class="ant-picker-input-end"
+              data-range="end"
+              placeholder="End time"
+              size="10"
+              value="18:00:00"
+            />
+            <!---->
+            <!---->
+          </div>
+          <div
+            class="ant-picker-active-bar"
+            style="position: absolute; width: 0px;"
+          />
+          <span
+            class="ant-picker-suffix"
+          >
+            <span
+              aria-label="clock-circle"
+              class="anticon anticon-clock-circle"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="clock-circle"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                />
+                <path
+                  d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+                />
+              </svg>
+            </span>
+            <!---->
+          </span>
+          <span
+            class="ant-picker-clear"
+            role="button"
+          >
+            <span
+              aria-label="close-circle"
+              class="anticon anticon-close-circle"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close-circle"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <!---->
+      </div>
+      <!---->
+      <div
+        class="ant-space-item"
+      >
+        <span>
+          value: 09:30:00 ~ 18:00:00
+        </span>
+      </div>
+      <!---->
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`time-picker demo > renders variant correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-vertical"
+  style="gap: 12px;"
+>
+  <div
+    class="ant-flex css-var-root"
+    style="gap: 8px;"
+  >
+    <div
+      class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Outlined"
+          size="10"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+    <div
+      class="ant-picker ant-picker-range ant-picker-outlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input ant-picker-input-start"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-start"
+          data-range="start"
+          placeholder="Outlined Start"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-range-separator"
+      >
+        <span
+          aria-label="to"
+          class="ant-picker-separator"
+        >
+          <span
+            aria-label="swap-right"
+            class="anticon anticon-swap-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="swap-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-picker-input ant-picker-input-end"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-end"
+          data-range="end"
+          placeholder="Outlined End"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-active-bar"
+        style="position: absolute; width: 0px;"
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+    <!---->
+  </div>
+  <div
+    class="ant-flex css-var-root"
+    style="gap: 8px;"
+  >
+    <div
+      class="ant-picker ant-picker-filled css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Filled"
+          size="10"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+    <div
+      class="ant-picker ant-picker-range ant-picker-filled css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input ant-picker-input-start"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-start"
+          data-range="start"
+          placeholder="Filled Start"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-range-separator"
+      >
+        <span
+          aria-label="to"
+          class="ant-picker-separator"
+        >
+          <span
+            aria-label="swap-right"
+            class="anticon anticon-swap-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="swap-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-picker-input ant-picker-input-end"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-end"
+          data-range="end"
+          placeholder="Filled End"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-active-bar"
+        style="position: absolute; width: 0px;"
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+    <!---->
+  </div>
+  <div
+    class="ant-flex css-var-root"
+    style="gap: 8px;"
+  >
+    <div
+      class="ant-picker ant-picker-borderless css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Borderless"
+          size="10"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+    <div
+      class="ant-picker ant-picker-range ant-picker-borderless css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input ant-picker-input-start"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-start"
+          data-range="start"
+          placeholder="Borderless Start"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-range-separator"
+      >
+        <span
+          aria-label="to"
+          class="ant-picker-separator"
+        >
+          <span
+            aria-label="swap-right"
+            class="anticon anticon-swap-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="swap-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-picker-input ant-picker-input-end"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-end"
+          data-range="end"
+          placeholder="Borderless End"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-active-bar"
+        style="position: absolute; width: 0px;"
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+    <!---->
+  </div>
+  <div
+    class="ant-flex css-var-root"
+    style="gap: 8px;"
+  >
+    <div
+      class="ant-picker ant-picker-underlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          placeholder="Underlined"
+          size="10"
+          value=""
+        />
+        <span
+          class="ant-picker-suffix"
+        >
+          <span
+            aria-label="clock-circle"
+            class="anticon anticon-clock-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="clock-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+              />
+            </svg>
+          </span>
+          <!---->
+        </span>
+        <!---->
+      </div>
+    </div>
+    <!---->
+    <div
+      class="ant-picker ant-picker-range ant-picker-underlined css-var-root ant-picker-css-var"
+    >
+      <!---->
+      <div
+        class="ant-picker-input ant-picker-input-start"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-start"
+          data-range="start"
+          placeholder="Underlined Start"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-range-separator"
+      >
+        <span
+          aria-label="to"
+          class="ant-picker-separator"
+        >
+          <span
+            aria-label="swap-right"
+            class="anticon anticon-swap-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="swap-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-picker-input ant-picker-input-end"
+      >
+        <input
+          aria-invalid="false"
+          class="ant-picker-input-end"
+          data-range="end"
+          placeholder="Underlined End"
+          size="10"
+          value=""
+        />
+        <!---->
+        <!---->
+      </div>
+      <div
+        class="ant-picker-active-bar"
+        style="position: absolute; width: 0px;"
+      />
+      <span
+        class="ant-picker-suffix"
+      >
+        <span
+          aria-label="clock-circle"
+          class="anticon anticon-clock-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="clock-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+        </span>
+        <!---->
+      </span>
+      <!---->
+    </div>
+    <!---->
+  </div>
+</div>
+`;

--- a/packages/antdv-next/src/time-picker/tests/demo.test.tsx
+++ b/packages/antdv-next/src/time-picker/tests/demo.test.tsx
@@ -1,0 +1,3 @@
+import demoTest from '/@tests/shared/demoTest'
+
+demoTest('time-picker')


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ✅ Test Case

### 🔗 Related Issues

close #63 (TimePicker part)

### 💡 Background and Solution

Add comprehensive unit tests for TimePicker and TimeRangePicker components as part of the unit test coverage initiative (Issue #63).

**Test files:**
- `TimePicker.test.tsx` — 50 tests covering:
  - Basic rendering, placeholders, size variants (small/large)
  - Disabled state, status (error/warning)
  - Value display, defaultValue, custom format
  - AllowClear with custom clear icon
  - Popup open/close, time column rendering
  - showHour/showMinute/showSecond, use12Hours mode
  - Controlled open prop, focus/blur events
  - renderExtraFooter (slot + prop), deprecated addon (slot + prop)
  - Slot priority (renderExtraFooter over addon)
  - Expose methods (focus/blur)
  - Variant styles (filled/borderless), deprecated bordered prop
  - Deprecated popupClassName, custom suffixIcon, id passthrough
  - RTL direction, ConfigProvider size inheritance
  - Snapshot tests for both TimePicker and RangePicker
  - RangePicker: rendering, placeholders, disabled, size, status, value display, popup, controlled open, variants, RTL, deprecated popupClassName, expose methods
- `TimePicker.semantic.test.tsx` — 4 tests covering:
  - Semantic classes and styles (object form)
  - Semantic classes as function (dynamic based on props)
  - ConfigProvider context merging
  - RangePicker semantic customization
- `demo.test.tsx` — 19 demo snapshot tests

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add unit tests for TimePicker component |
| 🇨🇳 Chinese | 为 TimePicker 组件添加单元测试 |