### PR TITLE
fix(docs): prevent recommend card mask composite from being dropped

### DIFF
--- a/docs/src/pages/home/components/banner-recommends/recommend-card.vue
+++ b/docs/src/pages/home/components/banner-recommends/recommend-card.vue
@@ -189,14 +189,17 @@ onBeforeUnmount(() => {
     var(--ant-color-primary-border-hover),
     var(--ant-color-border-secondary)
   );
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  mask-composite: subtract;
+
   -webkit-mask:
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
+
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: subtract;
+
   transition: opacity 0.3s ease;
 }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

The home page recommend card gradient border can lose its standard `mask-composite` declaration when CSS processing reorders or drops duplicate mask rules.

This change keeps the prefixed WebKit mask declarations together and places the standard `mask` / `mask-composite` declarations after them so the generated CSS preserves both browser-specific and standard behavior.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix recommend card gradient border mask rendering in the docs home page. |
| 🇨🇳 Chinese | 修复文档首页推荐卡片渐变边框的 mask 渲染问题。 |