### PR TITLE
fix(transfer): sync 6.3.4 handle non-string render results when rendering items

### DIFF
--- a/packages/antdv-next/src/transfer/Section.tsx
+++ b/packages/antdv-next/src/transfer/Section.tsx
@@ -29,6 +29,18 @@ function getEnabledItemKeys<RecordType extends KeyWiseTransferItem>(items: Recor
   return items.filter(data => !data.disabled).map(data => data.key)
 }
 
+function getTextFromRenderResult<RecordType extends KeyWiseTransferItem>(
+  renderResult: RenderResult,
+  item: RecordType,
+): string {
+  for (const v of [renderResult, item.title, item.key]) {
+    if (typeof v === 'string' || typeof v === 'number') {
+      return String(v)
+    }
+  }
+  return ''
+}
+
 const isValidIcon = (icon: any) => icon !== undefined
 
 function getShowSearchOption(showSearch: boolean | TransferSearchOption) {
@@ -88,12 +100,13 @@ const TransferSection = defineComponent<
       else if (labelNode !== undefined && labelNode !== null) {
         mergedLabel = labelNode
       }
+      const renderedEl = mergedLabel ?? (isRenderResultPlain ? renderResult.label : renderResult)
       const renderedText = isRenderResultPlain
         ? renderResult.value
-        : (typeof renderResult === 'string' || typeof renderResult === 'number' ? String(renderResult) : '')
+        : getTextFromRenderResult(renderResult, item)
       return {
         item,
-        renderedEl: mergedLabel ?? (isRenderResultPlain ? renderResult.label : renderResult),
+        renderedEl,
         renderedText,
       }
     }
@@ -300,7 +313,7 @@ const TransferSection = defineComponent<
                   newCheckedKeysSet.add(key)
                 }
               })
-              props.onItemSelectAll?.(Array.from(newCheckedKeysSet), 'replace')
+              props.onItemSelectAll?.([...newCheckedKeysSet], 'replace')
             },
           },
         ].filter(Boolean)

--- a/packages/antdv-next/src/transfer/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/antdv-next/src/transfer/tests/__snapshots__/index.test.tsx.snap
@@ -360,7 +360,7 @@ exports[`transfer > should render correctly 1`] = `
       >
         <li
           class="ant-transfer-list-content-item ant-transfer-list-content-item-checked"
-          title=""
+          title="a"
         >
           <label
             class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"
@@ -384,7 +384,7 @@ exports[`transfer > should render correctly 1`] = `
         </li>
         <li
           class="ant-transfer-list-content-item ant-transfer-list-content-item-disabled"
-          title=""
+          title="c"
         >
           <label
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"
@@ -534,7 +534,7 @@ exports[`transfer > should render correctly 1`] = `
       >
         <li
           class="ant-transfer-list-content-item"
-          title=""
+          title="b"
         >
           <label
             class="ant-checkbox-wrapper ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"
@@ -1157,7 +1157,7 @@ exports[`transfer immutable data > dataSource is frozen 1`] = `
       >
         <li
           class="ant-transfer-list-content-item"
-          title=""
+          title="title"
         >
           <label
             class="ant-checkbox-wrapper ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"

--- a/packages/antdv-next/src/transfer/tests/section.test.tsx
+++ b/packages/antdv-next/src/transfer/tests/section.test.tsx
@@ -150,4 +150,22 @@ describe('transfer.Section', () => {
 
     expect(onItemSelect).toHaveBeenCalledWith('a', false)
   })
+
+  it('should fallback to empty string text when render result is non-text', async () => {
+    const handleFilter = vi.fn()
+    const wrapper = mountComponent(Section, {
+      props: {
+        ...listCommonProps,
+        dataSource: [{ key: {} as unknown } as KeyWiseTransferItem],
+        showSearch: true,
+        handleFilter: handleFilter(),
+        handleClear: vi.fn(),
+      },
+    })
+
+    await wrapper.find('.ant-transfer-list-search input').trigger('click')
+
+    expect(handleFilter).toHaveBeenCalled()
+    expect(wrapper.find('.ant-transfer-list-body-not-found')).toBeTruthy()
+  })
 })


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Transfer `render` prop returning non-string causing search to fail. |
| 🇨🇳 Chinese | 修复 Transfer `render` 属性返回非字符串时搜索功能失效的问题。 |
