### PR TITLE
fix(docs): refine theme picker contrast logic for dark mode

### DIFF
--- a/docs/src/pages/home/components/theme/index.vue
+++ b/docs/src/pages/home/components/theme/index.vue
@@ -26,6 +26,8 @@ const activeTheme = computed(() => {
   return previewThemes.value.find(item => item.name === activeName.value) ?? previewThemes.value[0]
 })
 
+const isThemeListDark = computed(() => !!activeTheme.value?.bgImgDark)
+
 const backgroundPrefetchList = computed(() => {
   return previewThemes.value
     .map(item => item.bgImg)
@@ -97,14 +99,13 @@ function handleThemeKeyDown(event: KeyboardEvent, name: string) {
   >
     <a-flex class="theme-container" gap="large">
       <div style="display: flex;">
-        <div class="theme-list" role="tablist" aria-label="Theme selection">
+        <div class="theme-list" :class="{ 'theme-list-dark': isThemeListDark }" role="tablist" aria-label="Theme selection">
           <div
             v-for="item in previewThemes"
             :key="item.name"
             class="theme-list-item"
             :class="{
               active: activeName === item.name,
-              dark: activeTheme?.bgImgDark,
             }"
             role="tab"
             :tabindex="activeName === item.name ? 0 : -1"
@@ -136,6 +137,8 @@ function handleThemeKeyDown(event: KeyboardEvent, name: string) {
 }
 
 .theme-list {
+  --theme-list-text-color: rgba(0, 0, 0, 0.88);
+
   flex: auto;
   margin: 0;
   padding: 0;
@@ -145,10 +148,15 @@ function handleThemeKeyDown(event: KeyboardEvent, name: string) {
   gap: var(--ant-padding-sm);
 }
 
+.theme-list.theme-list-dark {
+  --theme-list-text-color: var(--ant-color-text-light-solid);
+}
+
 .theme-list-item {
   margin: 0;
   font-size: var(--ant-font-size-lg);
   line-height: var(--ant-line-height-lg);
+  color: var(--theme-list-text-color);
   padding-block: var(--ant-padding);
   padding-inline: var(--ant-padding-lg);
   border: var(--ant-line-width) var(--ant-line-type) var(--ant-color-border-secondary);
@@ -161,6 +169,7 @@ function handleThemeKeyDown(event: KeyboardEvent, name: string) {
 .theme-list-item:hover:not(.active) {
   border-color: var(--ant-color-primary-border);
   background-color: var(--ant-color-primary-bg);
+  color: var(--ant-color-text-light-solid);
   cursor: pointer;
 }
 
@@ -175,15 +184,14 @@ function handleThemeKeyDown(event: KeyboardEvent, name: string) {
   color: var(--ant-color-primary);
 }
 
-.theme-list-item.dark {
-  color: var(--ant-color-text-light-solid);
+.theme-list.theme-list-dark .theme-list-item:hover,
+.theme-list.theme-list-dark .theme-list-item.active {
+  border-color: var(--ant-color-text-light-solid);
   background-color: transparent;
 }
 
-.theme-list-item.dark:hover,
-.theme-list-item.dark.active {
-  border-color: var(--ant-color-text-light-solid);
-  background-color: transparent;
+.theme-list.theme-list-dark .theme-list-item.active {
+  color: var(--ant-color-text-light-solid);
 }
 
 .components-block {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- User-reported issue on homepage theme picker (`/index-cn`):
  in dark mode, when switching among preview styles (e.g. Default / MUI-like / shadcn-like / Illustration / Bootstrap-like),
  non-active option labels could become hard to read.

### 💡 Background and Solution

The previous implementation coupled label color handling to item-level state and could produce low-contrast text in mixed scenarios
(dark site mode + light preview backgrounds).

This PR refines the theme-picker contrast logic in:

- `docs/src/pages/home/components/theme/index.vue`

Key updates:

1. Introduce a semantic computed state for the list container:
   - `isThemeListDark`
2. Move dark-mode styling control from per-item class coupling to container-level state:
   - `.theme-list.theme-list-dark`
3. Use a local CSS variable for list text color to improve maintainability:
   - `--theme-list-text-color`
4. Keep active/hover behavior consistent with existing visual design while ensuring readability.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Refine homepage theme picker contrast logic in dark mode by using container-level dark state and semantic text-color variable. |
| 🇨🇳 Chinese | 优化官网首页主题选择器在暗色模式下的对比度逻辑，改为容器级深色状态与语义化文本色变量控制。 |
