### PR TITLE
fix(Tree): sync 6.3.4 correct custom switcherIcon class when showLine is enabled

### DIFF
--- a/packages/antdv-next/src/tree/tests/__snapshots__/demo.test.ts.snap
+++ b/packages/antdv-next/src/tree/tests/__snapshots__/demo.test.ts.snap
@@ -5321,7 +5321,7 @@ exports[`tree demo > renders switcher-icon correctly 1`] = `
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg
@@ -5376,7 +5376,7 @@ exports[`tree demo > renders switcher-icon correctly 1`] = `
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg
@@ -5554,7 +5554,7 @@ exports[`tree demo > renders switcher-icon correctly 1`] = `
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg
@@ -5609,7 +5609,7 @@ exports[`tree demo > renders switcher-icon correctly 1`] = `
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg

--- a/packages/antdv-next/src/tree/utils/iconUtil.tsx
+++ b/packages/antdv-next/src/tree/utils/iconUtil.tsx
@@ -65,7 +65,7 @@ const SwitcherIconCom = defineComponent<SwitcherIconProps>(
       }
       if (isVNode(switcher)) {
         return createVNode(switcher, {
-          class: switcherCls,
+          class: [switcher.props?.classes, showLine ? `${prefixCls}-switcher-line-icon` : switcherCls],
         })
       }
       if (switcher !== undefined) {


### PR DESCRIPTION
… is enabled

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Tree custom switcherIcon missing switcher-line-icon class when showLine is enabled.  |
| 🇨🇳 Chinese |  Tree 修复开启 `showLine` 时自定义 `switcherIcon` 缺少 `switcher-line-icon` 类名导致样式异常的问题。|
