### PR TITLE
fix(menu): align collapsed icon layout in inline mode

### DIFF
--- a/packages/antdv-next/src/menu/style/vertical.ts
+++ b/packages/antdv-next/src/menu/style/vertical.ts
@@ -176,6 +176,11 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
             },
           },
         },
+        [`> ${componentCls}-item`]: {
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
 
         [`> ${componentCls}-item,
           > ${componentCls}-item-group > ${componentCls}-item-group-list > ${componentCls}-item,
@@ -200,7 +205,7 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
             lineHeight: unit(itemHeight),
 
             '+ span': {
-              display: 'inline-block',
+              display: 'none',
               opacity: 0,
             },
           },


### PR DESCRIPTION
Close #381
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->
[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)
### 🤔 This is a ...
- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)
### 🔗 Related Issues
- fix #381
### 💡 Background and Solution
在 `Menu` 的 `inlineCollapsed` 场景下，当用户自定义并增大 `collapsedIconSize` 时，折叠后的一级菜单图标会出现视觉偏移，看起来未在菜单项中垂直/水平居中。
本 PR 在 `packages/antdv-next/src/menu/style/vertical.ts` 中调整了折叠态一级菜单项布局：
- 对折叠态一级 item 使用稳定居中布局（`display: flex; align-items: center; justify-content: center`）
- 让隐藏标题内容不再参与图标居中计算（`title-content` 设为 `display: none`）
### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix misaligned icons in `Menu` when `inlineCollapsed` is enabled and `collapsedIconSize` is customized. |
| 🇨🇳 Chinese | 🐞 修复 `Menu` 在 `inlineCollapsed` 模式下自定义 `collapsedIconSize` 后图标看起来未居中的问题。 |