### PR TITLE
fix(image): fix mask blur behavior when mask is true

### DIFF
--- a/packages/antdv-next/src/image/hooks/usePreviewConfig.ts
+++ b/packages/antdv-next/src/image/hooks/usePreviewConfig.ts
@@ -12,8 +12,14 @@ function normalizeMask(mask?: MaskType | VueNode) {
   if (isVNode(mask)) {
     return [mask, undefined]
   }
-  if (typeof mask === 'boolean' || (mask && typeof mask === 'object')) {
-    return [undefined, mask]
+  if (mask === true) {
+    return [undefined, { blur: true }]
+  }
+  if (mask === false) {
+    return [undefined, false]
+  }
+  if (mask && typeof mask === 'object') {
+    return [undefined, { blur: true, ...mask }]
   }
   return [undefined, undefined]
 }

--- a/packages/antdv-next/src/image/tests/Image.test.tsx
+++ b/packages/antdv-next/src/image/tests/Image.test.tsx
@@ -170,4 +170,40 @@ describe('image.PreviewGroup', () => {
     ))
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('should support mask blur behavior', async () => {
+    // 1. Default true mask has blur
+    const wrapper = mount(Image, {
+      props: {
+        src,
+        preview: { open: true, mask: true },
+      },
+    })
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(document.querySelector('.ant-image-preview-mask-blur')).not.toBeNull()
+    wrapper.unmount()
+
+    // 2. mask=false should not have blur
+    const wrapper2 = mount(Image, {
+      props: {
+        src,
+        preview: { open: true, mask: false },
+      },
+    })
+    await new Promise(resolve => setTimeout(resolve, 100))
+    // wait for DOM to update
+    expect(document.querySelector('.ant-image-preview-mask-blur')).toBeNull()
+    wrapper2.unmount()
+
+    // 3. Object mask can disable blur
+    const wrapper3 = mount(Image, {
+      props: {
+        src,
+        preview: { open: true, mask: { blur: false } },
+      },
+    })
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(document.querySelector('.ant-image-preview-mask-blur')).toBeNull()
+    wrapper3.unmount()
+  })
 })


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - N/A

### 💡 Background and Solution

> - In the current 1.1.5 version, when the mask is set to true in the preview property of the Image component, the default blur behavior is disabled.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue of preview mask blur failure in Image component version 1.1.5 |
| 🇨🇳 Chinese | 修复 1.1.5 版本 Image 组件 preview mask blur 失效问题 |
