### PR TITLE
fix(switch): emit click event from Switch component

### DIFF
--- a/packages/antdv-next/src/switch/index.tsx
+++ b/packages/antdv-next/src/switch/index.tsx
@@ -189,6 +189,9 @@ const Switch = defineComponent<
     const changeHandler: SwitchChangeEventHandler = (...args) => {
       emit('change', ...args)
     }
+    const clickHandler: SwitchClickEventHandler = (...args) => {
+      emit('click', ...args)
+    }
     const handleVMHandler = (checked: boolean) => {
       // 根据 checked 状态返回对应的自定义值
       const newValue = checked ? mergedCheckedValue.value : mergedUnCheckedValue.value
@@ -245,6 +248,7 @@ const Switch = defineComponent<
             styles={mergedStyles.value}
             checked={isChecked.value}
             onChange={changeHandler}
+            onClick={clickHandler}
             prefixCls={prefixCls.value}
             className={classes}
             style={mergedStyle}

--- a/packages/antdv-next/src/switch/tests/Switch.test.tsx
+++ b/packages/antdv-next/src/switch/tests/Switch.test.tsx
@@ -235,6 +235,16 @@ describe('switch', () => {
     expect(onChange).toHaveBeenCalledWith(true, expect.anything())
   })
 
+  it('should emit click event only once per click', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(Switch, {
+      props: { onClick },
+    })
+    await wrapper.find('button').trigger('click')
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onClick).toHaveBeenCalledWith(true, expect.anything())
+  })
+
   // ===================== click toggles switch =====================
 
   it('should toggle on button click', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,8 +402,8 @@ catalogs:
       specifier: ^1.0.0
       version: 1.0.0
     '@v-c/switch':
-      specifier: ^1.0.0
-      version: 1.0.0
+      specifier: ^1.0.1
+      version: 1.0.1
     '@v-c/table':
       specifier: ^1.1.3
       version: 1.1.3
@@ -608,7 +608,7 @@ importers:
         version: link:../packages/cssinjs
       '@antdv-next/happy-work-theme':
         specifier: catalog:prod
-        version: 1.0.0(antdv-next@1.3.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.0(antdv-next@1.3.2-beta.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       '@antdv-next/icons':
         specifier: catalog:prod
         version: 1.0.6(vue@3.5.30(typescript@5.9.3))
@@ -626,7 +626,7 @@ importers:
         version: 14.2.1(vue@3.5.30(typescript@5.9.3))
       antdv-style:
         specifier: catalog:prod
-        version: 1.0.0-rc.1(antdv-next@1.3.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.0-rc.1(antdv-next@1.3.2-beta.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       dayjs:
         specifier: catalog:prod
         version: 1.11.20
@@ -873,7 +873,7 @@ importers:
         version: 1.0.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/switch':
         specifier: catalog:vc
-        version: 1.0.0(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/table':
         specifier: catalog:vc
         version: 1.1.3(vue@3.5.30(typescript@5.9.3))
@@ -2982,8 +2982,8 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/table@1.1.2':
-    resolution: {integrity: sha512-rMEoU2ZzwmgdNR0u8CYdXunskJqVJXgPBsDvG/ohIqnpSf0ORzNgRfX9pfyVDz/XsH6tZdpKC6A3h3jEfoGdNQ==}
+  '@v-c/switch@1.0.1':
+    resolution: {integrity: sha512-dWMBfb5/8o3GFGvayyT576YWB6yPW8Aa2Ba5I9hXcYvuIH4JJ5NYI3WJqc8KpFMNA4Y4/MyVIY3NNsXyXa22bw==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3295,8 +3295,8 @@ packages:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
-  antdv-next@1.3.1:
-    resolution: {integrity: sha512-L0bAG4o7pc/e0VogkldJ309/U8jjwd0RUXmZ1ev5Gihn2T4no/ylpldonN5iDI/ksjSqjkeOSnKy5/Tkg3l2sg==}
+  antdv-next@1.3.2-beta.1:
+    resolution: {integrity: sha512-XoIoxQ5aq5RdDzDbbyg3rvf7uZpZZPbA2oPZHQEt3YhZs+iGZWkePadd1rKV4L3h8IMw7ZiGXsmFDrxP11eqsg==}
 
   antdv-style@1.0.0-rc.1:
     resolution: {integrity: sha512-CRu+zwJ0nRy3u9vpWm1odesX9Xk1kgvYrGR/enLNbn6yfY8HEgIIvRkeXASIHoaVMDi2E8Jozi+1lGOfiVg0LQ==}
@@ -6474,10 +6474,10 @@ snapshots:
       stylis: 4.3.6
       vue: 3.5.30(typescript@5.9.3)
 
-  '@antdv-next/happy-work-theme@1.0.0(antdv-next@1.3.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+  '@antdv-next/happy-work-theme@1.0.0(antdv-next@1.3.2-beta.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@ant-design/fast-color': 3.0.1
-      antdv-next: 1.3.1(vue@3.5.30(typescript@5.9.3))
+      antdv-next: 1.3.2-beta.1(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@antdv-next/icons@1.0.6(vue@3.5.30(typescript@5.9.3))':
@@ -8485,11 +8485,9 @@ snapshots:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@v-c/table@1.1.2(vue@3.5.30(typescript@5.9.3))':
+  '@v-c/switch@1.0.1(vue@3.5.30(typescript@5.9.3))':
     dependencies:
-      '@v-c/resize-observer': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      '@v-c/virtual-list': 1.0.7(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@v-c/table@1.1.3(vue@3.5.30(typescript@5.9.3))':
@@ -8890,7 +8888,7 @@ snapshots:
 
   ansis@4.2.0: {}
 
-  antdv-next@1.3.1(vue@3.5.30(typescript@5.9.3)):
+  antdv-next@1.3.2-beta.1(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@ant-design/colors': 8.0.1
       '@ant-design/fast-color': 3.0.1
@@ -8923,7 +8921,7 @@ snapshots:
       '@v-c/slider': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/steps': 1.0.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/switch': 1.0.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/table': 1.1.2(vue@3.5.30(typescript@5.9.3))
+      '@v-c/table': 1.1.3(vue@3.5.30(typescript@5.9.3))
       '@v-c/tabs': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/textarea': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/tooltip': 1.0.3(vue@3.5.30(typescript@5.9.3))
@@ -8945,10 +8943,10 @@ snapshots:
       - moment
       - vue
 
-  antdv-style@1.0.0-rc.1(antdv-next@1.3.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
+  antdv-style@1.0.0-rc.1(antdv-next@1.3.2-beta.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@emotion/css': 11.13.5
-      antdv-next: 1.3.1(vue@3.5.30(typescript@5.9.3))
+      antdv-next: 1.3.2-beta.1(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -154,7 +154,7 @@ catalogs:
     '@v-c/slick': ^1.0.2
     '@v-c/slider': ^1.1.0
     '@v-c/steps': ^1.0.0
-    '@v-c/switch': ^1.0.0
+    '@v-c/switch': ^1.0.1
     '@v-c/table': ^1.1.3
     '@v-c/tabs': ^1.1.0
     '@v-c/textarea': ^1.1.0


### PR DESCRIPTION
[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

`Switch` 组件之前没有透传 `click` 事件，在模板中写 `<a-switch @click="...">` 不会触发任何回调。

- 在 `Switch` 内部新增 `clickHandler`，通过 `emit('click', ...)` 抛出。
- 将该 handler 透传给底层 `@v-c/switch` 的 `onClick`。
- 同步升级 `@v-c/switch` 到 `1.0.1`（该版本解决 `onClick` 在 button 上触发两次问题）。
- 新增单测：单次点击只触发一次 `click`，参数为 `(checked, event)`。

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `Switch` now emits the `click` event. |
| 🇨🇳 Chinese | `Switch` 组件支持 `click` 事件透传。 |