### PR TITLE
feat(playground): add VC_LOCAL mode for local @v-c/* debugging

### DIFF
--- a/playground/.env.example
+++ b/playground/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env.local and uncomment to enable VC_LOCAL mode.
+# See vite.config.ts for details.
+
+# Watch specific @v-c/* packages (comma-separated):
+# VC_LOCAL=input,textarea
+
+# Watch default packages (input, textarea):
+# VC_LOCAL=1
+
+# Watch ALL @v-c/* packages:
+# VC_LOCAL=*
+
+# Path to vue-components repo root (default: ../../vue-components):
+# VC_PATH=../../vue-components

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,51 @@
+# Playground
+
+Dev sandbox for testing antdv-next components. Start with:
+
+```bash
+pnpm dev:play
+```
+
+## VC_LOCAL Mode
+
+Debug `@v-c/*` packages locally with auto-rebuild on source change.
+
+### Prerequisites
+
+- Clone [vue-components](https://github.com/nicepkg/vue-components) as a sibling directory (or set `VC_PATH`)
+- Ensure the target package has been built at least once (`pnpm -F @v-c/input build`)
+
+### Quick Start
+
+```bash
+# CLI — watch input + textarea (defaults)
+VC_LOCAL=1 pnpm dev:play
+
+# CLI — specific packages
+VC_LOCAL=input,textarea pnpm dev:play
+
+# Persistent — copy .env.example to .env.local
+cp playground/.env.example playground/.env.local
+# Edit .env.local, uncomment VC_LOCAL=input,textarea
+pnpm dev:play
+```
+
+### How It Works
+
+1. `loadEnv` reads `VC_LOCAL` / `VC_PATH` from `.env.local` (or CLI env vars)
+2. Vite `resolve.alias` redirects `@v-c/{pkg}` to local `dist/` instead of `node_modules`
+3. Chokidar watches `vue-components/packages/{pkg}/src/`
+4. On file change → `pnpm -F @v-c/{pkg} build` (~1s) → browser full-reload
+
+### Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `VC_LOCAL` | Packages to watch. `1` = input,textarea. `*` = all packages. Comma-separated list for specific packages. | _(disabled)_ |
+| `VC_PATH` | Path to vue-components repo root (relative to `playground/` or absolute). | `../../vue-components` |
+
+### Limitations
+
+- **Root imports only** — `@v-c/input` is aliased, but subpath imports like `@v-c/picker/generate/*` are not. Add aliases manually if needed.
+- **Playground only** — `pnpm test` and `pnpm build` still use npm-published versions.
+- **Sync rebuild** — Vite blocks for ~1s during each rebuild. Fine for 1-2 packages.

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,33 +1,176 @@
+import type { Plugin } from 'vite'
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import { tsxResolveTypes } from 'vite-plugin-tsx-resolve-types'
 
 const baseUrl = fileURLToPath(new URL('.', import.meta.url))
-export default defineConfig({
-  resolve: {
-    alias: [
-      {
-        find: /^antdv-next/,
-        replacement: path.resolve(baseUrl, '../packages/antdv-next/src'),
+
+// ─── VC_LOCAL mode ──────────────────────────────────────────────────
+// Debug @v-c/* packages locally with auto-rebuild on source change.
+//
+// Usage (pick one):
+//   1. VC_LOCAL=1 pnpm dev:play              (CLI, watch input+textarea)
+//   2. VC_LOCAL=input,textarea pnpm dev:play  (CLI, specific packages)
+//   3. VC_LOCAL=* pnpm dev:play              (CLI, watch ALL packages)
+//   4. Add VC_LOCAL=input,textarea to playground/.env.local (persistent)
+//
+// VC_PATH: path to vue-components repo root (default: ../../vue-components)
+//   VC_PATH=/path/to/vue-components VC_LOCAL=1 pnpm dev:play
+//
+// Edit @v-c/input src → auto rebuild → Vite full-reload → done.
+//
+// Limitation: only root imports (@v-c/pkg) are aliased. Subpath imports
+// like @v-c/picker/generate/* are NOT covered — add subpath aliases if needed.
+// ─────────────────────────────────────────────────────────────────────
+
+const VC_PATH_DEFAULT = '../../vue-components'
+const PKG_NAME_RE = /^[a-z][\w-]*$/
+
+function resolveVcRoot(vcPath: string | undefined): string {
+  const rel = vcPath || VC_PATH_DEFAULT
+  return path.resolve(baseUrl, rel, 'packages')
+}
+
+function parseVcPackages(vcLocalEnv: string | undefined, pkgDir: string): string[] {
+  if (!vcLocalEnv)
+    return []
+  if (vcLocalEnv === '1')
+    return ['input', 'textarea']
+  if (vcLocalEnv === '*') {
+    try {
+      return fs.readdirSync(pkgDir, { withFileTypes: true })
+        .filter(d => d.isDirectory() && PKG_NAME_RE.test(d.name))
+        .map(d => d.name)
+    }
+    catch {
+      return []
+    }
+  }
+  return vcLocalEnv.split(',').map(s => s.trim()).filter(s => PKG_NAME_RE.test(s))
+}
+
+function buildVcAliases(packages: string[], pkgDir: string) {
+  return packages.map(pkg => ({
+    find: new RegExp(`^@v-c/${pkg}$`),
+    replacement: path.resolve(pkgDir, `${pkg}/dist`),
+  }))
+}
+
+/**
+ * Vite plugin: watch @v-c/* source, auto-rebuild on change, full-reload.
+ */
+function vcAutoRebuild(packages: string[], pkgDir: string): Plugin {
+  if (!packages.length)
+    return { name: 'vc-auto-rebuild' }
+
+  const vcRoot = path.resolve(pkgDir, '..')
+  const watchDirs = packages.map(pkg => path.resolve(pkgDir, `${pkg}/src`))
+  const building = new Set<string>()
+
+  return {
+    name: 'vc-auto-rebuild',
+    configureServer(server) {
+      // Startup check: verify dist exists for each package
+      for (const pkg of packages) {
+        const distDir = path.resolve(pkgDir, `${pkg}/dist`)
+        if (!fs.existsSync(distDir)) {
+          server.config.logger.warn(
+            `[vc-local] @v-c/${pkg}/dist not found. Run: cd ${vcRoot} && pnpm -F @v-c/${pkg} build`,
+          )
+        }
+      }
+
+      const chokidar = server.watcher
+      for (const dir of watchDirs) {
+        chokidar.add(dir)
+      }
+
+      const rebuild = (filePath: string) => {
+        const matched = packages.find(pkg =>
+          filePath.startsWith(path.resolve(pkgDir, `${pkg}/src`)),
+        )
+        if (!matched || building.has(matched))
+          return
+
+        building.add(matched)
+        const label = `@v-c/${matched}`
+        server.config.logger.info(`\n[vc-local] ${label} source changed, rebuilding...`, { timestamp: true })
+
+        try {
+          execSync(`pnpm -F ${label} build`, {
+            cwd: vcRoot,
+            stdio: 'pipe',
+            timeout: 30_000,
+          })
+          server.config.logger.info(`[vc-local] ${label} rebuilt, reloading.`, { timestamp: true })
+          server.ws.send({ type: 'full-reload' })
+        }
+        catch (err: any) {
+          server.config.logger.error(`[vc-local] ${label} build failed:\n${err.stderr?.toString() || err.message}`)
+        }
+        finally {
+          building.delete(matched)
+        }
+      }
+
+      chokidar.on('change', rebuild)
+      chokidar.on('add', rebuild)
+      chokidar.on('unlink', rebuild)
+
+      server.config.logger.info(
+        `[vc-local] Watching: ${packages.map(p => `@v-c/${p}`).join(', ')}`,
+        { timestamp: true },
+      )
+    },
+  }
+}
+
+export default defineConfig(({ mode }) => {
+  // loadEnv reads .env / .env.local with the VC_ prefix
+  const env = loadEnv(mode, baseUrl, 'VC_')
+  const vcLocalEnv = process.env.VC_LOCAL || env.VC_LOCAL
+  const vcLocalDir = resolveVcRoot(process.env.VC_PATH || env.VC_PATH)
+  const vcPackages = parseVcPackages(vcLocalEnv, vcLocalDir)
+  const vcAliases = buildVcAliases(vcPackages, vcLocalDir)
+
+  return {
+    server: {
+      // Allow serving files from sibling vue-components repo when VC_LOCAL is active
+      fs: {
+        allow: vcPackages.length
+          ? [path.resolve(baseUrl, '..'), path.resolve(vcLocalDir, '..')]
+          : undefined,
       },
-      {
-        find: /^@antdv-next\/cssinjs/,
-        replacement: path.resolve(baseUrl, '../packages/cssinjs/src'),
-      },
-      {
-        find: '@',
-        replacement: '/src',
-      },
+    },
+    resolve: {
+      alias: [
+        ...vcAliases,
+        {
+          find: /^antdv-next/,
+          replacement: path.resolve(baseUrl, '../packages/antdv-next/src'),
+        },
+        {
+          find: /^@antdv-next\/cssinjs/,
+          replacement: path.resolve(baseUrl, '../packages/cssinjs/src'),
+        },
+        {
+          find: '@',
+          replacement: '/src',
+        },
+      ],
+    },
+    plugins: [
+      vcAutoRebuild(vcPackages, vcLocalDir),
+      tsxResolveTypes({
+        defaultPropsToUndefined: ['Boolean'],
+      }),
+      vueJsx(),
+      vue(),
     ],
-  },
-  plugins: [
-    tsxResolveTypes({
-      defaultPropsToUndefined: ['Boolean'],
-    }),
-    vueJsx(),
-    vue(),
-  ],
+  }
 })


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues

