### PR TITLE
fix: sync ant-design 6.4.3 P1 fixes (Result/DatePicker/Select)

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React 主组件库 -> antdv-next 主包"
         }
       ],
-      "last_synced_commit": "616f681b5c1140cf8317dfc700cca8eda0af3ad0",
-      "last_synced_commit_short": "616f681b",
-      "last_synced_at": "2026-05-16T08:39:21Z",
-      "last_synced_tag": "6.4.2",
-      "sync_count": 5
+      "last_synced_commit": "5afcdabaa83be47d7e8ec64b9711713212edcadd",
+      "last_synced_commit_short": "5afcdabaa8",
+      "last_synced_at": "2026-05-18T09:46:00Z",
+      "last_synced_tag": "6.4.3",
+      "sync_count": 6
     },
     {
       "name": "cssinjs",

--- a/packages/antdv-next/src/date-picker/tests/RangePicker.test.tsx
+++ b/packages/antdv-next/src/date-picker/tests/RangePicker.test.tsx
@@ -58,6 +58,33 @@ describe('range-picker', () => {
     expect(inputs[1]?.attributes('placeholder')).toBe('End quarter')
   })
 
+  it('should fall back to rangePlaceholder when locale omits range-variant placeholder', () => {
+    const partialLocale = {
+      ...enUS,
+      lang: {
+        ...enUS.lang,
+        rangePlaceholder: ['Fallback start', 'Fallback end'] as [string, string],
+        rangeYearPlaceholder: undefined,
+        rangeQuarterPlaceholder: undefined,
+        rangeMonthPlaceholder: undefined,
+        rangeWeekPlaceholder: undefined,
+      },
+    } as typeof enUS
+
+    ;(['year', 'quarter', 'month', 'week'] as const).forEach((picker) => {
+      const wrapper = mount(RangePicker, {
+        props: {
+          picker,
+          locale: partialLocale,
+        },
+      })
+      const inputs = wrapper.findAll('input')
+      expect(inputs[0]?.attributes('placeholder')).toBe('Fallback start')
+      expect(inputs[inputs.length - 1]?.attributes('placeholder')).toBe('Fallback end')
+      wrapper.unmount()
+    })
+  })
+
   it('should support allowClear and custom clearIcon', async () => {
     const open = ref(true)
     const value = [dayjs('2023-08-01'), dayjs('2023-08-02')]

--- a/packages/antdv-next/src/date-picker/util.ts
+++ b/packages/antdv-next/src/date-picker/util.ts
@@ -39,19 +39,19 @@ export function getRangePlaceholder(
     return customizePlaceholder
   }
 
-  if (picker === 'year' && locale.lang.yearPlaceholder) {
+  if (picker === 'year' && locale.lang.rangeYearPlaceholder) {
     return locale.lang.rangeYearPlaceholder
   }
-  if (picker === 'quarter' && locale.lang.quarterPlaceholder) {
+  if (picker === 'quarter' && locale.lang.rangeQuarterPlaceholder) {
     return locale.lang.rangeQuarterPlaceholder
   }
-  if (picker === 'month' && locale.lang.monthPlaceholder) {
+  if (picker === 'month' && locale.lang.rangeMonthPlaceholder) {
     return locale.lang.rangeMonthPlaceholder
   }
-  if (picker === 'week' && locale.lang.weekPlaceholder) {
+  if (picker === 'week' && locale.lang.rangeWeekPlaceholder) {
     return locale.lang.rangeWeekPlaceholder
   }
-  if (picker === 'time' && locale.timePickerLocale.placeholder) {
+  if (picker === 'time' && locale.timePickerLocale.rangePlaceholder) {
     return locale.timePickerLocale.rangePlaceholder
   }
   return locale.lang.rangePlaceholder

--- a/packages/antdv-next/src/result/index.tsx
+++ b/packages/antdv-next/src/result/index.tsx
@@ -225,7 +225,7 @@ const Result = defineComponent<
       return (
         <div {...restProps} class={rootClassNames} style={rootStyles}>
           <Icon class={iconClassNames} status={status!} icon={icon} style={mergedStyles.value.icon} />
-          <div class={titleClassNames} style={mergedStyles.value.title}>{title}</div>
+          {!!title && <div class={titleClassNames} style={mergedStyles.value.title}>{title}</div>}
           {!!subTitle && <div class={subTitleClassNames} style={mergedStyles.value.subTitle}>{subTitle}</div>}
           <Extra class={extraClassNames} extra={extra} style={mergedStyles.value.extra} />
           {!!children.length && <div class={bodyClassNames} style={mergedStyles.value.body}>{children}</div>}

--- a/packages/antdv-next/src/result/tests/Result.test.tsx
+++ b/packages/antdv-next/src/result/tests/Result.test.tsx
@@ -15,7 +15,8 @@ describe('result', () => {
     expect(wrapper.find('.ant-result').exists()).toBe(true)
     expect(wrapper.find('.ant-result-info').exists()).toBe(true)
     expect(wrapper.find('.ant-result-icon').exists()).toBe(true)
-    expect(wrapper.find('.ant-result-title').exists()).toBe(true)
+    // title is omitted when not provided (aligned with antd 6.4.3 #58028)
+    expect(wrapper.find('.ant-result-title').exists()).toBe(false)
   })
 
   describe('status', () => {
@@ -125,6 +126,11 @@ describe('result', () => {
         slots: { title: () => 'Slot Title' },
       })
       expect(wrapper.find('.ant-result-title').text()).toBe('Slot Title')
+    })
+
+    it('should not render title when not provided', () => {
+      const wrapper = mount(Result)
+      expect(wrapper.find('.ant-result-title').exists()).toBe(false)
     })
   })
 

--- a/packages/antdv-next/src/result/tests/__snapshots__/Result.test.tsx.snap
+++ b/packages/antdv-next/src/result/tests/__snapshots__/Result.test.tsx.snap
@@ -68,11 +68,7 @@ exports[`result > rtl render > component should be rendered correctly in RTL dir
         </svg>
       </span>
     </div>
-    <div
-      class="ant-result-title"
-    >
-      <!---->
-    </div>
+    <!---->
     <!---->
     <!---->
     <!---->

--- a/packages/antdv-next/src/select/style/select-input.ts
+++ b/packages/antdv-next/src/select/style/select-input.ts
@@ -253,6 +253,8 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
             margin: 0,
             padding: 0,
             color: varRef('color'),
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
 
             '&::-webkit-search-cancel-button': {
               display: 'none',
@@ -270,7 +272,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
           [`${componentCls}-input`]: {
             position: 'absolute',
             inset: 0,
-            lineHeight: `calc(${varRef('font-height')} + ${varRef('padding-vertical')} * 2)`,
+            lineHeight: 'inherit',
           },
 
           // Content center align


### PR DESCRIPTION
## Summary

跟进 [ant-design 6.4.3](https://github.com/ant-design/ant-design/releases/tag/6.4.3) 的三个 P1 用户可见 fix：

- **Result** ([ant-design#58028](https://github.com/ant-design/ant-design/pull/58028)) — \`title\` 未传时不再渲染空的 \`.ant-result-title\` 元素，避免污染 DOM / 屏幕阅读器。
- **DatePicker** ([ant-design#58020](https://github.com/ant-design/ant-design/pull/58020)) — \`getRangePlaceholder\` 之前用单数 \`*Placeholder\` 字段判断，导致只定义了单数变体的 20+ locale（fr_FR、ru_RU、tr_TR、nl_NL、sv_SE…）下 RangePicker 输入框 placeholder 为空。改为检查 \`range*Placeholder\` 字段，缺失时直接回退到 \`lang.rangePlaceholder\`。
- **Select** ([ant-design#57990](https://github.com/ant-design/ant-design/pull/57990)) — Safari 下 \`input[type=search]\` 不继承父级字体，给搜索输入加 \`fontFamily: inherit\` + \`fontSize: inherit\`；single 块 \`lineHeight\` 改为 \`inherit\` 跟随父行高。

同步状态文件 \`.sync-upstream.json\` 已推进到 \`5afcdabaa8\` / tag \`6.4.3\`。

## Test plan

- [x] \`pnpm -F antdv-next test result.test --run\` — 46/46 ✅
- [x] \`pnpm -F antdv-next test RangePicker.test --run\` — 9/9 ✅（新增 1 个 fallback 用例）
- [x] \`pnpm -F antdv-next test select --run\` — 114/114 ✅
- [x] 全量受影响包 (result + RangePicker + select + Table + transfer + Mentions + useFilter) — 516/516 ✅
- [x] ESLint 全部干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)