### PR TITLE
docs(carousel): remove missing component token demo

### DIFF
--- a/docs/src/pages/components/carousel/index.en-US.md
+++ b/docs/src/pages/components/carousel/index.en-US.md
@@ -24,7 +24,6 @@ demo:
   <demo src="./demo/fade.vue">Fade in</demo>
   <demo src="./demo/arrows.vue" >Arrows for switching</demo>
   <demo src="./demo/dot-duration.vue" >Progress of dots</demo>
-  <demo src="./demo/component-token.vue" debug>Component Token</demo>
 </demo-group>
 
 ## API


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

The English Carousel documentation references ./demo/component-token.vue, but that demo file does not exist. This leaves an empty Component Token demo card on the docs page.

This PR removes the extra demo entry from the English Carousel docs, keeping the demo list aligned with the available demo files and the Chinese documentation.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove the missing Component Token demo entry from Carousel docs. |
| 🇨🇳 Chinese | 移除 Carousel 英文文档中缺失的 Component Token 示例入口。 |