Motivated by debugging workflow for #368 — when fixing `@v-c/*` package bugs, there was no automated way to test changes in the antdv-next playground without manually rebuilding and refreshing.

### 💡 Background and Solution

**Problem:** Debugging `@v-c/*` packages locally requires: edit source → manually run `pnpm -F @v-c/input build` → manually refresh browser. No automation, easy to forget the build step and wonder why changes aren't showing.

**Solution:** Add an opt-in `VC_LOCAL` mode to the playground's Vite config that:

1. **Aliases** `@v-c/{pkg}` imports to local `vue-components/packages/{pkg}/dist` (bypasses `node_modules`)
2. **Watches** the source directory via chokidar
3. **Auto-rebuilds** on file change (~1s) and sends `full-reload` to the browser

**Key design decisions:**
- **Env-gated:** Only active when `VC_LOCAL` is set. Zero impact on normal `pnpm dev:play`.
- **No lockfile mutation:** Uses Vite `resolve.alias`, never touches `node_modules` or `pnpm-lock.yaml`.
- **Configurable:** Supports CLI env vars or persistent `playground/.env.local`.
- **`VC_LOCAL` values:** `1` (defaults: input, textarea), `*` (all packages), or comma-separated list.
- **`VC_PATH`:** Custom path to `vue-components` repo root (default: `../../vue-components`).

**Usage:**
```bash
# CLI
VC_LOCAL=input,textarea pnpm dev:play

# Or persistent via .env.local
cp playground/.env.example playground/.env.local
# Edit .env.local, uncomment VC_LOCAL=input,textarea
pnpm dev:play
```

**Limitations (documented in code and README):**
- Only root imports (`@v-c/pkg`) are aliased; subpath imports like `@v-c/picker/generate/*` are not covered.
- Playground only — `pnpm test` and `pnpm build` still use npm-published versions.
- Synchronous rebuild blocks Vite for ~1s per package.

**Files changed:**
- `playground/vite.config.ts` — VC_LOCAL plugin implementation
- `playground/.env.example` — Configuration template
- `playground/README.md` — Usage documentation

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `VC_LOCAL` mode to playground for local `@v-c/*` package debugging with auto-rebuild |
| 🇨🇳 Chinese | playground 新增 `VC_LOCAL` 模式，支持本地 `@v-c/*` 包联调与自动重建 |