### PR TITLE
fix(tour): exclude children from button props spread to avoid Vue DOM warning

### DIFF
--- a/packages/antdv-next/src/tour/panelRender.tsx
+++ b/packages/antdv-next/src/tour/panelRender.tsx
@@ -162,6 +162,11 @@ const TourPanel = defineComponent<
         _nextBtn = nextButtonPropsChild
       }
 
+      // Exclude `children` from spread — it is extracted above for slot content
+      // and must not leak as a DOM prop onto the <button> element.
+      const { children: _prevChildren, ...prevBtnRest } = prevButtonProps ?? {} as any
+      const { children: _nextChildren, ...nextBtnRest } = nextButtonProps ?? {} as any
+
       const defaultActionsNode = (
         <>
           {current !== 0
@@ -169,7 +174,7 @@ const TourPanel = defineComponent<
                 <Button
                   size="small"
                   {...secondaryBtnProps}
-                  {...prevButtonProps}
+                  {...prevBtnRest}
                   onClick={prevBtnClick}
                   class={clsx(`${prefixCls}-prev-btn`, prevButtonProps?.class)}
                 >
@@ -180,7 +185,7 @@ const TourPanel = defineComponent<
           <Button
             size="small"
             type={mainBtnType}
-            {...nextButtonProps}
+            {...nextBtnRest}
             onClick={nextBtnClick}
             class={clsx(`${prefixCls}-next-btn`, nextButtonProps?.class)}
           >


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

N/A — found during local testing of Tour component.

### 💡 Background and Solution

When `nextButtonProps` or `prevButtonProps` on a Tour step contains a `children` key (e.g. `{ children: 'Go Forward' }`), the object is spread directly onto the `<Button>` component. In Vue, `children` is not a valid DOM prop — it's a React concept — so Vue tries to set it as a property on the underlying `<button>` element, producing:

```
Failed setting prop "children" on <button>: value Go Forward is invalid.
TypeError: Cannot set property children of [object Element] which has only a getter
```

The `children` value is already extracted separately via `getSlotPropsFnRun` for slot content, so it doesn't need to be in the spread at all. The fix destructures `children` out of `nextButtonProps` and `prevButtonProps` before spreading the rest onto `<Button>`.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(tour): exclude `children` from `nextButtonProps`/`prevButtonProps` spread to avoid Vue DOM warning when customizing button text |
| 🇨🇳 Chinese | fix(tour): 从 `nextButtonProps`/`prevButtonProps` 展开中排除 `children`，避免自定义按钮文本时的 Vue DOM 警告 |
