### PR TITLE
fix(splitter): fix incorrect size calculation when partially controlled

### DIFF
--- a/packages/antdv-next/src/splitter/hooks/useSizes.ts
+++ b/packages/antdv-next/src/splitter/hooks/useSizes.ts
@@ -32,7 +32,6 @@ export default function useSizes(items: Ref<PanelProps[]>, containerSize?: Ref<n
 
   const sizes = computed(() => {
     const currentCount = itemsCount.value
-    const mergedSizes: PanelProps['size'][] = []
 
     // Initialize or re-initialize innerSizes when items count changes
     // This happens on first render or when panels are added/removed
@@ -41,11 +40,12 @@ export default function useSizes(items: Ref<PanelProps[]>, containerSize?: Ref<n
       innerSizes.value = items.value?.map(item => item.defaultSize)
     }
 
-    for (let i = 0; i < currentCount; i += 1) {
-      mergedSizes[i] = propSizes.value?.[i] ?? innerSizes.value?.[i]
-    }
-
-    return mergedSizes
+    // If any panel has a defined size prop, use all propSizes
+    // (let undefined values be handled by autoPtgSizes).
+    // Otherwise fall back to innerSizes.
+    return propSizes.value.some(size => size != null)
+      ? propSizes.value
+      : innerSizes.value
   })
 
   const postPercentMinSizes = computed(() => {


### PR DESCRIPTION
## Summary

- Fix Splitter size calculation when some panels have defined `size` props while others are `undefined`
- Changed from per-item merge logic to all-or-nothing approach: if any panel has a `size` prop, use all `propSizes` and let `autoPtgSizes` handle undefined values

## Related

- Upstream: ant-design/ant-design#57142
- Tracking: #345