### PR TITLE
fix(modal): upgrade @v-c/dialog to v1.1.1 to fix forceRender

### DIFF
--- a/packages/antdv-next/src/modal/tests/Modal.test.tsx
+++ b/packages/antdv-next/src/modal/tests/Modal.test.tsx
@@ -170,4 +170,26 @@ describe('modal integration', () => {
 
     expect(document.activeElement).toBe(popupInput)
   })
+
+  it('should render content when forceRender is true even if modal is closed', async () => {
+    const wrapper = mount(Modal, {
+      attachTo: document.body,
+      props: {
+        open: false,
+        forceRender: true,
+        title: 'Force Render Modal',
+      },
+      slots: {
+        default: () => <div id="force-render-content">Hello</div>,
+      },
+    })
+
+    await waitFakeTimer(20, 10)
+
+    const content = document.getElementById('force-render-content')
+    expect(content).not.toBeNull()
+    expect(content!.textContent).toBe('Hello')
+
+    wrapper.unmount()
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,8 +342,8 @@ catalogs:
       specifier: ^1.0.6
       version: 1.0.6
     '@v-c/dialog':
-      specifier: ^1.1.0
-      version: 1.1.0
+      specifier: ^1.1.1
+      version: 1.1.1
     '@v-c/drawer':
       specifier: ^1.0.6
       version: 1.0.6
@@ -608,7 +608,7 @@ importers:
         version: link:../packages/cssinjs
       '@antdv-next/happy-work-theme':
         specifier: catalog:prod
-        version: 1.0.0(antdv-next@1.3.2(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.0(antdv-next@1.3.3(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       '@antdv-next/icons':
         specifier: catalog:prod
         version: 1.0.6(vue@3.5.30(typescript@5.9.3))
@@ -626,7 +626,7 @@ importers:
         version: 14.2.1(vue@3.5.30(typescript@5.9.3))
       antdv-style:
         specifier: catalog:prod
-        version: 1.0.0-rc.1(antdv-next@1.3.2(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.0-rc.1(antdv-next@1.3.3(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       dayjs:
         specifier: catalog:prod
         version: 1.11.20
@@ -810,7 +810,7 @@ importers:
         version: 1.0.6(vue@3.5.30(typescript@5.9.3))
       '@v-c/dialog':
         specifier: catalog:vc
-        version: 1.1.0(vue@3.5.30(typescript@5.9.3))
+        version: 1.1.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/drawer':
         specifier: catalog:vc
         version: 1.0.6(vue@3.5.30(typescript@5.9.3))
@@ -2848,6 +2848,11 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
+  '@v-c/dialog@1.1.1':
+    resolution: {integrity: sha512-hYy5kr671GY8lIXNqeDzDFFT60r+kAmaw75H6YBPXjlI+QndULnUH9/x+DzuBZDp8Tx5WzvGp8ZQgg9J8NROjQ==}
+    peerDependencies:
+      vue: ^3.0.0
+
   '@v-c/drawer@1.0.6':
     resolution: {integrity: sha512-nW8rCsf7viUsTo+8SAfqcNDO4B0GC4n2VidHV4kJzbERrMvMsHVpDz1LO+UFgLs8Mn9EjpQm40JtF6d/BNkW0g==}
     peerDependencies:
@@ -2875,11 +2880,6 @@ packages:
 
   '@v-c/mentions@1.1.0':
     resolution: {integrity: sha512-sCMsUh4He0uAflcltLGqpg2YFS9wPRfZxoJaJVeCI2Z96sIoYpoaXTfZzkbHuFsISABFPH7kdHgqw/SUjKwqqQ==}
-    peerDependencies:
-      vue: ^3.0.0
-
-  '@v-c/menu@1.1.0':
-    resolution: {integrity: sha512-pgso+Z+VE4GlmcC1pMKVFWksaqPCyIN2GVtrt/ioK9kAKnJ9YW82XhjJYcyUyjZAX//+QSmFvsj7BVOxL1CUvg==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3034,11 +3034,6 @@ packages:
 
   '@v-c/util@1.0.19':
     resolution: {integrity: sha512-apJGS4BVzhXbrNR6jxXF18jAiOWIn/UNmGjgSvB5r4ba9Wr/ireKCfJvhuuNsZi+scLaM0W3ghB81PbQ5vwoJg==}
-    peerDependencies:
-      vue: ^3.0.0
-
-  '@v-c/virtual-list@1.0.7':
-    resolution: {integrity: sha512-zoINTbsUh7VNGHEAZnY/TZRWBmL7lhFxr1bwK6KxP+3CJSIG26b2jTQFzfdr/qq4CrmLcmpcW2jlHass7PAMAg==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3300,8 +3295,8 @@ packages:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
-  antdv-next@1.3.2:
-    resolution: {integrity: sha512-lAk9wbIfwBjPsWlZxdXCSC6qrfk/ZNwc2m9VH94B6SxwEuqkiszUDCEMU6odEInF5f0Kd5Bjmap0t3msZl7bFA==}
+  antdv-next@1.3.3:
+    resolution: {integrity: sha512-QrWPlLCEBmms5O7Hr1ZgElXJLAez2MDnqH6FZJCRcukH50iTOk7jOqHYtwznkCq33XilIuL8xcL6Yc4py40wyw==}
 
   antdv-style@1.0.0-rc.1:
     resolution: {integrity: sha512-CRu+zwJ0nRy3u9vpWm1odesX9Xk1kgvYrGR/enLNbn6yfY8HEgIIvRkeXASIHoaVMDi2E8Jozi+1lGOfiVg0LQ==}
@@ -6479,10 +6474,10 @@ snapshots:
       stylis: 4.3.6
       vue: 3.5.30(typescript@5.9.3)
 
-  '@antdv-next/happy-work-theme@1.0.0(antdv-next@1.3.2(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+  '@antdv-next/happy-work-theme@1.0.0(antdv-next@1.3.3(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@ant-design/fast-color': 3.0.1
-      antdv-next: 1.3.2(vue@3.5.30(typescript@5.9.3))
+      antdv-next: 1.3.3(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@antdv-next/icons@1.0.6(vue@3.5.30(typescript@5.9.3))':
@@ -8336,6 +8331,12 @@ snapshots:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
+  '@v-c/dialog@1.1.1(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@v-c/portal': 1.0.8(vue@3.5.30(typescript@5.9.3))
+      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
   '@v-c/drawer@1.0.6(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.30(typescript@5.9.3))
@@ -8371,13 +8372,6 @@ snapshots:
       '@v-c/input': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/menu': 1.1.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/textarea': 1.1.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/trigger': 1.0.15(vue@3.5.30(typescript@5.9.3))
-      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@v-c/menu@1.1.0(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@v-c/overflow': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/trigger': 1.0.15(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
@@ -8560,12 +8554,6 @@ snapshots:
 
   '@v-c/util@1.0.19(vue@3.5.30(typescript@5.9.3))':
     dependencies:
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@v-c/virtual-list@1.0.7(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@v-c/resize-observer': 1.1.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@v-c/virtual-list@1.0.8(vue@3.5.30(typescript@5.9.3))':
@@ -8901,7 +8889,7 @@ snapshots:
 
   ansis@4.2.0: {}
 
-  antdv-next@1.3.2(vue@3.5.30(typescript@5.9.3)):
+  antdv-next@1.3.3(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@ant-design/colors': 8.0.1
       '@ant-design/fast-color': 3.0.1
@@ -8919,7 +8907,7 @@ snapshots:
       '@v-c/input': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/input-number': 1.0.5(vue@3.5.30(typescript@5.9.3))
       '@v-c/mentions': 1.1.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/menu': 1.1.0(vue@3.5.30(typescript@5.9.3))
+      '@v-c/menu': 1.1.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/mutate-observer': 1.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/notification': 2.0.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/pagination': 1.0.0(vue@3.5.30(typescript@5.9.3))
@@ -8944,7 +8932,7 @@ snapshots:
       '@v-c/trigger': 1.0.15(vue@3.5.30(typescript@5.9.3))
       '@v-c/upload': 1.0.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      '@v-c/virtual-list': 1.0.7(vue@3.5.30(typescript@5.9.3))
+      '@v-c/virtual-list': 1.0.8(vue@3.5.30(typescript@5.9.3))
       '@vueuse/core': 14.2.1(vue@3.5.30(typescript@5.9.3))
       dayjs: 1.11.20
       es-toolkit: 1.45.1
@@ -8956,10 +8944,10 @@ snapshots:
       - moment
       - vue
 
-  antdv-style@1.0.0-rc.1(antdv-next@1.3.2(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
+  antdv-style@1.0.0-rc.1(antdv-next@1.3.3(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@emotion/css': 11.13.5
-      antdv-next: 1.3.2(vue@3.5.30(typescript@5.9.3))
+      antdv-next: 1.3.3(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -132,7 +132,7 @@ catalogs:
     '@v-c/checkbox': ^1.0.1
     '@v-c/collapse': ^1.0.0
     '@v-c/color-picker': ^1.0.6
-    '@v-c/dialog': ^1.1.0
+    '@v-c/dialog': ^1.1.1
     '@v-c/drawer': ^1.0.6
     '@v-c/dropdown': ^1.0.2
     '@v-c/image': ^1.0.12


### PR DESCRIPTION
## 问题描述

`@v-c/dialog@1.1.0` 的 `Panel.js` 中存在 forceRender 条件判断错误：

```javascript
// Bug: 条件反转
if (!animationVisible && forceRender) return null;
```

当 `forceRender=true` 时，内容应该始终渲染，但原逻辑会导致内容被错误地隐藏。

## 修复方式

升级 `@v-c/dialog` 到 `v1.1.1`，该版本修复了 forceRender 的条件判断问题：
- Panel 现在始终渲染内容，通过 `vShow` 控制显示/隐藏

## 改动内容

1. `pnpm-workspace.yaml` - 更新 `@v-c/dialog` 版本从 `^1.1.0` 到 `^1.1.1`
2. `pnpm-lock.yaml` - 更新依赖锁文件
3. `packages/antdv-next/src/modal/tests/Modal.test.tsx` - 添加 forceRender 测试用例

## 测试

7/7 Modal 测试用例全部通过。