### PR TITLE
fix: docs icon message display issue

### DIFF
--- a/docs/src/components/icon-search/Category.vue
+++ b/docs/src/components/icon-search/Category.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { CategoriesKeys } from './field'
-import { message } from 'antdv-next'
+import { App } from 'antdv-next'
 import { computed, onBeforeUnmount, ref } from 'vue'
 import { useLocale } from '@/composables/use-locale'
 import CopyableIcon from './CopyableIcon.vue'
@@ -14,6 +14,7 @@ const props = defineProps<{
   newIcons: string[]
 }>()
 
+const { message } = App.useApp()
 const { t } = useLocale()
 const justCopied = ref<string | null>(null)
 const copyId = ref<ReturnType<typeof setTimeout> | null>(null)


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

N/A

### 💡 背景与方案

修复 docs 中 icon message 显示问题。将直接从 `antdv-next` 导入 `message` 改为通过 `App.useApp()` 获取，确保 message 组件在正确的 App 上下文中运行。

### 📝 变更日志

&gt; - 建议阅读 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)。
&gt; - 变更日志应描述对开发者的影响，而不是实现过程。
&gt; - 参考：https://ant.design/changelog

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Fix docs icon message display issue |
| 🇨🇳 中文 | 修复 docs 中 icon message 显示问题 |
