### PR TITLE
fix(modal): add KeyboardEvent support to onCancel type

### DIFF
--- a/packages/antdv-next/src/modal/Modal.tsx
+++ b/packages/antdv-next/src/modal/Modal.tsx
@@ -1,3 +1,4 @@
+import type { DialogProps } from '@v-c/dialog'
 import type { SlotsType } from 'vue'
 import type { Breakpoint } from '../_util/responsiveObserver'
 import type { ModalClassNamesType, ModalEmits, ModalProps, ModalSlots, ModalStylesType, MousePosition } from './interface'
@@ -132,7 +133,7 @@ const Modal = defineComponent<
       closableContext.value?.[1]?.()
     }
 
-    const handleCancel = (e: MouseEvent) => {
+    const handleCancel = (e: MouseEvent | KeyboardEvent) => {
       if (props.confirmLoading) {
         return
       }
@@ -360,7 +361,7 @@ const Modal = defineComponent<
               title={titleNode}
               visible={props.open}
               mousePosition={props.mousePosition ?? mousePosition}
-              onClose={handleCancel as any}
+              onClose={handleCancel as DialogProps['onClose']}
               closable={mergedClosable as any}
               closeIcon={mergedCloseIcon}
               focusTriggerAfterClose={mergedFocusable.value?.focusTriggerAfterClose}

--- a/packages/antdv-next/src/modal/interface.ts
+++ b/packages/antdv-next/src/modal/interface.ts
@@ -127,8 +127,8 @@ export interface ModalProps extends ModalCommonProps {
 export interface ModalEmits {
   /** Specify a function that will be called when a user clicks the OK button */
   'ok': (e: MouseEvent) => void
-  /** Specify a function that will be called when a user clicks mask, close button on top right or Cancel button */
-  'cancel': (e: MouseEvent) => void
+  /** Specify a function that will be called when a user clicks mask, close button on top right or Cancel button, or presses Esc key */
+  'cancel': (e: MouseEvent | KeyboardEvent) => void
   'update:open': (open: boolean) => void
 }
 

--- a/packages/antdv-next/src/modal/shared.tsx
+++ b/packages/antdv-next/src/modal/shared.tsx
@@ -25,7 +25,7 @@ export interface FooterProps
     'footer' | 'okText' | 'okType' | 'cancelText' | 'confirmLoading' | 'okButtonProps' | 'cancelButtonProps'
   > {
   onOk?: ModalEmits['ok']
-  onCancel?: ModalEmits['cancel']
+  onCancel?: ModalEmits['cancel'] // aligned with ModalEmits to support MouseEvent | KeyboardEvent
 }
 
 export const Footer = defineComponent<


### PR DESCRIPTION
Sync with ant-design/ant-design#57048

- Update ModalEmits.cancel to accept MouseEvent | KeyboardEvent
- Update handleCancel parameter type accordingly
- Replace s any cast with s DialogProps['onClose'] for type safety
- Align FooterProps.onCancel with ModalEmits['cancel']

Fixes: pressing Escape key caused type mismatch because @v-c/dialog's onClose emits a KeyboardEvent while onCancel was only typed for MouseEvent.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
同步 https://github.com/antdv-next/antdv-next/issues/317 onCancel 类型支持 KeyboardEvent

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

The onCancel callback in ModalProps was typed as (e: React.MouseEvent<HTMLButtonElement>) => void, but pressing the Escape key triggers a KeyboardEvent via @rc-component/dialog's onClose (typed as (e: SyntheticEvent | KeyboardEvent) => any). This caused a type mismatch — users handling keyboard events in the callback would get TypeScript errors.

### 📝 Change Log

> - components/modal/interface.ts: Update onCancel type to (e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLElement>) => void
> - components/modal/Modal.tsx: Update handleCancel parameter type to match; replace as any cast with as DialogProps['onClose']
> - components/modal/shared.tsx: Align FooterProps.onCancel with ModalProps['onCancel']
> - Demos & tests: Update explicit MouseEvent type annotations in demos and tests to align with the new signature

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Modal onCancel now correctly types the event parameter as React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLElement> to support Escape key dismissal.|
| 🇨🇳 Chinese |Modal onCancel 事件参数类型现在正确支持 React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLElement>，以适配 Esc 键关闭场景。|
