### PR TITLE
docs: Update key description from React to Vue and add column key des…

### DIFF
--- a/docs/src/pages/components/table/index.en-US.md
+++ b/docs/src/pages/components/table/index.en-US.md
@@ -184,6 +184,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | filters | Filter menu config | object\[] | - | - |
 | filterDropdownProps | Customized dropdown props | [DropdownProps](/components/dropdown#api) | - | - |
 | fixed | (IE not support) Set column to be fixed: `true`(same as `'start'`) `'start'` `'end'` | boolean \| string | false | - |
+| key | Unique key of this column, you can ignore this prop if you've set a unique `dataIndex` | string | - |  |
 | render | Renderer of the table cell. `value` is the value of current cell; `record` is the value object of current row; `index` is the row number. The return value should be a VueNode | (value: V, record: T, index: number): VueNode | - | - |
 | responsive | The list of breakpoints at which to display this column. Always visible if not set | [Breakpoint](https://github.com/antdv-next/antdv-next/blob/main/packages/antdv-next/src/_util/responsiveObserver.ts#L9)\[] | - | - |
 | rowScope | Set scope attribute for all cells in this column | `row` \| `rowgroup` | - | - |

--- a/docs/src/pages/components/table/index.zh-CN.md
+++ b/docs/src/pages/components/table/index.zh-CN.md
@@ -185,6 +185,7 @@ const columns = [
 | filters | 表头的筛选菜单项 | object\[] | - | - |
 | filterDropdownProps | 自定义下拉属性 | [DropdownProps](/components/dropdown#api) | - | - |
 | fixed | （IE 下无效）列是否固定，可选 `true` (等效于 `'start'`) `'start'` `'end'` | boolean \| string | false | - |
+| key | Vue 需要的 key，如果已经设置了唯一的 `dataIndex`，可以忽略这个属性 | string | - |  |
 | render | 生成复杂数据的渲染函数，参数分别为当前单元格的值，当前行数据，行索引 | (value: V, record: T, index: number): VueNode | - | - |
 | responsive | 响应式 breakpoint 配置列表。未设置则始终可见。 | [Breakpoint](https://github.com/antdv-next/antdv-next/blob/main/packages/antdv-next/src/_util/responsiveObserver.ts#L9)\[] | - | - |
 | rowScope | 设置列范围 | `row` \| `rowgroup` | - | - |
@@ -277,7 +278,7 @@ const columns = [
 
 | 参数     | 说明                       | 类型                        | 默认值 |
 | -------- | -------------------------- | --------------------------- | ------ |
-| key      | React 需要的 key，建议设置 | string                      | -      |
+| key      | Vue 需要的 key，建议设置 | string                      | -      |
 | text     | 选择项显示的文字           | VueNode                   | -      |
 | onSelect | 选择项点击回调             | function(changeableRowKeys) | -      |
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - N/A

### 💡 Background and Solution

> - Fix the inaccurate description of the selection key configuration for the Table component in the 1.1.6 version document.
> - Add the description for the Column key configuration of the Table component in the document.


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Update the selection key description of the document Table component from React to Vue and add a Column key description |
| 🇨🇳 Chinese | 将文档 Table 组件 selection key 描述从 React 更新为 Vue 并添加 Column key 描述 |
