### PR TITLE
chore: upgrade @v-c/menu to v1.1.2 to fix large-menu toggle jank

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ catalogs:
       specifier: ^1.1.0
       version: 1.1.0
     '@v-c/menu':
-      specifier: ^1.1.1
-      version: 1.1.1
+      specifier: ^1.1.2
+      version: 1.1.2
     '@v-c/mutate-observer':
       specifier: ^1.0.1
       version: 1.0.1
@@ -608,7 +608,7 @@ importers:
         version: link:../packages/cssinjs
       '@antdv-next/happy-work-theme':
         specifier: catalog:prod
-        version: 1.0.0(antdv-next@1.3.3(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.0(antdv-next@1.3.4-beta.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       '@antdv-next/icons':
         specifier: catalog:prod
         version: 1.0.6(vue@3.5.30(typescript@5.9.3))
@@ -626,7 +626,7 @@ importers:
         version: 14.2.1(vue@3.5.30(typescript@5.9.3))
       antdv-style:
         specifier: catalog:prod
-        version: 1.0.0-rc.1(antdv-next@1.3.3(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.0-rc.1(antdv-next@1.3.4-beta.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       dayjs:
         specifier: catalog:prod
         version: 1.11.20
@@ -831,7 +831,7 @@ importers:
         version: 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/menu':
         specifier: catalog:vc
-        version: 1.1.1(vue@3.5.30(typescript@5.9.3))
+        version: 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/mutate-observer':
         specifier: catalog:vc
         version: 1.0.1(vue@3.5.30(typescript@5.9.3))
@@ -2843,11 +2843,6 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/dialog@1.1.0':
-    resolution: {integrity: sha512-AAZuXPnVWQ4Bd/XgcsQqXGnp9t/6+vnbUTfRIjaMQ1WuUGu3aB1rwNrofnbB7l3KPBR/wmQ96GJSQjTm/dGLug==}
-    peerDependencies:
-      vue: ^3.0.0
-
   '@v-c/dialog@1.1.1':
     resolution: {integrity: sha512-hYy5kr671GY8lIXNqeDzDFFT60r+kAmaw75H6YBPXjlI+QndULnUH9/x+DzuBZDp8Tx5WzvGp8ZQgg9J8NROjQ==}
     peerDependencies:
@@ -2885,6 +2880,11 @@ packages:
 
   '@v-c/menu@1.1.1':
     resolution: {integrity: sha512-PQFVBjF93P+XLnBak1b2tFSKXa862qohEKJ6sKGeHyTH4DSKfAxMtxKGUghprbL2bqNmudjkDgioOqP1svh5pw==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@v-c/menu@1.1.2':
+    resolution: {integrity: sha512-SRbPYgSiGDYZmuFr6X4cpNf7j3HVA5k9usEIMInOUEwcxKJbbJV5Se2CTrKEulSUnZBl+8tR/rTZ5a85MQ6OAQ==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3295,8 +3295,8 @@ packages:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
-  antdv-next@1.3.3:
-    resolution: {integrity: sha512-QrWPlLCEBmms5O7Hr1ZgElXJLAez2MDnqH6FZJCRcukH50iTOk7jOqHYtwznkCq33XilIuL8xcL6Yc4py40wyw==}
+  antdv-next@1.3.4-beta.1:
+    resolution: {integrity: sha512-GBni1pV+zPWC4YxMlCcUnOxzF8n/PWaDMhkBPaypB7wZjlqO+ZUJEr0krd+NBJDUBKgWHc2o09rIUE9A0+CzwA==}
 
   antdv-style@1.0.0-rc.1:
     resolution: {integrity: sha512-CRu+zwJ0nRy3u9vpWm1odesX9Xk1kgvYrGR/enLNbn6yfY8HEgIIvRkeXASIHoaVMDi2E8Jozi+1lGOfiVg0LQ==}
@@ -6474,10 +6474,10 @@ snapshots:
       stylis: 4.3.6
       vue: 3.5.30(typescript@5.9.3)
 
-  '@antdv-next/happy-work-theme@1.0.0(antdv-next@1.3.3(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+  '@antdv-next/happy-work-theme@1.0.0(antdv-next@1.3.4-beta.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@ant-design/fast-color': 3.0.1
-      antdv-next: 1.3.3(vue@3.5.30(typescript@5.9.3))
+      antdv-next: 1.3.4-beta.1(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@antdv-next/icons@1.0.6(vue@3.5.30(typescript@5.9.3))':
@@ -8325,12 +8325,6 @@ snapshots:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@v-c/dialog@1.1.0(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@v-c/portal': 1.0.8(vue@3.5.30(typescript@5.9.3))
-      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
-
   '@v-c/dialog@1.1.1(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.30(typescript@5.9.3))
@@ -8370,13 +8364,20 @@ snapshots:
   '@v-c/mentions@1.1.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/input': 1.1.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/menu': 1.1.1(vue@3.5.30(typescript@5.9.3))
+      '@v-c/menu': 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/textarea': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/trigger': 1.0.15(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@v-c/menu@1.1.1(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@v-c/overflow': 1.1.0(vue@3.5.30(typescript@5.9.3))
+      '@v-c/trigger': 1.0.15(vue@3.5.30(typescript@5.9.3))
+      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
+  '@v-c/menu@1.1.2(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/trigger': 1.0.15(vue@3.5.30(typescript@5.9.3))
@@ -8501,7 +8502,7 @@ snapshots:
   '@v-c/tabs@1.1.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/dropdown': 1.0.2(vue@3.5.30(typescript@5.9.3))
-      '@v-c/menu': 1.1.1(vue@3.5.30(typescript@5.9.3))
+      '@v-c/menu': 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/overflow': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/resize-observer': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
@@ -8889,7 +8890,7 @@ snapshots:
 
   ansis@4.2.0: {}
 
-  antdv-next@1.3.3(vue@3.5.30(typescript@5.9.3)):
+  antdv-next@1.3.4-beta.1(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@ant-design/colors': 8.0.1
       '@ant-design/fast-color': 3.0.1
@@ -8900,7 +8901,7 @@ snapshots:
       '@v-c/checkbox': 1.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/collapse': 1.0.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/color-picker': 1.0.6(vue@3.5.30(typescript@5.9.3))
-      '@v-c/dialog': 1.1.0(vue@3.5.30(typescript@5.9.3))
+      '@v-c/dialog': 1.1.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/drawer': 1.0.6(vue@3.5.30(typescript@5.9.3))
       '@v-c/dropdown': 1.0.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/image': 1.0.12(vue@3.5.30(typescript@5.9.3))
@@ -8944,10 +8945,10 @@ snapshots:
       - moment
       - vue
 
-  antdv-style@1.0.0-rc.1(antdv-next@1.3.3(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
+  antdv-style@1.0.0-rc.1(antdv-next@1.3.4-beta.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@emotion/css': 11.13.5
-      antdv-next: 1.3.3(vue@3.5.30(typescript@5.9.3))
+      antdv-next: 1.3.4-beta.1(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -139,7 +139,7 @@ catalogs:
     '@v-c/input': ^1.1.0
     '@v-c/input-number': ^1.0.5
     '@v-c/mentions': ^1.1.0
-    '@v-c/menu': ^1.1.1
+    '@v-c/menu': ^1.1.2
     '@v-c/mutate-observer': ^1.0.1
     '@v-c/notification': ^2.0.0
     '@v-c/pagination': ^1.0.0


### PR DESCRIPTION
## Summary

Upgrade `@v-c/menu` to v1.1.2, which aligns the menu render memoization with rc-menu:

- both `parseItems` results are now memoized like rc-menu's `useMemo([children, items, _internalComponents])`, so controlled `openKeys` updates no longer rebuild and re-patch the whole vnode tree (visible + hidden measure list) on every toggle — this was freezing the inline collapse animation on 1000+ item menus
- `InheritableContextProvider` restores rc-menu's `locked` + deep-equal semantics, reusing the previous merged context reference when nothing changed so descendants are not invalidated by identity churn

close #583

## Test plan

- `@v-c/menu` side: new re-render regression specs (parseItems memo on openKeys toggle verified to fail before the fix), 11/11 menu tests pass
- antdv-next side: menu / dropdown / layout suites pass (186 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)