### PR TITLE
fix(menu): align collapsed icons with custom collapsedIconSize

### DIFF
--- a/packages/antdv-next/src/menu/style/vertical.ts
+++ b/packages/antdv-next/src/menu/style/vertical.ts
@@ -181,6 +181,9 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
           > ${componentCls}-item-group > ${componentCls}-item-group-list > ${componentCls}-item,
           > ${componentCls}-item-group > ${componentCls}-item-group-list > ${componentCls}-submenu > ${componentCls}-submenu-title,
           > ${componentCls}-submenu > ${componentCls}-submenu-title`]: {
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
           insetInlineStart: 0,
           paddingInline: `calc(50% - ${unit(token.calc(collapsedIconSize).div(2).equal())} - ${unit(
             itemMarginInline,
@@ -192,6 +195,12 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
             ${componentCls}-submenu-expand-icon
           `]: {
             opacity: 0,
+          },
+
+          [`> ${componentCls}-title-content`]: {
+            width: 0,
+            opacity: 0,
+            overflow: 'hidden',
           },
 
           [`${componentCls}-item-icon, ${iconCls}`]: {

--- a/packages/antdv-next/src/menu/tests/index.test.tsx
+++ b/packages/antdv-next/src/menu/tests/index.test.tsx
@@ -1,7 +1,9 @@
 import type { MenuProps } from '..'
+import { MailOutlined } from '@antdv-next/icons'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import Menu, { MenuItem, MenuItemGroup, SubMenu } from '..'
+import ConfigProvider from '../../config-provider'
 import { mountTest, rtlTest } from '/@tests/shared'
 import { mount } from '/@tests/utils'
 
@@ -248,5 +250,39 @@ describe('menu', () => {
     expect(wrapper.find('.menu-prop-icon').exists()).toBe(true)
     expect(wrapper.find('.ant-menu-item-extra').exists()).toBe(true)
     expect(wrapper.find('.ant-menu-item-icon').exists()).toBe(true)
+  })
+
+  it('aligns inline-collapsed icon when collapsedIconSize is customized', async () => {
+    Array.from(document.querySelectorAll('style')).forEach((style) => {
+      style.parentNode?.removeChild(style)
+    })
+
+    const wrapper = mount(() => (
+      <ConfigProvider theme={{ components: { Menu: { collapsedIconSize: 30 } } }}>
+        <Menu
+          mode="inline"
+          inlineCollapsed
+          items={[
+            {
+              key: 'sub1',
+              label: 'Navigation One',
+              icon: MailOutlined,
+              children: [{ key: '1', label: 'Option 1' }],
+            },
+          ]}
+        />
+      </ConfigProvider>
+    ))
+
+    await nextTick()
+
+    const dynamicStyleText = Array.from(document.querySelectorAll('style[data-css-hash]'))
+      .map(style => style.innerHTML)
+      .join('\n')
+
+    expect(dynamicStyleText).toMatch(/ant-menu-inline-collapsed[\s\S]*justify-content:center/)
+    expect(dynamicStyleText).toMatch(/ant-menu-inline-collapsed[\s\S]*ant-menu-title-content\{width:0;opacity:0;overflow:hidden/)
+
+    wrapper.unmount()
   })
 })


### PR DESCRIPTION
## 🐞 问题背景

- 修复 issue: #381
- 参考上游修复：ant-design/ant-design#57360（关联问题 #57348）

在 `Menu` 的 `inlineCollapsed` 场景下，当用户放大 `collapsedIconSize` 时，一级菜单 icon 会出现视觉偏移（hover 背景内未垂直居中）。

## ✅ 变更内容

1. 样式修复（`packages/antdv-next/src/menu/style/vertical.ts`）
   - 对折叠态首层 item/submenu-title 增加稳定居中布局：
     - `display: flex`
     - `alignItems: center`
     - `justifyContent: center`
   - 隐藏标题内容对布局计算的影响：
     - `> .ant-menu-title-content { width: 0; opacity: 0; overflow: hidden; }`

2. 回归测试（`packages/antdv-next/src/menu/tests/index.test.tsx`）
   - 新增用例：`aligns inline-collapsed icon when collapsedIconSize is customized`
   - 覆盖 `ConfigProvider` 自定义 `Menu.collapsedIconSize = 30` 场景
   - 断言生成样式中包含折叠态居中规则与标题隐藏规则

## 🧪 验证

已在本地执行菜单相关测试：

- `menu/tests/index.test.tsx`
- `menu/tests/semantic.test.tsx`
- `menu/tests/Menu.slot-render.test.tsx`
- `menu/tests/demo.test.tsx`
- `menu/tests/type.test.tsx`

结果：**38 passed, 0 failed**

## 📌 兼容性

- 仅影响 `inlineCollapsed` 折叠态样式计算逻辑
- 不涉及公共 API 变更