### PR TITLE
fix: remove duplicate initMotionCommonLeave function

### DIFF
--- a/packages/antdv-next/src/style/motion/motion.ts
+++ b/packages/antdv-next/src/style/motion/motion.ts
@@ -20,6 +20,7 @@ export function initMotion(motionCls: string, inKeyframes: Keyframes, outKeyfram
     },
 
     [`${sameLevelPrefix}${motionCls}-leave`]: {
+      ...initMotionCommon(duration),
       animationPlayState: 'paused',
     },
 


### PR DESCRIPTION
(#57118)

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - FIXME comment in components/style/motion/motion.ts

### 💡 Background and Solution

initMotionCommonLeave was identical to initMotionCommon (as noted by the existing FIXME comment). Removed the duplicate and unified both enter and leave motion to use initMotionCommon.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove duplicate initMotionCommonLeave function, reuse initMotionCommon for both enter and leave motion. |
| 🇨🇳 Chinese |移除重复的 initMotionCommonLeave 函数，enter 和 leave 动画统一使用 initMotionCommon。|
