### PR TITLE
fix(modal): support global config locale

### DIFF
--- a/packages/antdv-next/src/config-provider/index.tsx
+++ b/packages/antdv-next/src/config-provider/index.tsx
@@ -119,6 +119,7 @@ export interface GlobalConfigProps {
   prefixCls?: string
   iconPrefixCls?: string
   theme?: Theme | ThemeConfig
+  locale?: Locale
   holderRender?: holderRenderType
   appContext?: AppContext
 }
@@ -134,7 +135,7 @@ function getGlobalIconPrefixCls() {
 }
 
 function setGlobalConfig(props: GlobalConfigProps) {
-  const { prefixCls, iconPrefixCls, theme, holderRender, appContext } = props
+  const { prefixCls, iconPrefixCls, theme, locale, holderRender, appContext } = props
   if (prefixCls !== undefined) {
     globalPrefixCls = prefixCls
     globalConfigData.prefixCls = prefixCls
@@ -153,6 +154,9 @@ function setGlobalConfig(props: GlobalConfigProps) {
   if (theme) {
     globalTheme = theme
     globalConfigData.theme = theme
+  }
+  if ('locale' in props) {
+    globalConfigData.locale = locale
   }
 }
 
@@ -401,6 +405,7 @@ export function globalConfig() {
     },
     getTheme: () => globalTheme,
     theme: computed(() => globalConfigData.theme || globalTheme),
+    locale: globalConfigData.locale,
     holderRender: globalHolderRender,
     get appContext() {
       return globalConfigData.appContext

--- a/packages/antdv-next/src/modal/confirm.tsx
+++ b/packages/antdv-next/src/modal/confirm.tsx
@@ -72,6 +72,7 @@ export default function confirm(config: ModalFuncProps) {
         prefixCls: rootPrefixCls,
         iconPrefixCls,
         theme,
+        locale: global.locale,
       },
       {
         default: () => holderNode,

--- a/packages/antdv-next/src/modal/tests/Modal.test.tsx
+++ b/packages/antdv-next/src/modal/tests/Modal.test.tsx
@@ -12,7 +12,7 @@ describe('modal static', () => {
 
   afterEach(async () => {
     Modal.destroyAll()
-    ConfigProvider.config({ holderRender: undefined })
+    ConfigProvider.config({ holderRender: undefined, locale: undefined })
     await waitFakeTimer(1, 5)
     vi.useRealTimers()
     document.body.innerHTML = ''
@@ -48,6 +48,22 @@ describe('modal static', () => {
         </ConfigProvider>
       ),
     })
+
+    Modal.confirm({
+      title: '标题',
+      content: '内容',
+    })
+
+    await waitFakeTimer(1, 5)
+
+    const buttons = Array.from(document.querySelectorAll('.ant-modal-confirm-btns .ant-btn'))
+      .map(node => node.textContent?.replace(/\s+/g, '').trim())
+
+    expect(buttons).toEqual(['取消', '确定'])
+  })
+
+  it('modal.confirm should support locale from global config', async () => {
+    ConfigProvider.config({ locale: zhCN })
 
     Modal.confirm({
       title: '标题',


### PR DESCRIPTION
## Summary

- Allow `ConfigProvider.config({ locale })` to provide locale data to Modal static methods.
- Pass the configured global locale into the internal ConfigProvider used by `Modal.confirm`.
- Add a regression test for Chinese confirm/cancel button text from global config.

## Test Plan

- `pnpm test packages/antdv-next/src/modal/tests/Modal.test.tsx --run`
- `pnpm exec eslint packages/antdv-next/src/config-provider/index.tsx packages/antdv-next/src/modal/confirm.tsx packages/antdv-next/src/modal/tests/Modal.test.tsx`

Closes #544
