### PR TITLE
docs(tabs): replace children to content

### DIFF
--- a/docs/src/pages/components/tabs/demo/_semantic.vue
+++ b/docs/src/pages/components/tabs/demo/_semantic.vue
@@ -22,7 +22,7 @@ const items = computed(() =>
       label: `Tab-${id}`,
       key: id,
       disabled: i === 28,
-      children: `Content of tab ${id}`,
+      content: `Content of tab ${id}`,
     }
   }),
 )

--- a/packages/antdv-next/src/tabs/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/tabs/tests/__snapshots__/demo.test.tsx.snap
@@ -568,7 +568,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 0
             </div>
             <!---->
             <div
@@ -577,7 +577,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               role="tabpanel"
               tabindex="0"
             >
-              <!---->
+              Content of tab 1
             </div>
             <!---->
             <div
@@ -587,7 +587,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 2
             </div>
             <!---->
             <div
@@ -597,7 +597,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 3
             </div>
             <!---->
             <div
@@ -607,7 +607,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 4
             </div>
             <!---->
             <div
@@ -617,7 +617,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 5
             </div>
             <!---->
             <div
@@ -627,7 +627,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 6
             </div>
             <!---->
             <div
@@ -637,7 +637,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 7
             </div>
             <!---->
             <div
@@ -647,7 +647,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 8
             </div>
             <!---->
             <div
@@ -657,7 +657,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 9
             </div>
             <!---->
             <div
@@ -667,7 +667,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 10
             </div>
             <!---->
             <div
@@ -677,7 +677,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 11
             </div>
             <!---->
             <div
@@ -687,7 +687,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 12
             </div>
             <!---->
             <div
@@ -697,7 +697,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 13
             </div>
             <!---->
             <div
@@ -707,7 +707,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 14
             </div>
             <!---->
             <div
@@ -717,7 +717,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 15
             </div>
             <!---->
             <div
@@ -727,7 +727,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 16
             </div>
             <!---->
             <div
@@ -737,7 +737,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 17
             </div>
             <!---->
             <div
@@ -747,7 +747,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 18
             </div>
             <!---->
             <div
@@ -757,7 +757,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 19
             </div>
             <!---->
             <div
@@ -767,7 +767,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 20
             </div>
             <!---->
             <div
@@ -777,7 +777,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 21
             </div>
             <!---->
             <div
@@ -787,7 +787,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 22
             </div>
             <!---->
             <div
@@ -797,7 +797,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 23
             </div>
             <!---->
             <div
@@ -807,7 +807,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 24
             </div>
             <!---->
             <div
@@ -817,7 +817,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 25
             </div>
             <!---->
             <div
@@ -827,7 +827,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 26
             </div>
             <!---->
             <div
@@ -837,7 +837,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 27
             </div>
             <!---->
             <div
@@ -847,7 +847,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 28
             </div>
             <!---->
             <div
@@ -857,7 +857,7 @@ exports[`tabs demo > renders _semantic correctly 1`] = `
               style="display: none;"
               tabindex="-1"
             >
-              <!---->
+              Content of tab 29
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Replace `children` to `content `      |
| 🇨🇳 Chinese |    将`children`替换为`content`       |
