### PR TITLE
perf(mentions): sync ant-design 6.4.3 getMentions reduce iteration

### DIFF
--- a/packages/antdv-next/src/mentions/index.tsx
+++ b/packages/antdv-next/src/mentions/index.tsx
@@ -439,29 +439,29 @@ Mentions.getMentions = (value = '', config: MentionsConfig = {}): MentionsEntity
   const { prefix = '@', split = ' ' } = config
   const prefixList: string[] = toList(prefix)
 
-  return value
-    .split(split)
-    .map((str = ''): MentionsEntity | null => {
-      let hitPrefix: string | null = null
+  return value.split(split).reduce<MentionsEntity[]>((list, str = '') => {
+    let hitPrefix: string | null = null
 
-      prefixList.some((prefixStr) => {
-        const startStr = str.slice(0, prefixStr.length)
-        if (startStr === prefixStr) {
-          hitPrefix = prefixStr
-          return true
-        }
-        return false
-      })
-
-      if (hitPrefix !== null) {
-        return {
-          prefix: hitPrefix,
-          value: str.slice((hitPrefix as string).length),
-        }
+    prefixList.some((prefixStr) => {
+      const startStr = str.slice(0, prefixStr.length)
+      if (startStr === prefixStr) {
+        hitPrefix = prefixStr
+        return true
       }
-      return null
+      return false
     })
-    .filter((entity): entity is MentionsEntity => !!entity && !!entity.value)
+
+    if (hitPrefix !== null) {
+      const entity = {
+        prefix: hitPrefix,
+        value: str.slice((hitPrefix as string).length),
+      }
+      if (entity.value) {
+        list.push(entity)
+      }
+    }
+    return list
+  }, [])
 }
 
 // We don't care debug panel


### PR DESCRIPTION
## Summary

跟进 [ant-design#58006](https://github.com/ant-design/ant-design/pull/58006) 中的 Mentions 部分（Table 部分在另一个 PR 里）。

\`Mentions.getMentions\` 之前是 \`value.split(split).map(...).filter(entity => entity?.value)\`，会先生成一个含 null 的中间数组再过滤；改写成单个 \`reduce\`，命中前缀且 \`value\` 非空时直接 push，省一次遍历和一份临时数组。语义完全不变。

## Test plan

- [x] \`pnpm -F antdv-next test Mentions --run\` — 全部 ✅
- [x] ESLint 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)