### PR TITLE
fix(style): improve link focus-visible outline for accessibility

### DIFF
--- a/packages/antdv-next/src/style/index.tsx
+++ b/packages/antdv-next/src/style/index.tsx
@@ -95,6 +95,8 @@ export const genLinkStyle: GenerateStyle<AliasToken, CSSObject> = token => ({
       outline: 0,
     },
 
+    ...genFocusStyle(token),
+
     '&[disabled]': {
       color: token.colorTextDisabled,
       cursor: 'not-allowed',


### PR DESCRIPTION
## Summary

- Add `genFocusStyle` to `genLinkStyle` so links show proper `:focus-visible` outline for keyboard navigation

## Upstream

- ant-design/ant-design#57266

Relates to #372