### PR TITLE
test(image): update snapshots for alt attribute fix

### DIFF
--- a/packages/antdv-next/src/image/tests/__snapshots__/Image.test.tsx.snap
+++ b/packages/antdv-next/src/image/tests/__snapshots__/Image.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`image > rtl render > component should be rendered correctly in RTL dire
 `;
 
 exports[`image > should match snapshot 1`] = `
-"<div alt="Test" class="ant-image css-var-root ant-image-css-var" role="button" tabindex="0" aria-label="Test" style="width: 200px;"><img src="https://example.com/test.png" class="ant-image-img" width="200">
+"<div class="ant-image css-var-root ant-image-css-var" role="button" tabindex="0" aria-label="Test" style="width: 200px;"><img alt="Test" src="https://example.com/test.png" class="ant-image-img" width="200">
   <!---->
   <div class="ant-image-cover ant-image-cover-center">
     <!---->

--- a/packages/antdv-next/src/image/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/image/tests/__snapshots__/demo.test.tsx.snap
@@ -1029,7 +1029,6 @@ exports[`image demo > renders basic correctly 1`] = `
   data-v-app=""
 >
   <div
-    alt="basic"
     aria-label="basic"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1037,6 +1036,7 @@ exports[`image demo > renders basic correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="basic"
       class="ant-image-img"
       src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
       width="200"
@@ -1154,7 +1154,6 @@ exports[`image demo > renders controlled-preview correctly 1`] = `
     <!---->
   </button>
   <div
-    alt="basic image"
     aria-label="basic image"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1162,6 +1161,7 @@ exports[`image demo > renders controlled-preview correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="basic image"
       class="ant-image-img"
       src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
       style="display: none;"
@@ -1183,7 +1183,6 @@ exports[`image demo > renders fallback correctly 1`] = `
   data-v-app=""
 >
   <div
-    alt="basic image"
     aria-label="basic image"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1191,6 +1190,7 @@ exports[`image demo > renders fallback correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="basic image"
       class="ant-image-img"
       height="200"
       src="error"
@@ -1213,7 +1213,6 @@ exports[`image demo > renders imageRender correctly 1`] = `
   data-v-app=""
 >
   <div
-    alt="slot image"
     aria-label="slot image"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1221,6 +1220,7 @@ exports[`image demo > renders imageRender correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="slot image"
       class="ant-image-img"
       src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
       width="200"
@@ -1235,7 +1235,6 @@ exports[`image demo > renders imageRender correctly 1`] = `
   <!---->
   <br />
   <div
-    alt="preview image"
     aria-label="preview image"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1243,6 +1242,7 @@ exports[`image demo > renders imageRender correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="preview image"
       class="ant-image-img"
       src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
       width="200"
@@ -1263,7 +1263,6 @@ exports[`image demo > renders mask correctly 1`] = `
   data-v-app=""
 >
   <div
-    alt="Default blur"
     aria-label="Default blur"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1271,6 +1270,7 @@ exports[`image demo > renders mask correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="Default blur"
       class="ant-image-img"
       src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
       width="100"
@@ -1293,7 +1293,6 @@ exports[`image demo > renders mask correctly 1`] = `
   </div>
   <!---->
   <div
-    alt="Dimmed mask"
     aria-label="Dimmed mask"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1301,6 +1300,7 @@ exports[`image demo > renders mask correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="Dimmed mask"
       class="ant-image-img"
       src="https://www.antdv-next.com/antdv-next.svg"
       width="100"
@@ -1323,7 +1323,6 @@ exports[`image demo > renders mask correctly 1`] = `
   </div>
   <!---->
   <div
-    alt="No mask"
     aria-label="No mask"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1331,6 +1330,7 @@ exports[`image demo > renders mask correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="No mask"
       class="ant-image-img"
       src="https://cn.vuejs.org/logo.svg"
       width="100"
@@ -1389,7 +1389,6 @@ exports[`image demo > renders placeholder correctly 1`] = `
     class="ant-space-item"
   >
     <div
-      alt="basic image"
       aria-label="basic image"
       class="ant-image css-var-root ant-image-css-var"
       role="button"
@@ -1397,6 +1396,7 @@ exports[`image demo > renders placeholder correctly 1`] = `
       tabindex="0"
     >
       <img
+        alt="basic image"
         class="ant-image-img"
         src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?1505705407795"
         width="200"
@@ -1406,11 +1406,11 @@ exports[`image demo > renders placeholder correctly 1`] = `
         class="ant-image-placeholder"
       >
         <div
-          alt="placeholder image"
           class="ant-image css-var-root ant-image-css-var"
           style="width: 200px;"
         >
           <img
+            alt="placeholder image"
             class="ant-image-img"
             src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
             width="200"
@@ -1459,7 +1459,6 @@ exports[`image demo > renders preview-group correctly 1`] = `
   data-v-app=""
 >
   <div
-    alt="svg image"
     aria-label="svg image"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1467,6 +1466,7 @@ exports[`image demo > renders preview-group correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="svg image"
       class="ant-image-img"
       src="https://www.antdv-next.com/antdv-next.svg"
       width="200"
@@ -1480,7 +1480,6 @@ exports[`image demo > renders preview-group correctly 1`] = `
   </div>
   <!---->
   <div
-    alt="svg image"
     aria-label="svg image"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1488,6 +1487,7 @@ exports[`image demo > renders preview-group correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="svg image"
       class="ant-image-img"
       src="https://cn.vuejs.org/logo.svg"
       width="200"
@@ -1509,7 +1509,6 @@ exports[`image demo > renders preview-group-visible correctly 1`] = `
   data-v-app=""
 >
   <div
-    alt="webp image"
     aria-label="webp image"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1517,6 +1516,7 @@ exports[`image demo > renders preview-group-visible correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="webp image"
       class="ant-image-img"
       src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp"
       width="200"
@@ -1538,7 +1538,6 @@ exports[`image demo > renders previewSrc correctly 1`] = `
   data-v-app=""
 >
   <div
-    alt="basic image"
     aria-label="basic image"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1546,6 +1545,7 @@ exports[`image demo > renders previewSrc correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="basic image"
       class="ant-image-img"
       src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
       width="200"
@@ -1566,7 +1566,6 @@ exports[`image demo > renders style-class correctly 1`] = `
   class="ant-flex css-var-root ant-flex-gap-middle"
 >
   <div
-    alt="示例图片"
     aria-label="示例图片"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1574,6 +1573,7 @@ exports[`image demo > renders style-class correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="示例图片"
       class="ant-image-img"
       src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
       style="border-radius: 4px;"
@@ -1588,7 +1588,6 @@ exports[`image demo > renders style-class correctly 1`] = `
   </div>
   <!---->
   <div
-    alt="示例图片"
     aria-label="示例图片"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1596,6 +1595,7 @@ exports[`image demo > renders style-class correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="示例图片"
       class="ant-image-img"
       src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
       style="border-radius: 4px; filter: grayscale(50%);"
@@ -1617,7 +1617,6 @@ exports[`image demo > renders toolbarRender correctly 1`] = `
   data-v-app=""
 >
   <div
-    alt="image-0"
     aria-label="image-0"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1625,6 +1624,7 @@ exports[`image demo > renders toolbarRender correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="image-0"
       class="ant-image-img"
       src="https://www.antdv-next.com/antdv-next.svg"
       width="200"
@@ -1638,7 +1638,6 @@ exports[`image demo > renders toolbarRender correctly 1`] = `
   </div>
   <!---->
   <div
-    alt="image-1"
     aria-label="image-1"
     class="ant-image css-var-root ant-image-css-var"
     role="button"
@@ -1646,6 +1645,7 @@ exports[`image demo > renders toolbarRender correctly 1`] = `
     tabindex="0"
   >
     <img
+      alt="image-1"
       class="ant-image-img"
       src="https://cn.vuejs.org/logo.svg"
       width="200"


### PR DESCRIPTION
[English template / 英文模板](./PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

> - 请说明需求来源，如相关 Issue 或讨论链接。
> - 例如：close #xxxx, fix #xxxx

### 💡 背景与方案

> - 需要解决的具体问题是什么。
> - 如有必要，请给出最终 API 设计与使用方式。
> - 如果有 UI / 交互变化，建议提供截图或 GIF。

更新 Image 组件的测试快照，将 `alt` 属性从外层 `div` 元素移到正确的 `img` 元素上，提升无障碍访问性。

### 📝 变更日志

> - 建议阅读 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)。
> - 变更日志应描述对开发者的影响，而不是实现过程。
> - 参考：https://ant.design/changelog

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | test(image): update snapshots for alt attribute fix |
| 🇨🇳 中文 | test(image): 更新 alt 属性修复的测试快照 |
