### PR TITLE
chore(deps): update @v-c/table to 1.1.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,8 +405,8 @@ catalogs:
       specifier: ^1.0.0
       version: 1.0.0
     '@v-c/table':
-      specifier: ^1.1.1
-      version: 1.1.1
+      specifier: ^1.1.2
+      version: 1.1.2
     '@v-c/tabs':
       specifier: ^1.1.0
       version: 1.1.0
@@ -608,7 +608,7 @@ importers:
         version: link:../packages/cssinjs
       '@antdv-next/happy-work-theme':
         specifier: catalog:prod
-        version: 1.0.0(antdv-next@1.3.0(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.0(antdv-next@1.3.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       '@antdv-next/icons':
         specifier: catalog:prod
         version: 1.0.6(vue@3.5.30(typescript@5.9.3))
@@ -626,7 +626,7 @@ importers:
         version: 14.2.1(vue@3.5.30(typescript@5.9.3))
       antdv-style:
         specifier: catalog:prod
-        version: 1.0.0-rc.1(antdv-next@1.3.0(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.0-rc.1(antdv-next@1.3.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       dayjs:
         specifier: catalog:prod
         version: 1.11.20
@@ -876,7 +876,7 @@ importers:
         version: 1.0.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/table':
         specifier: catalog:vc
-        version: 1.1.1(vue@3.5.30(typescript@5.9.3))
+        version: 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/tabs':
         specifier: catalog:vc
         version: 1.1.0(vue@3.5.30(typescript@5.9.3))
@@ -2858,11 +2858,6 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/image@1.0.11':
-    resolution: {integrity: sha512-BkvIkEcP2M25fvNCEMcWX7hk+gFtk6Vg6V08wtoQZmvt/0shl3uS5q+4/NxJFOOjtMzWAkmGreRcqzfsOE/ptw==}
-    peerDependencies:
-      vue: ^3.0.0
-
   '@v-c/image@1.0.12':
     resolution: {integrity: sha512-SwGOHRSHPiAWlazy+vfwE3dIniIWQLXfl6R0SdlMFbUZ6mbklkym2KqJxj+ZL7psl4tpO+WsgU9IZDMBzXmFPw==}
     peerDependencies:
@@ -2989,6 +2984,11 @@ packages:
 
   '@v-c/table@1.1.1':
     resolution: {integrity: sha512-x45kpgTLFJV4MTgYbgQk5+TMwMCaD4TVBqoAQIR10JVuICj+Kd3Le2yjjNE99Fo4oiICUX1hlTx7/3Cx9G9Sgg==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@v-c/table@1.1.2':
+    resolution: {integrity: sha512-rMEoU2ZzwmgdNR0u8CYdXunskJqVJXgPBsDvG/ohIqnpSf0ORzNgRfX9pfyVDz/XsH6tZdpKC6A3h3jEfoGdNQ==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3295,8 +3295,8 @@ packages:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
-  antdv-next@1.3.0:
-    resolution: {integrity: sha512-gq03r9zd7LOLYke7BpAnk2AzjLw+QLRtTjbx4Wqtp8hNjqBRTEaZ5bUX3MmpzsAgxrSDNy8JdEKH9SEHjfoBUQ==}
+  antdv-next@1.3.1:
+    resolution: {integrity: sha512-L0bAG4o7pc/e0VogkldJ309/U8jjwd0RUXmZ1ev5Gihn2T4no/ylpldonN5iDI/ksjSqjkeOSnKy5/Tkg3l2sg==}
 
   antdv-style@1.0.0-rc.1:
     resolution: {integrity: sha512-CRu+zwJ0nRy3u9vpWm1odesX9Xk1kgvYrGR/enLNbn6yfY8HEgIIvRkeXASIHoaVMDi2E8Jozi+1lGOfiVg0LQ==}
@@ -6474,10 +6474,10 @@ snapshots:
       stylis: 4.3.6
       vue: 3.5.30(typescript@5.9.3)
 
-  '@antdv-next/happy-work-theme@1.0.0(antdv-next@1.3.0(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+  '@antdv-next/happy-work-theme@1.0.0(antdv-next@1.3.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@ant-design/fast-color': 3.0.1
-      antdv-next: 1.3.0(vue@3.5.30(typescript@5.9.3))
+      antdv-next: 1.3.1(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@antdv-next/icons@1.0.6(vue@3.5.30(typescript@5.9.3))':
@@ -8343,12 +8343,6 @@ snapshots:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@v-c/image@1.0.11(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@v-c/portal': 1.0.8(vue@3.5.30(typescript@5.9.3))
-      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
-
   '@v-c/image@1.0.12(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.30(typescript@5.9.3))
@@ -8492,6 +8486,13 @@ snapshots:
       vue: 3.5.30(typescript@5.9.3)
 
   '@v-c/table@1.1.1(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@v-c/resize-observer': 1.1.0(vue@3.5.30(typescript@5.9.3))
+      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
+      '@v-c/virtual-list': 1.0.7(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
+  '@v-c/table@1.1.2(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
@@ -8889,7 +8890,7 @@ snapshots:
 
   ansis@4.2.0: {}
 
-  antdv-next@1.3.0(vue@3.5.30(typescript@5.9.3)):
+  antdv-next@1.3.1(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@ant-design/colors': 8.0.1
       '@ant-design/fast-color': 3.0.1
@@ -8903,7 +8904,7 @@ snapshots:
       '@v-c/dialog': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/drawer': 1.0.6(vue@3.5.30(typescript@5.9.3))
       '@v-c/dropdown': 1.0.2(vue@3.5.30(typescript@5.9.3))
-      '@v-c/image': 1.0.11(vue@3.5.30(typescript@5.9.3))
+      '@v-c/image': 1.0.12(vue@3.5.30(typescript@5.9.3))
       '@v-c/input': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/input-number': 1.0.5(vue@3.5.30(typescript@5.9.3))
       '@v-c/mentions': 1.1.0(vue@3.5.30(typescript@5.9.3))
@@ -8944,10 +8945,10 @@ snapshots:
       - moment
       - vue
 
-  antdv-style@1.0.0-rc.1(antdv-next@1.3.0(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
+  antdv-style@1.0.0-rc.1(antdv-next@1.3.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@emotion/css': 11.13.5
-      antdv-next: 1.3.0(vue@3.5.30(typescript@5.9.3))
+      antdv-next: 1.3.1(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -155,7 +155,7 @@ catalogs:
     '@v-c/slider': ^1.1.0
     '@v-c/steps': ^1.0.0
     '@v-c/switch': ^1.0.0
-    '@v-c/table': ^1.1.1
+    '@v-c/table': ^1.1.2
     '@v-c/tabs': ^1.1.0
     '@v-c/textarea': ^1.1.0
     '@v-c/tooltip': ^1.0.3


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

中文版模板 / Chinese template: [中文版模板](./PULL_REQUEST_TEMPLATE_CN.md)
-->

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [x] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

ref #545

### 💡 Background and Solution

Update `@v-c/table` dependency version from `1.1.1` to `1.1.2` in pnpm workspace catalog configuration.

**Change:**
- `pnpm-workspace.yaml`: `@v-c/table` catalog version `^1.1.1` → `^1.1.2`
- `pnpm-lock.yaml`: auto-regenerated lock file

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | chore(deps): update @v-c/table to 1.1.2 |
| 🇨🇳 Chinese | chore(deps): 更新 @v-c/table 至 1.1.2 |
