### PR TITLE
perf(table): sync ant-design 6.4.3 Table perf and FilterResetProps rename

### DIFF
--- a/packages/antdv-next/src/table/hooks/useFilter/FilterDropdown.tsx
+++ b/packages/antdv-next/src/table/hooks/useFilter/FilterDropdown.tsx
@@ -147,7 +147,7 @@ export interface FilterDropdownProps<RecordType = AnyObject> {
 
 type FilterTreeDataNode = FieldDataNode
 
-interface FilterRestProps {
+interface FilterResetProps {
   confirm?: boolean
   closeDropdown?: boolean
 }
@@ -288,7 +288,7 @@ const FilterDropdown = defineComponent<
     }
 
     const onReset = (
-      { confirm, closeDropdown }: FilterRestProps = { confirm: false, closeDropdown: false },
+      { confirm, closeDropdown }: FilterResetProps = { confirm: false, closeDropdown: false },
     ) => {
       if (confirm) {
         internalTriggerFilter([])

--- a/packages/antdv-next/src/table/hooks/useFilter/index.tsx
+++ b/packages/antdv-next/src/table/hooks/useFilter/index.tsx
@@ -256,19 +256,21 @@ export function getMergedFilterStates<RecordType extends AnyObject = AnyObject>(
     const keyList = (mergedColumns || []).map((column, index) =>
       getColumnKey(column, getColumnPos(index)),
     )
-    return filterStates
-      .filter(({ key }) => keyList.includes(key))
-      .map((item) => {
-        const col = mergedColumns[keyList.indexOf(item.key)]
-        return {
+    return filterStates.reduce<FilterState<RecordType>[]>((list, item) => {
+      const keyIndex = keyList.indexOf(item.key)
+      if (keyIndex !== -1) {
+        const col = mergedColumns[keyIndex]
+        list.push({
           ...item,
           column: {
             ...item.column,
             ...col,
           },
           forceFiltered: col?.filtered as any,
-        }
-      })
+        })
+      }
+      return list
+    }, [])
   }
 
   warning?.(

--- a/packages/antdv-next/src/table/hooks/useSelection.tsx
+++ b/packages/antdv-next/src/table/hooks/useSelection.tsx
@@ -525,7 +525,9 @@ export default function useSelection<RecordType extends AnyObject = AnyObject>(
                 const nativeEvent = event.nativeEvent
                 const { shiftKey } = nativeEvent
                 const currentSelectedIndex = recordKeys.indexOf(key)
-                const isMultiple = derivedSelectedKeys.value[0].some(item => recordKeys.includes(item))
+                const isMultiple
+                  = derivedSelectedKeySet.value.size > 0
+                    && recordKeys.some(key => derivedSelectedKeySet.value.has(key))
 
                 if (shiftKey && checkStrictly.value && isMultiple) {
                   const changedKeys = multipleSelect(currentSelectedIndex, recordKeys, keySet)

--- a/packages/antdv-next/src/table/hooks/useSorter.tsx
+++ b/packages/antdv-next/src/table/hooks/useSorter.tsx
@@ -268,9 +268,12 @@ function stateToInfo<RecordType extends AnyObject = AnyObject>(sorterState: Sort
 }
 
 function generateSorterInfo<RecordType extends AnyObject = AnyObject>(sorterStates: SortState<RecordType>[]): SorterResult<RecordType> | SorterResult<RecordType>[] {
-  const activeSorters = sorterStates
-    .filter(({ sortOrder }) => sortOrder)
-    .map<SorterResult<RecordType>>(stateToInfo)
+  const activeSorters = sorterStates.reduce<SorterResult<RecordType>[]>((list, sorterState) => {
+    if (sorterState.sortOrder) {
+      list.push(stateToInfo(sorterState))
+    }
+    return list
+  }, [])
 
   if (activeSorters.length === 0 && sorterStates.length) {
     const lastIndex = sorterStates.length - 1

--- a/packages/antdv-next/src/table/interface.ts
+++ b/packages/antdv-next/src/table/interface.ts
@@ -86,10 +86,13 @@ export interface FilterConfirmProps {
   closeDropdown: boolean
 }
 
-export interface FilterRestProps {
+export interface FilterResetProps {
   confirm?: boolean
   closeDropdown?: boolean
 }
+
+/** @deprecated Please use `FilterResetProps` instead. */
+export interface FilterRestProps extends FilterResetProps {}
 
 export interface FilterDropdownProps {
   prefixCls: string
@@ -100,7 +103,7 @@ export interface FilterDropdownProps {
    * {closeDropdown: true}
    */
   confirm: (param?: FilterConfirmProps) => void
-  clearFilters?: (param?: FilterRestProps) => void
+  clearFilters?: (param?: FilterResetProps) => void
   filters?: ColumnFilterItem[]
   /** Only close filterDropdown */
   close: () => void

--- a/packages/antdv-next/src/transfer/Section.tsx
+++ b/packages/antdv-next/src/transfer/Section.tsx
@@ -233,7 +233,7 @@ const TransferSection = defineComponent<
     return () => {
       const checkBox = (
         <Checkbox
-          disabled={dataSource.value.filter(d => !d.disabled).length === 0 || props.disabled}
+          disabled={!dataSource.value.some(d => !d.disabled) || props.disabled}
           checked={checkStatus.value === 'all'}
           indeterminate={checkStatus.value === 'part'}
           class={`${listPrefixCls.value}-checkbox`}


### PR DESCRIPTION
## Summary

跟进 [ant-design 6.4.3](https://github.com/ant-design/ant-design/releases/tag/6.4.3) 中和 Table / Transfer 相关的所有变更（合并三个上游 PR 集中改动同一组文件，避免拆分后冲突）：

### #58004 — Table.useSelection 性能 + Transfer Section
- \`useSelection.tsx\` 的 \`isMultiple\` 之前 \`derivedSelectedKeys[0].some(item => recordKeys.includes(item))\` 是 O(n*m)；改用已经存在的 \`derivedSelectedKeySet\`，反过来 \`recordKeys.some(key => set.has(key))\`，命中率高时 O(1) 短路。
- Transfer \`Section.tsx\` checkbox \`disabled\` 由 \`dataSource.filter(d => !d.disabled).length === 0\` 改为 \`!dataSource.some(d => !d.disabled)\`，遇到首个 enabled 项即短路。
- 备注：React 版 \`filteredItems\` 的 \`useMemo\` deps 漏了 \`filterOption / direction\`，Vue 版用 \`computed\`，在 \`filterValue\` 真值分支会调用 \`matchFilter\`，自动追踪那两个 props，**不存在该 bug**。

### #57985 — FilterRestProps → FilterResetProps
- \`table/interface.ts\` 新增 \`FilterResetProps\` 为规范名；\`FilterRestProps extends FilterResetProps {}\` 保留 deprecated 别名做源码级兼容。
- \`clearFilters?: (param?: FilterResetProps) => void\`。
- \`useFilter/FilterDropdown.tsx\` 内部本地 interface 同步重命名。

### #58006 — Table 内部 \`.filter().map()\` → \`reduce\`
- \`useSorter.tsx\` 的 \`generateSorterInfo\`
- \`useFilter/index.tsx\` 的 \`getMergedFilterStates\`（顺便缓存 \`keyIndex\` 避免 indexOf 两次）

## Test plan

- [x] \`pnpm -F antdv-next test Table.selection Table.filter Table.sorter useFilter.test transfer --run\` — 全部 ✅
- [x] 全量受影响包 516/516 ✅
- [x] ESLint 干净
- [x] 上游 \`FilterRestProps\` 不在 Table \`index.tsx\` 公开导出，下游沿用相同导出面（消费者从 \`interface.ts\` 类型导入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)