### PR TITLE
fix(image): improve preview mask blur transition and movable cursor

### DIFF
--- a/packages/antdv-next/src/image/style/index.ts
+++ b/packages/antdv-next/src/image/style/index.ts
@@ -148,6 +148,8 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken, CSSObject> = (token
         inset: 0,
         position: 'absolute',
         background: colorBgMask,
+        backdropFilter: 'blur(0px)',
+        transition: `backdrop-filter ${motionDurationSlow}`,
         [`&${componentCls}-preview-mask-blur`]: {
           backdropFilter: 'blur(4px)',
         },
@@ -175,8 +177,11 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken, CSSObject> = (token
         maxHeight: '70%',
         verticalAlign: 'middle',
         transform: 'scale3d(1, 1, 1)',
-        cursor: 'grab',
         transition: `transform ${motionDurationSlow} ${motionEaseOut} 0s`,
+      },
+
+      [`&-movable ${previewCls}-img`]: {
+        cursor: 'grab',
       },
 
       [`&-moving ${previewCls}-img`]: {


### PR DESCRIPTION
## Summary

- Add initial `backdropFilter: 'blur(0px)'` and transition to preview mask for smooth blur animation
- Move `cursor: 'grab'` to `&-movable` selector so it only shows when movable is enabled

## Upstream

- ant-design/ant-design#57299
- ant-design/ant-design#57288

Relates to #372