### PR TITLE
fix(docs): improve theme picker text visibility in dark mode

### DIFF
--- a/docs/src/pages/home/components/theme/index.vue
+++ b/docs/src/pages/home/components/theme/index.vue
@@ -149,6 +149,7 @@ function handleThemeKeyDown(event: KeyboardEvent, name: string) {
   margin: 0;
   font-size: var(--ant-font-size-lg);
   line-height: var(--ant-line-height-lg);
+  color: var(--ant-color-text-base);
   padding-block: var(--ant-padding);
   padding-inline: var(--ant-padding-lg);
   border: var(--ant-line-width) var(--ant-line-type) var(--ant-color-border-secondary);


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [x] 💄 Component style improvement

### 🔗 Related Issues

- User-reported homepage issue on `https://www.antdv-next.com/index-cn`:
  in dark mode, when **Default** style is selected, other theme options in the picker become hard to read.

### 💡 Background and Solution

On the homepage theme picker, non-active `.theme-list-item` text can inherit a light-on-dark text color in dark mode.
When the preview is switched to **Default** style (with a light background), this causes low contrast and poor readability.

This PR applies a minimal style fix in `docs/src/pages/home/components/theme/index.vue`:

- Set explicit base text color for `.theme-list-item`:
  `color: var(--ant-color-text-base);`

This keeps sufficient contrast on light backgrounds while preserving existing hover/active visual behavior.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fix homepage theme picker text contrast in dark mode when the Default style is selected. |
| 🇨🇳 Chinese | 修复官网首页在暗色模式下选择默认风格时主题选项文字对比度不足的问题。 |