### PR TITLE
fix(form): remove hardcoded SimSun font from required mark

### DIFF
--- a/packages/antdv-next/src/form/style/index.ts
+++ b/packages/antdv-next/src/form/style/index.ts
@@ -273,7 +273,7 @@ const genFormItemStyle: GenerateStyle<FormToken, CSSObject> = (token) => {
               marginInlineEnd: token.marginXXS,
               color: labelRequiredMarkColor,
               fontSize: token.fontSize,
-              fontFamily: 'SimSun, sans-serif',
+              fontFamily: 'sans-serif',
               lineHeight: 1,
               content: '"*"',
             },


### PR DESCRIPTION
## Summary

- Replace `fontFamily: 'SimSun, sans-serif'` with `fontFamily: 'sans-serif'` for required asterisk mark

## Upstream

- ant-design/ant-design#57273

Relates to #372