### PR TITLE
fix(descriptions): fix label styles not applied in non-bordered mode

### DIFF
--- a/packages/antdv-next/src/descriptions/Cell.tsx
+++ b/packages/antdv-next/src/descriptions/Cell.tsx
@@ -60,14 +60,16 @@ const Cell = defineComponent<CellProps>(
         >
           <div class={`${itemPrefixCls}-item-container`}>
             {(label || label === 0) && (
-              <span class={classNames(
-                `${itemPrefixCls}-item-label`,
-                descriptionsClassNames?.label,
-                {
-                  [`${itemPrefixCls}-item-no-colon`]: !colon,
-                },
-                classes?.label,
-              )}
+              <span
+                class={classNames(
+                  `${itemPrefixCls}-item-label`,
+                  descriptionsClassNames?.label,
+                  {
+                    [`${itemPrefixCls}-item-no-colon`]: !colon,
+                  },
+                  classes?.label,
+                )}
+                style={styles?.label}
               >
                 {label}
               </span>

--- a/packages/antdv-next/src/descriptions/tests/Descriptions.semantic.test.tsx
+++ b/packages/antdv-next/src/descriptions/tests/Descriptions.semantic.test.tsx
@@ -66,6 +66,8 @@ describe('descriptions.Semantic', () => {
     const contentSpan = wrapper.find('.ant-descriptions-item-content')
     expect(labelSpan.exists()).toBe(true)
     expect(contentSpan.exists()).toBe(true)
+    expect(labelSpan.attributes('style')).toContain('color: blue')
+    expect(contentSpan.attributes('style')).toContain('color: green')
   })
 
   it('should support classes and styles as functions', () => {


### PR DESCRIPTION
## 问题描述

在 `Cell.tsx` 中，非 bordered 模式下 label 的 span 元素缺少 `style` 属性绑定，导致通过 `styles` prop 传入的 label 样式无法应用到 DOM 上。

## 修复内容

- 修复了非 bordered 模式下 label 样式不生效的问题
- 添加了相应的单元测试验证修复效果

## 测试

运行 `Descriptions.semantic.test.tsx` 验证修复。