### PR TITLE
chore: upgrade @v-c/menu to v1.1.3 with menu regression tests

### DIFF
--- a/packages/antdv-next/src/layout/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/layout/tests/__snapshots__/demo.test.tsx.snap
@@ -420,8 +420,6 @@ exports[`layout demo > renders fixed correctly 1`] = `
       <li
         aria-hidden="true"
         class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal"
-        eventkey="vc-menu-more"
-        internalpopupclose="true"
         role="none"
         style="opacity: 0; height: 0px; overflow-y: hidden; order: 9007199254740991; pointer-events: none; position: absolute;"
       >
@@ -1607,7 +1605,6 @@ exports[`layout demo > renders side correctly 1`] = `
         <!---->
         <li
           class="ant-menu-submenu ant-menu-submenu-inline"
-          eventkey="sub1"
           role="none"
         >
           <div
@@ -1662,70 +1659,11 @@ exports[`layout demo > renders side correctly 1`] = `
             name="ant-motion-collapse"
             persisted="false"
           >
-            <ul
-              class="ant-menu ant-menu-sub ant-menu-inline"
-              data-menu-list="true"
-              id="vc-menu-uuid-sub1-popup"
-              role="menu"
-              style="display: none;"
-            >
-              <li
-                class="ant-menu-item ant-menu-item-only-child"
-                data-menu-id="vc-menu-uuid-3"
-                label="Tom"
-                role="menuitem"
-                style="padding-left: 48px;"
-                tabindex="-1"
-              >
-                <!---->
-                <span
-                  class="ant-menu-title-content"
-                >
-                  Tom
-                </span>
-                <!---->
-              </li>
-              <!---->
-              <li
-                class="ant-menu-item ant-menu-item-only-child"
-                data-menu-id="vc-menu-uuid-4"
-                label="Bill"
-                role="menuitem"
-                style="padding-left: 48px;"
-                tabindex="-1"
-              >
-                <!---->
-                <span
-                  class="ant-menu-title-content"
-                >
-                  Bill
-                </span>
-                <!---->
-              </li>
-              <!---->
-              <li
-                class="ant-menu-item ant-menu-item-only-child"
-                data-menu-id="vc-menu-uuid-5"
-                label="Alex"
-                role="menuitem"
-                style="padding-left: 48px;"
-                tabindex="-1"
-              >
-                <!---->
-                <span
-                  class="ant-menu-title-content"
-                >
-                  Alex
-                </span>
-                <!---->
-              </li>
-              <!---->
-            </ul>
+            <!---->
           </transition-stub>
         </li>
         <li
           class="ant-menu-submenu ant-menu-submenu-inline"
-          eventkey="sub2"
           role="none"
         >
           <div
@@ -1780,48 +1718,7 @@ exports[`layout demo > renders side correctly 1`] = `
             name="ant-motion-collapse"
             persisted="false"
           >
-            <ul
-              class="ant-menu ant-menu-sub ant-menu-inline"
-              data-menu-list="true"
-              id="vc-menu-uuid-sub2-popup"
-              role="menu"
-              style="display: none;"
-            >
-              <li
-                class="ant-menu-item ant-menu-item-only-child"
-                data-menu-id="vc-menu-uuid-6"
-                label="Team 1"
-                role="menuitem"
-                style="padding-left: 48px;"
-                tabindex="-1"
-              >
-                <!---->
-                <span
-                  class="ant-menu-title-content"
-                >
-                  Team 1
-                </span>
-                <!---->
-              </li>
-              <!---->
-              <li
-                class="ant-menu-item ant-menu-item-only-child"
-                data-menu-id="vc-menu-uuid-8"
-                label="Team 2"
-                role="menuitem"
-                style="padding-left: 48px;"
-                tabindex="-1"
-              >
-                <!---->
-                <span
-                  class="ant-menu-title-content"
-                >
-                  Team 2
-                </span>
-                <!---->
-              </li>
-              <!---->
-            </ul>
+            <!---->
           </transition-stub>
         </li>
         <li
@@ -2229,8 +2126,6 @@ exports[`layout demo > renders top correctly 1`] = `
       <li
         aria-hidden="true"
         class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal"
-        eventkey="vc-menu-more"
-        internalpopupclose="true"
         role="none"
         style="opacity: 0; height: 0px; overflow-y: hidden; order: 9007199254740991; pointer-events: none; position: absolute;"
       >
@@ -2415,8 +2310,6 @@ exports[`layout demo > renders top-side correctly 1`] = `
       <li
         aria-hidden="true"
         class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal"
-        eventkey="vc-menu-more"
-        internalpopupclose="true"
         role="none"
         style="opacity: 0; height: 0px; overflow-y: hidden; order: 9007199254740991; pointer-events: none; position: absolute;"
       >
@@ -2522,7 +2415,6 @@ exports[`layout demo > renders top-side correctly 1`] = `
             <!---->
             <li
               class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
-              eventkey="sub1"
               role="none"
             >
               <div
@@ -2656,7 +2548,6 @@ exports[`layout demo > renders top-side correctly 1`] = `
             </li>
             <li
               class="ant-menu-submenu ant-menu-submenu-inline"
-              eventkey="sub2"
               role="none"
             >
               <div
@@ -2711,87 +2602,11 @@ exports[`layout demo > renders top-side correctly 1`] = `
                 name="ant-motion-collapse"
                 persisted="false"
               >
-                <ul
-                  class="ant-menu ant-menu-sub ant-menu-inline"
-                  data-menu-list="true"
-                  id="vc-menu-uuid-sub2-popup"
-                  role="menu"
-                  style="display: none;"
-                >
-                  <li
-                    class="ant-menu-item ant-menu-item-only-child"
-                    data-menu-id="vc-menu-uuid-5"
-                    label="option5"
-                    role="menuitem"
-                    style="padding-left: 48px;"
-                    tabindex="-1"
-                  >
-                    <!---->
-                    <span
-                      class="ant-menu-title-content"
-                    >
-                      option5
-                    </span>
-                    <!---->
-                  </li>
-                  <!---->
-                  <li
-                    class="ant-menu-item ant-menu-item-only-child"
-                    data-menu-id="vc-menu-uuid-6"
-                    label="option6"
-                    role="menuitem"
-                    style="padding-left: 48px;"
-                    tabindex="-1"
-                  >
-                    <!---->
-                    <span
-                      class="ant-menu-title-content"
-                    >
-                      option6
-                    </span>
-                    <!---->
-                  </li>
-                  <!---->
-                  <li
-                    class="ant-menu-item ant-menu-item-only-child"
-                    data-menu-id="vc-menu-uuid-7"
-                    label="option7"
-                    role="menuitem"
-                    style="padding-left: 48px;"
-                    tabindex="-1"
-                  >
-                    <!---->
-                    <span
-                      class="ant-menu-title-content"
-                    >
-                      option7
-                    </span>
-                    <!---->
-                  </li>
-                  <!---->
-                  <li
-                    class="ant-menu-item ant-menu-item-only-child"
-                    data-menu-id="vc-menu-uuid-8"
-                    label="option8"
-                    role="menuitem"
-                    style="padding-left: 48px;"
-                    tabindex="-1"
-                  >
-                    <!---->
-                    <span
-                      class="ant-menu-title-content"
-                    >
-                      option8
-                    </span>
-                    <!---->
-                  </li>
-                  <!---->
-                </ul>
+                <!---->
               </transition-stub>
             </li>
             <li
               class="ant-menu-submenu ant-menu-submenu-inline"
-              eventkey="sub3"
               role="none"
             >
               <div
@@ -2846,82 +2661,7 @@ exports[`layout demo > renders top-side correctly 1`] = `
                 name="ant-motion-collapse"
                 persisted="false"
               >
-                <ul
-                  class="ant-menu ant-menu-sub ant-menu-inline"
-                  data-menu-list="true"
-                  id="vc-menu-uuid-sub3-popup"
-                  role="menu"
-                  style="display: none;"
-                >
-                  <li
-                    class="ant-menu-item ant-menu-item-only-child"
-                    data-menu-id="vc-menu-uuid-9"
-                    label="option9"
-                    role="menuitem"
-                    style="padding-left: 48px;"
-                    tabindex="-1"
-                  >
-                    <!---->
-                    <span
-                      class="ant-menu-title-content"
-                    >
-                      option9
-                    </span>
-                    <!---->
-                  </li>
-                  <!---->
-                  <li
-                    class="ant-menu-item ant-menu-item-only-child"
-                    data-menu-id="vc-menu-uuid-10"
-                    label="option10"
-                    role="menuitem"
-                    style="padding-left: 48px;"
-                    tabindex="-1"
-                  >
-                    <!---->
-                    <span
-                      class="ant-menu-title-content"
-                    >
-                      option10
-                    </span>
-                    <!---->
-                  </li>
-                  <!---->
-                  <li
-                    class="ant-menu-item ant-menu-item-only-child"
-                    data-menu-id="vc-menu-uuid-11"
-                    label="option11"
-                    role="menuitem"
-                    style="padding-left: 48px;"
-                    tabindex="-1"
-                  >
-                    <!---->
-                    <span
-                      class="ant-menu-title-content"
-                    >
-                      option11
-                    </span>
-                    <!---->
-                  </li>
-                  <!---->
-                  <li
-                    class="ant-menu-item ant-menu-item-only-child"
-                    data-menu-id="vc-menu-uuid-12"
-                    label="option12"
-                    role="menuitem"
-                    style="padding-left: 48px;"
-                    tabindex="-1"
-                  >
-                    <!---->
-                    <span
-                      class="ant-menu-title-content"
-                    >
-                      option12
-                    </span>
-                    <!---->
-                  </li>
-                  <!---->
-                </ul>
+                <!---->
               </transition-stub>
             </li>
             <!---->
@@ -3037,8 +2777,6 @@ exports[`layout demo > renders top-side-2 correctly 1`] = `
       <li
         aria-hidden="true"
         class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal"
-        eventkey="vc-menu-more"
-        internalpopupclose="true"
         role="none"
         style="opacity: 0; height: 0px; overflow-y: hidden; order: 9007199254740991; pointer-events: none; position: absolute;"
       >
@@ -3094,7 +2832,6 @@ exports[`layout demo > renders top-side-2 correctly 1`] = `
           <!---->
           <li
             class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
-            eventkey="sub1"
             role="none"
           >
             <div
@@ -3228,7 +2965,6 @@ exports[`layout demo > renders top-side-2 correctly 1`] = `
           </li>
           <li
             class="ant-menu-submenu ant-menu-submenu-inline"
-            eventkey="sub2"
             role="none"
           >
             <div
@@ -3283,87 +3019,11 @@ exports[`layout demo > renders top-side-2 correctly 1`] = `
               name="ant-motion-collapse"
               persisted="false"
             >
-              <ul
-                class="ant-menu ant-menu-sub ant-menu-inline"
-                data-menu-list="true"
-                id="vc-menu-uuid-sub2-popup"
-                role="menu"
-                style="display: none;"
-              >
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-5"
-                  label="option5"
-                  role="menuitem"
-                  style="padding-left: 48px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    option5
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-6"
-                  label="option6"
-                  role="menuitem"
-                  style="padding-left: 48px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    option6
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-7"
-                  label="option7"
-                  role="menuitem"
-                  style="padding-left: 48px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    option7
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-8"
-                  label="option8"
-                  role="menuitem"
-                  style="padding-left: 48px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    option8
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-              </ul>
+              <!---->
             </transition-stub>
           </li>
           <li
             class="ant-menu-submenu ant-menu-submenu-inline"
-            eventkey="sub3"
             role="none"
           >
             <div
@@ -3418,82 +3078,7 @@ exports[`layout demo > renders top-side-2 correctly 1`] = `
               name="ant-motion-collapse"
               persisted="false"
             >
-              <ul
-                class="ant-menu ant-menu-sub ant-menu-inline"
-                data-menu-list="true"
-                id="vc-menu-uuid-sub3-popup"
-                role="menu"
-                style="display: none;"
-              >
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-9"
-                  label="option9"
-                  role="menuitem"
-                  style="padding-left: 48px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    option9
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-10"
-                  label="option10"
-                  role="menuitem"
-                  style="padding-left: 48px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    option10
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-11"
-                  label="option11"
-                  role="menuitem"
-                  style="padding-left: 48px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    option11
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-12"
-                  label="option12"
-                  role="menuitem"
-                  style="padding-left: 48px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    option12
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-              </ul>
+              <!---->
             </transition-stub>
           </li>
           <!---->

--- a/packages/antdv-next/src/menu/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/menu/tests/__snapshots__/demo.test.tsx.snap
@@ -124,7 +124,6 @@ exports[`menu demo > renders _semantic correctly 1`] = `
             <!---->
             <li
               class="ant-menu-overflow-item ant-menu-submenu ant-menu-submenu-horizontal"
-              eventkey="SubMenu"
               role="none"
               style="opacity: 1; order: 1;"
             >
@@ -170,8 +169,6 @@ exports[`menu demo > renders _semantic correctly 1`] = `
             <li
               aria-hidden="true"
               class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal"
-              eventkey="vc-menu-more"
-              internalpopupclose="true"
               role="none"
               style="opacity: 0; height: 0px; overflow-y: hidden; order: 9007199254740991; pointer-events: none; position: absolute;"
             >
@@ -1472,7 +1469,6 @@ exports[`menu demo > renders custom-popup-render correctly 1`] = `
     <!---->
     <li
       class="ant-menu-overflow-item ant-menu-submenu ant-menu-submenu-horizontal"
-      eventkey="features"
       role="none"
       style="opacity: 1; order: 1;"
     >
@@ -1498,7 +1494,6 @@ exports[`menu demo > renders custom-popup-render correctly 1`] = `
     </li>
     <li
       class="ant-menu-overflow-item ant-menu-submenu ant-menu-submenu-horizontal"
-      eventkey="resources"
       role="none"
       style="opacity: 1; order: 2;"
     >
@@ -1525,8 +1520,6 @@ exports[`menu demo > renders custom-popup-render correctly 1`] = `
     <li
       aria-hidden="true"
       class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal"
-      eventkey="vc-menu-more"
-      internalpopupclose="true"
       role="none"
       style="opacity: 0; height: 0px; overflow-y: hidden; order: 9007199254740991; pointer-events: none; position: absolute;"
     >
@@ -1648,7 +1641,6 @@ exports[`menu demo > renders horizontal correctly 1`] = `
     <!---->
     <li
       class="ant-menu-overflow-item ant-menu-submenu ant-menu-submenu-horizontal"
-      eventkey="SubMenu"
       role="none"
       style="opacity: 1; order: 2;"
     >
@@ -1716,8 +1708,6 @@ exports[`menu demo > renders horizontal correctly 1`] = `
     <li
       aria-hidden="true"
       class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal"
-      eventkey="vc-menu-more"
-      internalpopupclose="true"
       role="none"
       style="opacity: 0; height: 0px; overflow-y: hidden; order: 9007199254740991; pointer-events: none; position: absolute;"
     >
@@ -1840,7 +1830,6 @@ exports[`menu demo > renders horizontal-dark correctly 1`] = `
     <!---->
     <li
       class="ant-menu-overflow-item ant-menu-submenu ant-menu-submenu-horizontal"
-      eventkey="SubMenu"
       role="none"
       style="opacity: 1; order: 2;"
     >
@@ -1908,8 +1897,6 @@ exports[`menu demo > renders horizontal-dark correctly 1`] = `
     <li
       aria-hidden="true"
       class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal"
-      eventkey="vc-menu-more"
-      internalpopupclose="true"
       role="none"
       style="opacity: 0; height: 0px; overflow-y: hidden; order: 9007199254740991; pointer-events: none; position: absolute;"
     >
@@ -1964,7 +1951,6 @@ exports[`menu demo > renders inline correctly 1`] = `
     <!---->
     <li
       class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
-      eventkey="sub1"
       role="none"
     >
       <div
@@ -2132,7 +2118,6 @@ exports[`menu demo > renders inline correctly 1`] = `
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="sub2"
       role="none"
     >
       <div
@@ -2187,130 +2172,7 @@ exports[`menu demo > renders inline correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-sub2-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-5"
-            label="Option 5"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 5
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-6"
-            label="Option 6"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 6
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-submenu ant-menu-submenu-inline"
-            eventkey="sub3"
-            role="none"
-          >
-            <div
-              aria-controls="vc-menu-uuid-sub3-popup"
-              aria-disabled="false"
-              aria-expanded="false"
-              aria-haspopup="true"
-              class="ant-menu-submenu-title"
-              data-menu-id="vc-menu-uuid-sub3"
-              role="menuitem"
-              style="padding-left: 48px;"
-              tabindex="-1"
-            >
-              <span
-                class="ant-menu-title-content"
-              >
-                Submenu
-              </span>
-              <i
-                class="ant-menu-submenu-arrow"
-              />
-            </div>
-            <!---->
-            <transition-stub
-              appear="false"
-              css="true"
-              enteractiveclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-prepare ant-motion-collapse-enter-prepare "
-              enterfromclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-prepare ant-motion-collapse-enter-prepare ant-motion-collapse-enter-start"
-              entertoclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-active ant-motion-collapse-enter-active"
-              leaveactiveclass="ant-motion-collapse ant-motion-collapse-leave ant-motion-collapse-leave-active"
-              leavefromclass="ant-motion-collapse ant-motion-collapse-leave"
-              leavetoclass="ant-motion-collapse ant-motion-collapse-leave ant-motion-collapse-leave-active"
-              name="ant-motion-collapse"
-              persisted="false"
-            >
-              <ul
-                class="ant-menu ant-menu-sub ant-menu-inline"
-                data-menu-list="true"
-                id="vc-menu-uuid-sub3-popup"
-                role="menu"
-                style="display: none;"
-              >
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-7"
-                  label="Option 7"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 7
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-8"
-                  label="Option 8"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 8
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-              </ul>
-            </transition-stub>
-          </li>
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <li
@@ -2320,7 +2182,6 @@ exports[`menu demo > renders inline correctly 1`] = `
     />
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="sub4"
       role="none"
     >
       <div
@@ -2375,82 +2236,7 @@ exports[`menu demo > renders inline correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-sub4-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-9"
-            label="Option 9"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 9
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-10"
-            label="Option 10"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 10
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-11"
-            label="Option 11"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 11
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-12"
-            label="Option 12"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 12
-            </span>
-            <!---->
-          </li>
-          <!---->
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <li
@@ -2689,7 +2475,6 @@ exports[`menu demo > renders inline-collapsed correctly 1`] = `
     <!---->
     <li
       class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
-      eventkey="sub1"
       role="none"
     >
       <div
@@ -2823,7 +2608,6 @@ exports[`menu demo > renders inline-collapsed correctly 1`] = `
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="sub2"
       role="none"
     >
       <div
@@ -2878,130 +2662,7 @@ exports[`menu demo > renders inline-collapsed correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-sub2-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-9"
-            label="Option 9"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 9
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-10"
-            label="Option 10"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 10
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-submenu ant-menu-submenu-inline"
-            eventkey="sub3"
-            role="none"
-          >
-            <div
-              aria-controls="vc-menu-uuid-sub3-popup"
-              aria-disabled="false"
-              aria-expanded="false"
-              aria-haspopup="true"
-              class="ant-menu-submenu-title"
-              data-menu-id="vc-menu-uuid-sub3"
-              role="menuitem"
-              style="padding-left: 48px;"
-              tabindex="-1"
-            >
-              <span
-                class="ant-menu-title-content"
-              >
-                Submenu
-              </span>
-              <i
-                class="ant-menu-submenu-arrow"
-              />
-            </div>
-            <!---->
-            <transition-stub
-              appear="false"
-              css="true"
-              enteractiveclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-prepare ant-motion-collapse-enter-prepare "
-              enterfromclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-prepare ant-motion-collapse-enter-prepare ant-motion-collapse-enter-start"
-              entertoclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-active ant-motion-collapse-enter-active"
-              leaveactiveclass="ant-motion-collapse ant-motion-collapse-leave ant-motion-collapse-leave-active"
-              leavefromclass="ant-motion-collapse ant-motion-collapse-leave"
-              leavetoclass="ant-motion-collapse ant-motion-collapse-leave ant-motion-collapse-leave-active"
-              name="ant-motion-collapse"
-              persisted="false"
-            >
-              <ul
-                class="ant-menu ant-menu-sub ant-menu-inline"
-                data-menu-list="true"
-                id="vc-menu-uuid-sub3-popup"
-                role="menu"
-                style="display: none;"
-              >
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-11"
-                  label="Option 11"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 11
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-12"
-                  label="Option 12"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 12
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-              </ul>
-            </transition-stub>
-          </li>
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <!---->
@@ -3243,7 +2904,6 @@ exports[`menu demo > renders sfc correctly 1`] = `
       <!---->
       <li
         class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
-        eventkey="sub1"
         role="none"
       >
         <div
@@ -3338,7 +2998,6 @@ exports[`menu demo > renders sfc correctly 1`] = `
             <!---->
             <li
               class="ant-menu-submenu ant-menu-submenu-inline"
-              eventkey="sub1-2"
               role="none"
             >
               <div
@@ -3374,46 +3033,7 @@ exports[`menu demo > renders sfc correctly 1`] = `
                 name="ant-motion-collapse"
                 persisted="false"
               >
-                <ul
-                  class="ant-menu ant-menu-sub ant-menu-inline"
-                  data-menu-list="true"
-                  id="vc-menu-uuid-sub1-2-popup"
-                  role="menu"
-                  style="display: none;"
-                >
-                  <li
-                    class="ant-menu-item ant-menu-item-only-child"
-                    data-menu-id="vc-menu-uuid-5"
-                    role="menuitem"
-                    style="padding-left: 72px;"
-                    tabindex="-1"
-                  >
-                    <!---->
-                    <span
-                      class="ant-menu-title-content"
-                    >
-                       Option 5 
-                    </span>
-                    <!---->
-                  </li>
-                  <!---->
-                  <li
-                    class="ant-menu-item ant-menu-item-only-child"
-                    data-menu-id="vc-menu-uuid-6"
-                    role="menuitem"
-                    style="padding-left: 72px;"
-                    tabindex="-1"
-                  >
-                    <!---->
-                    <span
-                      class="ant-menu-title-content"
-                    >
-                       Option 6 
-                    </span>
-                    <!---->
-                  </li>
-                  <!---->
-                </ul>
+                <!---->
               </transition-stub>
             </li>
           </ul>
@@ -3421,7 +3041,6 @@ exports[`menu demo > renders sfc correctly 1`] = `
       </li>
       <li
         class="ant-menu-submenu ant-menu-submenu-inline"
-        eventkey="sub2"
         role="none"
       >
         <div
@@ -3476,78 +3095,7 @@ exports[`menu demo > renders sfc correctly 1`] = `
           name="ant-motion-collapse"
           persisted="false"
         >
-          <ul
-            class="ant-menu ant-menu-sub ant-menu-inline"
-            data-menu-list="true"
-            id="vc-menu-uuid-sub2-popup"
-            role="menu"
-            style="display: none;"
-          >
-            <li
-              class="ant-menu-item ant-menu-item-only-child"
-              data-menu-id="vc-menu-uuid-7"
-              role="menuitem"
-              style="padding-left: 48px;"
-              tabindex="-1"
-            >
-              <!---->
-              <span
-                class="ant-menu-title-content"
-              >
-                 Option 7 
-              </span>
-              <!---->
-            </li>
-            <!---->
-            <li
-              class="ant-menu-item ant-menu-item-only-child"
-              data-menu-id="vc-menu-uuid-8"
-              role="menuitem"
-              style="padding-left: 48px;"
-              tabindex="-1"
-            >
-              <!---->
-              <span
-                class="ant-menu-title-content"
-              >
-                 Option 8 
-              </span>
-              <!---->
-            </li>
-            <!---->
-            <li
-              class="ant-menu-item ant-menu-item-only-child"
-              data-menu-id="vc-menu-uuid-9"
-              role="menuitem"
-              style="padding-left: 48px;"
-              tabindex="-1"
-            >
-              <!---->
-              <span
-                class="ant-menu-title-content"
-              >
-                 Option 9 
-              </span>
-              <!---->
-            </li>
-            <!---->
-            <li
-              class="ant-menu-item ant-menu-item-only-child"
-              data-menu-id="vc-menu-uuid-10"
-              role="menuitem"
-              style="padding-left: 48px;"
-              tabindex="-1"
-            >
-              <!---->
-              <span
-                class="ant-menu-title-content"
-              >
-                 Option 10 
-              </span>
-              <!---->
-            </li>
-            <!---->
-          </ul>
+          <!---->
         </transition-stub>
       </li>
       <li
@@ -3639,7 +3187,6 @@ exports[`menu demo > renders sider-current correctly 1`] = `
     <!---->
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="1"
       role="none"
     >
       <div
@@ -3694,87 +3241,11 @@ exports[`menu demo > renders sider-current correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-1-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-11"
-            label="Option 1"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 1
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-12"
-            label="Option 2"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 2
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-13"
-            label="Option 3"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 3
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-14"
-            label="Option 4"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 4
-            </span>
-            <!---->
-          </li>
-          <!---->
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
-      eventkey="2"
       role="none"
     >
       <div
@@ -3871,7 +3342,6 @@ exports[`menu demo > renders sider-current correctly 1`] = `
           <!---->
           <li
             class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
-            eventkey="23"
             role="none"
           >
             <div
@@ -3969,7 +3439,6 @@ exports[`menu demo > renders sider-current correctly 1`] = `
           </li>
           <li
             class="ant-menu-submenu ant-menu-submenu-inline"
-            eventkey="24"
             role="none"
           >
             <div
@@ -4005,65 +3474,7 @@ exports[`menu demo > renders sider-current correctly 1`] = `
               name="ant-motion-collapse"
               persisted="false"
             >
-              <ul
-                class="ant-menu ant-menu-sub ant-menu-inline"
-                data-menu-list="true"
-                id="vc-menu-uuid-24-popup"
-                role="menu"
-                style="display: none;"
-              >
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-241"
-                  label="Option 1"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 1
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-242"
-                  label="Option 2"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 2
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-243"
-                  label="Option 3"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 3
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-              </ul>
+              <!---->
             </transition-stub>
           </li>
         </ul>
@@ -4071,7 +3482,6 @@ exports[`menu demo > renders sider-current correctly 1`] = `
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="3"
       role="none"
     >
       <div
@@ -4126,82 +3536,7 @@ exports[`menu demo > renders sider-current correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-3-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-31"
-            label="Option 1"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 1
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-32"
-            label="Option 2"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 2
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-33"
-            label="Option 3"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 3
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-34"
-            label="Option 4"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 4
-            </span>
-            <!---->
-          </li>
-          <!---->
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <!---->
@@ -4246,7 +3581,6 @@ exports[`menu demo > renders slot-render correctly 1`] = `
     <!---->
     <li
       class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
-      eventkey="sub1"
       role="none"
     >
       <div
@@ -4601,7 +3935,6 @@ exports[`menu demo > renders slot-render correctly 1`] = `
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="sub2"
       role="none"
     >
       <div
@@ -4663,328 +3996,7 @@ exports[`menu demo > renders slot-render correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-sub2-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item"
-            data-menu-id="vc-menu-uuid-5"
-            label="Option 5"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <span
-              class="menu-slot-icon ant-menu-item-icon"
-              data-v-bf6f9cf7=""
-            >
-              <span
-                aria-label="clock-circle"
-                class="anticon anticon-clock-circle"
-                data-v-bf6f9cf7=""
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="clock-circle"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm176.5 585.7l-28.6 39a7.99 7.99 0 01-11.2 1.7L483.3 569.8a7.92 7.92 0 01-3.3-6.5V288c0-4.4 3.6-8 8-8h48.1c4.4 0 8 3.6 8 8v247.5l142.6 103.1c3.6 2.5 4.4 7.5 1.8 11.1z"
-                  />
-                </svg>
-              </span>
-            </span>
-            <span
-              class="ant-menu-title-content ant-menu-title-content-with-extra"
-            >
-              <span
-                class="ant-menu-item-label"
-              >
-                <span
-                  class="menu-slot-label"
-                  data-v-bf6f9cf7=""
-                >
-                  Option 5
-                </span>
-              </span>
-              <span
-                class="ant-menu-item-extra"
-              >
-                <span
-                  class="menu-slot-extra"
-                  data-v-bf6f9cf7=""
-                >
-                   #5
-                </span>
-              </span>
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item"
-            data-menu-id="vc-menu-uuid-6"
-            label="Option 6"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <span
-              class="menu-slot-icon ant-menu-item-icon"
-              data-v-bf6f9cf7=""
-            >
-              <span
-                aria-label="clock-circle"
-                class="anticon anticon-clock-circle"
-                data-v-bf6f9cf7=""
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="clock-circle"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm176.5 585.7l-28.6 39a7.99 7.99 0 01-11.2 1.7L483.3 569.8a7.92 7.92 0 01-3.3-6.5V288c0-4.4 3.6-8 8-8h48.1c4.4 0 8 3.6 8 8v247.5l142.6 103.1c3.6 2.5 4.4 7.5 1.8 11.1z"
-                  />
-                </svg>
-              </span>
-            </span>
-            <span
-              class="ant-menu-title-content ant-menu-title-content-with-extra"
-            >
-              <span
-                class="ant-menu-item-label"
-              >
-                <span
-                  class="menu-slot-label"
-                  data-v-bf6f9cf7=""
-                >
-                  Option 6
-                </span>
-              </span>
-              <span
-                class="ant-menu-item-extra"
-              >
-                <span
-                  class="menu-slot-extra"
-                  data-v-bf6f9cf7=""
-                >
-                   #6
-                </span>
-              </span>
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-submenu ant-menu-submenu-inline"
-            eventkey="sub3"
-            role="none"
-          >
-            <div
-              aria-controls="vc-menu-uuid-sub3-popup"
-              aria-disabled="false"
-              aria-expanded="false"
-              aria-haspopup="true"
-              class="ant-menu-submenu-title"
-              data-menu-id="vc-menu-uuid-sub3"
-              role="menuitem"
-              style="padding-left: 48px;"
-              tabindex="-1"
-            >
-              <span
-                class="menu-slot-icon ant-menu-item-icon"
-                data-v-bf6f9cf7=""
-              >
-                <span
-                  aria-label="clock-circle"
-                  class="anticon anticon-clock-circle"
-                  data-v-bf6f9cf7=""
-                  role="img"
-                >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="clock-circle"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm176.5 585.7l-28.6 39a7.99 7.99 0 01-11.2 1.7L483.3 569.8a7.92 7.92 0 01-3.3-6.5V288c0-4.4 3.6-8 8-8h48.1c4.4 0 8 3.6 8 8v247.5l142.6 103.1c3.6 2.5 4.4 7.5 1.8 11.1z"
-                    />
-                  </svg>
-                </span>
-              </span>
-              <span
-                class="menu-slot-label"
-                data-v-bf6f9cf7=""
-              >
-                Submenu
-              </span>
-              <i
-                class="ant-menu-submenu-arrow"
-              />
-            </div>
-            <!---->
-            <transition-stub
-              appear="false"
-              css="true"
-              enteractiveclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-prepare ant-motion-collapse-enter-prepare "
-              enterfromclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-prepare ant-motion-collapse-enter-prepare ant-motion-collapse-enter-start"
-              entertoclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-active ant-motion-collapse-enter-active"
-              leaveactiveclass="ant-motion-collapse ant-motion-collapse-leave ant-motion-collapse-leave-active"
-              leavefromclass="ant-motion-collapse ant-motion-collapse-leave"
-              leavetoclass="ant-motion-collapse ant-motion-collapse-leave ant-motion-collapse-leave-active"
-              name="ant-motion-collapse"
-              persisted="false"
-            >
-              <ul
-                class="ant-menu ant-menu-sub ant-menu-inline"
-                data-menu-list="true"
-                id="vc-menu-uuid-sub3-popup"
-                role="menu"
-                style="display: none;"
-              >
-                <li
-                  class="ant-menu-item"
-                  data-menu-id="vc-menu-uuid-7"
-                  label="Option 7"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <span
-                    class="menu-slot-icon ant-menu-item-icon"
-                    data-v-bf6f9cf7=""
-                  >
-                    <span
-                      aria-label="clock-circle"
-                      class="anticon anticon-clock-circle"
-                      data-v-bf6f9cf7=""
-                      role="img"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="clock-circle"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm176.5 585.7l-28.6 39a7.99 7.99 0 01-11.2 1.7L483.3 569.8a7.92 7.92 0 01-3.3-6.5V288c0-4.4 3.6-8 8-8h48.1c4.4 0 8 3.6 8 8v247.5l142.6 103.1c3.6 2.5 4.4 7.5 1.8 11.1z"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                  <span
-                    class="ant-menu-title-content ant-menu-title-content-with-extra"
-                  >
-                    <span
-                      class="ant-menu-item-label"
-                    >
-                      <span
-                        class="menu-slot-label"
-                        data-v-bf6f9cf7=""
-                      >
-                        Option 7
-                      </span>
-                    </span>
-                    <span
-                      class="ant-menu-item-extra"
-                    >
-                      <span
-                        class="menu-slot-extra"
-                        data-v-bf6f9cf7=""
-                      >
-                         #7
-                      </span>
-                    </span>
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item"
-                  data-menu-id="vc-menu-uuid-8"
-                  label="Option 8"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <span
-                    class="menu-slot-icon ant-menu-item-icon"
-                    data-v-bf6f9cf7=""
-                  >
-                    <span
-                      aria-label="clock-circle"
-                      class="anticon anticon-clock-circle"
-                      data-v-bf6f9cf7=""
-                      role="img"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="clock-circle"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm176.5 585.7l-28.6 39a7.99 7.99 0 01-11.2 1.7L483.3 569.8a7.92 7.92 0 01-3.3-6.5V288c0-4.4 3.6-8 8-8h48.1c4.4 0 8 3.6 8 8v247.5l142.6 103.1c3.6 2.5 4.4 7.5 1.8 11.1z"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                  <span
-                    class="ant-menu-title-content ant-menu-title-content-with-extra"
-                  >
-                    <span
-                      class="ant-menu-item-label"
-                    >
-                      <span
-                        class="menu-slot-label"
-                        data-v-bf6f9cf7=""
-                      >
-                        Option 8
-                      </span>
-                    </span>
-                    <span
-                      class="ant-menu-item-extra"
-                    >
-                      <span
-                        class="menu-slot-extra"
-                        data-v-bf6f9cf7=""
-                      >
-                         #8
-                      </span>
-                    </span>
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-              </ul>
-            </transition-stub>
-          </li>
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <li
@@ -4994,7 +4006,6 @@ exports[`menu demo > renders slot-render correctly 1`] = `
     />
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="sub4"
       role="none"
     >
       <div
@@ -5056,254 +4067,7 @@ exports[`menu demo > renders slot-render correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-sub4-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item"
-            data-menu-id="vc-menu-uuid-9"
-            label="Option 9"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <span
-              class="menu-slot-icon ant-menu-item-icon"
-              data-v-bf6f9cf7=""
-            >
-              <span
-                aria-label="clock-circle"
-                class="anticon anticon-clock-circle"
-                data-v-bf6f9cf7=""
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="clock-circle"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm176.5 585.7l-28.6 39a7.99 7.99 0 01-11.2 1.7L483.3 569.8a7.92 7.92 0 01-3.3-6.5V288c0-4.4 3.6-8 8-8h48.1c4.4 0 8 3.6 8 8v247.5l142.6 103.1c3.6 2.5 4.4 7.5 1.8 11.1z"
-                  />
-                </svg>
-              </span>
-            </span>
-            <span
-              class="ant-menu-title-content ant-menu-title-content-with-extra"
-            >
-              <span
-                class="ant-menu-item-label"
-              >
-                <span
-                  class="menu-slot-label"
-                  data-v-bf6f9cf7=""
-                >
-                  Option 9
-                </span>
-              </span>
-              <span
-                class="ant-menu-item-extra"
-              >
-                <span
-                  class="menu-slot-extra"
-                  data-v-bf6f9cf7=""
-                >
-                   #9
-                </span>
-              </span>
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item"
-            data-menu-id="vc-menu-uuid-10"
-            label="Option 10"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <span
-              class="menu-slot-icon ant-menu-item-icon"
-              data-v-bf6f9cf7=""
-            >
-              <span
-                aria-label="clock-circle"
-                class="anticon anticon-clock-circle"
-                data-v-bf6f9cf7=""
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="clock-circle"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm176.5 585.7l-28.6 39a7.99 7.99 0 01-11.2 1.7L483.3 569.8a7.92 7.92 0 01-3.3-6.5V288c0-4.4 3.6-8 8-8h48.1c4.4 0 8 3.6 8 8v247.5l142.6 103.1c3.6 2.5 4.4 7.5 1.8 11.1z"
-                  />
-                </svg>
-              </span>
-            </span>
-            <span
-              class="ant-menu-title-content ant-menu-title-content-with-extra"
-            >
-              <span
-                class="ant-menu-item-label"
-              >
-                <span
-                  class="menu-slot-label"
-                  data-v-bf6f9cf7=""
-                >
-                  Option 10
-                </span>
-              </span>
-              <span
-                class="ant-menu-item-extra"
-              >
-                <span
-                  class="menu-slot-extra"
-                  data-v-bf6f9cf7=""
-                >
-                   #10
-                </span>
-              </span>
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item"
-            data-menu-id="vc-menu-uuid-11"
-            label="Option 11"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <span
-              class="menu-slot-icon ant-menu-item-icon"
-              data-v-bf6f9cf7=""
-            >
-              <span
-                aria-label="clock-circle"
-                class="anticon anticon-clock-circle"
-                data-v-bf6f9cf7=""
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="clock-circle"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm176.5 585.7l-28.6 39a7.99 7.99 0 01-11.2 1.7L483.3 569.8a7.92 7.92 0 01-3.3-6.5V288c0-4.4 3.6-8 8-8h48.1c4.4 0 8 3.6 8 8v247.5l142.6 103.1c3.6 2.5 4.4 7.5 1.8 11.1z"
-                  />
-                </svg>
-              </span>
-            </span>
-            <span
-              class="ant-menu-title-content ant-menu-title-content-with-extra"
-            >
-              <span
-                class="ant-menu-item-label"
-              >
-                <span
-                  class="menu-slot-label"
-                  data-v-bf6f9cf7=""
-                >
-                  Option 11
-                </span>
-              </span>
-              <span
-                class="ant-menu-item-extra"
-              >
-                <span
-                  class="menu-slot-extra"
-                  data-v-bf6f9cf7=""
-                >
-                   #11
-                </span>
-              </span>
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item"
-            data-menu-id="vc-menu-uuid-12"
-            label="Option 12"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <span
-              class="menu-slot-icon ant-menu-item-icon"
-              data-v-bf6f9cf7=""
-            >
-              <span
-                aria-label="clock-circle"
-                class="anticon anticon-clock-circle"
-                data-v-bf6f9cf7=""
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="clock-circle"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm176.5 585.7l-28.6 39a7.99 7.99 0 01-11.2 1.7L483.3 569.8a7.92 7.92 0 01-3.3-6.5V288c0-4.4 3.6-8 8-8h48.1c4.4 0 8 3.6 8 8v247.5l142.6 103.1c3.6 2.5 4.4 7.5 1.8 11.1z"
-                  />
-                </svg>
-              </span>
-            </span>
-            <span
-              class="ant-menu-title-content ant-menu-title-content-with-extra"
-            >
-              <span
-                class="ant-menu-item-label"
-              >
-                <span
-                  class="menu-slot-label"
-                  data-v-bf6f9cf7=""
-                >
-                  Option 12
-                </span>
-              </span>
-              <span
-                class="ant-menu-item-extra"
-              >
-                <span
-                  class="menu-slot-extra"
-                  data-v-bf6f9cf7=""
-                >
-                   #12
-                </span>
-              </span>
-            </span>
-            <!---->
-          </li>
-          <!---->
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <li
@@ -5488,7 +4252,6 @@ exports[`menu demo > renders style-class correctly 1`] = `
     <!---->
     <li
       class="ant-menu-submenu ant-menu-submenu-vertical"
-      eventkey="SubMenu"
       role="none"
     >
       <div
@@ -5552,7 +4315,6 @@ exports[`menu demo > renders style-class correctly 1`] = `
     <!---->
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="SubMenu"
       role="none"
     >
       <div
@@ -5588,65 +4350,7 @@ exports[`menu demo > renders style-class correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-SubMenu-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item-group"
-            role="presentation"
-          >
-            <div
-              class="ant-menu-item-group-title"
-              role="presentation"
-              title="Item 1"
-            >
-              Item 1
-            </div>
-            <ul
-              class="ant-menu-item-group-list"
-              role="group"
-            >
-              <li
-                class="ant-menu-item ant-menu-item-only-child"
-                data-menu-id="vc-menu-uuid-1"
-                label="Option 1"
-                role="menuitem"
-                style="padding-left: 48px;"
-                tabindex="-1"
-              >
-                <!---->
-                <span
-                  class="ant-menu-title-content"
-                >
-                  Option 1
-                </span>
-                <!---->
-              </li>
-              <!---->
-              <li
-                class="ant-menu-item ant-menu-item-only-child"
-                data-menu-id="vc-menu-uuid-2"
-                label="Option 2"
-                role="menuitem"
-                style="padding-left: 48px;"
-                tabindex="-1"
-              >
-                <!---->
-                <span
-                  class="ant-menu-title-content"
-                >
-                  Option 2
-                </span>
-                <!---->
-              </li>
-              <!---->
-            </ul>
-          </li>
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <li
@@ -5722,7 +4426,6 @@ exports[`menu demo > renders submenu-theme correctly 1`] = `
     <!---->
     <li
       class="ant-menu-submenu ant-menu-submenu-vertical ant-menu-submenu-open"
-      eventkey="sub1"
       role="none"
     >
       <div
@@ -5963,7 +4666,6 @@ exports[`menu demo > renders switch-mode correctly 1`] = `
     <!---->
     <li
       class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
-      eventkey="sub1"
       role="none"
     >
       <div
@@ -6060,7 +4762,6 @@ exports[`menu demo > renders switch-mode correctly 1`] = `
           <!---->
           <li
             class="ant-menu-submenu ant-menu-submenu-inline"
-            eventkey="sub1-2"
             role="none"
           >
             <div
@@ -6096,48 +4797,7 @@ exports[`menu demo > renders switch-mode correctly 1`] = `
               name="ant-motion-collapse"
               persisted="false"
             >
-              <ul
-                class="ant-menu ant-menu-sub ant-menu-inline"
-                data-menu-list="true"
-                id="vc-menu-uuid-sub1-2-popup"
-                role="menu"
-                style="display: none;"
-              >
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-5"
-                  label="Option 5"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 5
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-6"
-                  label="Option 6"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 6
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-              </ul>
+              <!---->
             </transition-stub>
           </li>
         </ul>
@@ -6145,7 +4805,6 @@ exports[`menu demo > renders switch-mode correctly 1`] = `
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="sub2"
       role="none"
     >
       <div
@@ -6200,82 +4859,7 @@ exports[`menu demo > renders switch-mode correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-sub2-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-7"
-            label="Option 7"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 7
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-8"
-            label="Option 8"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 8
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-9"
-            label="Option 9"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 9
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-10"
-            label="Option 10"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 10
-            </span>
-            <!---->
-          </li>
-          <!---->
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <li
@@ -6385,7 +4969,6 @@ exports[`menu demo > renders theme correctly 1`] = `
     <!---->
     <li
       class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
-      eventkey="sub1"
       role="none"
     >
       <div
@@ -6519,7 +5102,6 @@ exports[`menu demo > renders theme correctly 1`] = `
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="sub2"
       role="none"
     >
       <div
@@ -6574,135 +5156,11 @@ exports[`menu demo > renders theme correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-sub2-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-5"
-            label="Option 5"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 5
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-6"
-            label="Option 6"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 6
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-submenu ant-menu-submenu-inline"
-            eventkey="sub3"
-            role="none"
-          >
-            <div
-              aria-controls="vc-menu-uuid-sub3-popup"
-              aria-disabled="false"
-              aria-expanded="false"
-              aria-haspopup="true"
-              class="ant-menu-submenu-title"
-              data-menu-id="vc-menu-uuid-sub3"
-              role="menuitem"
-              style="padding-left: 48px;"
-              tabindex="-1"
-            >
-              <span
-                class="ant-menu-title-content"
-              >
-                Submenu
-              </span>
-              <i
-                class="ant-menu-submenu-arrow"
-              />
-            </div>
-            <!---->
-            <transition-stub
-              appear="false"
-              css="true"
-              enteractiveclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-prepare ant-motion-collapse-enter-prepare "
-              enterfromclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-prepare ant-motion-collapse-enter-prepare ant-motion-collapse-enter-start"
-              entertoclass="ant-motion-collapse ant-motion-collapse-enter ant-motion-collapse-appear ant-motion-collapse-appear-active ant-motion-collapse-enter-active"
-              leaveactiveclass="ant-motion-collapse ant-motion-collapse-leave ant-motion-collapse-leave-active"
-              leavefromclass="ant-motion-collapse ant-motion-collapse-leave"
-              leavetoclass="ant-motion-collapse ant-motion-collapse-leave ant-motion-collapse-leave-active"
-              name="ant-motion-collapse"
-              persisted="false"
-            >
-              <ul
-                class="ant-menu ant-menu-sub ant-menu-inline"
-                data-menu-list="true"
-                id="vc-menu-uuid-sub3-popup"
-                role="menu"
-                style="display: none;"
-              >
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-7"
-                  label="Option 7"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 7
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-                <li
-                  class="ant-menu-item ant-menu-item-only-child"
-                  data-menu-id="vc-menu-uuid-8"
-                  label="Option 8"
-                  role="menuitem"
-                  style="padding-left: 72px;"
-                  tabindex="-1"
-                >
-                  <!---->
-                  <span
-                    class="ant-menu-title-content"
-                  >
-                    Option 8
-                  </span>
-                  <!---->
-                </li>
-                <!---->
-              </ul>
-            </transition-stub>
-          </li>
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-inline"
-      eventkey="sub4"
       role="none"
     >
       <div
@@ -6757,82 +5215,7 @@ exports[`menu demo > renders theme correctly 1`] = `
         name="ant-motion-collapse"
         persisted="false"
       >
-        <ul
-          class="ant-menu ant-menu-sub ant-menu-inline"
-          data-menu-list="true"
-          id="vc-menu-uuid-sub4-popup"
-          role="menu"
-          style="display: none;"
-        >
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-9"
-            label="Option 9"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 9
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-10"
-            label="Option 10"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 10
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-11"
-            label="Option 11"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 11
-            </span>
-            <!---->
-          </li>
-          <!---->
-          <li
-            class="ant-menu-item ant-menu-item-only-child"
-            data-menu-id="vc-menu-uuid-12"
-            label="Option 12"
-            role="menuitem"
-            style="padding-left: 48px;"
-            tabindex="-1"
-          >
-            <!---->
-            <span
-              class="ant-menu-title-content"
-            >
-              Option 12
-            </span>
-            <!---->
-          </li>
-          <!---->
-        </ul>
+        <!---->
       </transition-stub>
     </li>
     <!---->
@@ -6873,7 +5256,6 @@ exports[`menu demo > renders vertical correctly 1`] = `
     <!---->
     <li
       class="ant-menu-submenu ant-menu-submenu-vertical"
-      eventkey="sub1"
       role="none"
     >
       <div
@@ -6919,7 +5301,6 @@ exports[`menu demo > renders vertical correctly 1`] = `
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-vertical"
-      eventkey="sub2"
       role="none"
     >
       <div
@@ -6965,7 +5346,6 @@ exports[`menu demo > renders vertical correctly 1`] = `
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-vertical"
-      eventkey="sub4"
       role="none"
     >
       <div

--- a/packages/antdv-next/src/menu/tests/lazy-and-click.test.tsx
+++ b/packages/antdv-next/src/menu/tests/lazy-and-click.test.tsx
@@ -1,0 +1,121 @@
+import type { MenuProps } from '..'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import Menu from '..'
+import { mount } from '/@tests/utils'
+
+async function flushMenu() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('menu lazy render and single event dispatch', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // https://github.com/antdv-next/antdv-next/issues/583
+  it('does not render closed inline submenu content until first open', async () => {
+    const items: NonNullable<MenuProps['items']> = [
+      {
+        key: 'sub1',
+        label: 'Navigation One',
+        children: Array.from({ length: 20 }, (_, index) => ({
+          key: `item-${index}`,
+          label: `Option ${index}`,
+        })),
+      },
+      { key: 'top', label: 'Top Item' },
+    ]
+
+    const wrapper = mount(Menu, {
+      props: { mode: 'inline', items, openKeys: [] },
+    })
+    await flushMenu()
+
+    // Closed submenu keeps its content out of the DOM entirely
+    expect(wrapper.find('.ant-menu-sub').exists()).toBe(false)
+    expect(wrapper.findAll('.ant-menu-item')).toHaveLength(1)
+
+    await wrapper.setProps({ openKeys: ['sub1'] })
+    await flushMenu()
+    expect(wrapper.findAll('.ant-menu-sub .ant-menu-item')).toHaveLength(20)
+    expect(wrapper.find('.ant-menu-submenu').classes()).toContain('ant-menu-submenu-open')
+
+    // After closing, the DOM is kept and only hidden (rc-menu `removeOnLeave: false`)
+    await wrapper.setProps({ openKeys: [] })
+    await flushMenu()
+    expect(wrapper.find('.ant-menu-sub').exists()).toBe(true)
+    expect(wrapper.find('.ant-menu-submenu').classes()).not.toContain('ant-menu-submenu-open')
+  })
+
+  it('still highlights parent submenu of a selected key while closed', async () => {
+    const items: NonNullable<MenuProps['items']> = [
+      {
+        key: 'sub1',
+        label: 'Navigation One',
+        children: [{ key: 'leaf', label: 'Leaf' }],
+      },
+    ]
+
+    const wrapper = mount(Menu, {
+      props: { mode: 'inline', items, openKeys: [], selectedKeys: ['leaf'] },
+    })
+    await flushMenu()
+
+    expect(wrapper.find('.ant-menu-sub').exists()).toBe(false)
+    expect(wrapper.find('.ant-menu-submenu').classes()).toContain('ant-menu-submenu-selected')
+  })
+
+  // https://github.com/antdv-next/antdv-next/issues/588
+  it('fires item onClick exactly once with info payload', async () => {
+    const itemClick = vi.fn()
+    const menuClick = vi.fn()
+    const items: NonNullable<MenuProps['items']> = [
+      { key: '1', label: 'Option 1', onClick: itemClick } as any,
+    ]
+
+    const wrapper = mount(Menu, {
+      props: { items, onClick: menuClick },
+    })
+    await flushMenu()
+
+    await wrapper.find('.ant-menu-item').trigger('click')
+
+    expect(itemClick).toHaveBeenCalledTimes(1)
+    expect(menuClick).toHaveBeenCalledTimes(1)
+    // Callbacks receive the info object, not the raw DOM event
+    expect(itemClick.mock.calls[0][0].key).toBe('1')
+    expect(itemClick.mock.calls[0][0].domEvent).toBeInstanceOf(MouseEvent)
+    expect(menuClick.mock.calls[0][0].key).toBe('1')
+  })
+
+  it('fires submenu child onClick exactly once in inline mode', async () => {
+    const childClick = vi.fn()
+    const titleClick = vi.fn()
+    const items: NonNullable<MenuProps['items']> = [
+      {
+        key: 'sub1',
+        label: 'Navigation One',
+        onTitleClick: titleClick,
+        children: [
+          { key: 'child', label: 'Child', onClick: childClick } as any,
+        ],
+      } as any,
+    ]
+
+    const wrapper = mount(Menu, {
+      props: { mode: 'inline', items, openKeys: ['sub1'] },
+    })
+    await flushMenu()
+
+    await wrapper.find('.ant-menu-sub .ant-menu-item').trigger('click')
+    expect(childClick).toHaveBeenCalledTimes(1)
+    expect(titleClick).not.toHaveBeenCalled()
+
+    await wrapper.find('.ant-menu-submenu-title').trigger('click')
+    expect(titleClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ catalogs:
       specifier: ^1.1.0
       version: 1.1.0
     '@v-c/menu':
-      specifier: ^1.1.2
-      version: 1.1.2
+      specifier: ^1.1.3
+      version: 1.1.3
     '@v-c/mutate-observer':
       specifier: ^1.0.1
       version: 1.0.1
@@ -831,7 +831,7 @@ importers:
         version: 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/menu':
         specifier: catalog:vc
-        version: 1.1.2(vue@3.5.30(typescript@5.9.3))
+        version: 1.1.3(vue@3.5.30(typescript@5.9.3))
       '@v-c/mutate-observer':
         specifier: catalog:vc
         version: 1.0.1(vue@3.5.30(typescript@5.9.3))
@@ -2878,13 +2878,13 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/menu@1.1.1':
-    resolution: {integrity: sha512-PQFVBjF93P+XLnBak1b2tFSKXa862qohEKJ6sKGeHyTH4DSKfAxMtxKGUghprbL2bqNmudjkDgioOqP1svh5pw==}
+  '@v-c/menu@1.1.2':
+    resolution: {integrity: sha512-SRbPYgSiGDYZmuFr6X4cpNf7j3HVA5k9usEIMInOUEwcxKJbbJV5Se2CTrKEulSUnZBl+8tR/rTZ5a85MQ6OAQ==}
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/menu@1.1.2':
-    resolution: {integrity: sha512-SRbPYgSiGDYZmuFr6X4cpNf7j3HVA5k9usEIMInOUEwcxKJbbJV5Se2CTrKEulSUnZBl+8tR/rTZ5a85MQ6OAQ==}
+  '@v-c/menu@1.1.3':
+    resolution: {integrity: sha512-+R69sw6ctOkz62syvH3bvg5oi56LQjnk+gsiLFbG72SvioRKUa5HRn++E6vLOM5E38K2KJMdt9EbHso/op5uaQ==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -8364,20 +8364,20 @@ snapshots:
   '@v-c/mentions@1.1.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/input': 1.1.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/menu': 1.1.2(vue@3.5.30(typescript@5.9.3))
+      '@v-c/menu': 1.1.3(vue@3.5.30(typescript@5.9.3))
       '@v-c/textarea': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/trigger': 1.0.15(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@v-c/menu@1.1.1(vue@3.5.30(typescript@5.9.3))':
+  '@v-c/menu@1.1.2(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/trigger': 1.0.15(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@v-c/menu@1.1.2(vue@3.5.30(typescript@5.9.3))':
+  '@v-c/menu@1.1.3(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/trigger': 1.0.15(vue@3.5.30(typescript@5.9.3))
@@ -8502,7 +8502,7 @@ snapshots:
   '@v-c/tabs@1.1.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/dropdown': 1.0.2(vue@3.5.30(typescript@5.9.3))
-      '@v-c/menu': 1.1.2(vue@3.5.30(typescript@5.9.3))
+      '@v-c/menu': 1.1.3(vue@3.5.30(typescript@5.9.3))
       '@v-c/overflow': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/resize-observer': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
@@ -8908,7 +8908,7 @@ snapshots:
       '@v-c/input': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/input-number': 1.0.5(vue@3.5.30(typescript@5.9.3))
       '@v-c/mentions': 1.1.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/menu': 1.1.1(vue@3.5.30(typescript@5.9.3))
+      '@v-c/menu': 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/mutate-observer': 1.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/notification': 2.0.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/pagination': 1.0.0(vue@3.5.30(typescript@5.9.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -139,7 +139,7 @@ catalogs:
     '@v-c/input': ^1.1.0
     '@v-c/input-number': ^1.0.5
     '@v-c/mentions': ^1.1.0
-    '@v-c/menu': ^1.1.2
+    '@v-c/menu': ^1.1.3
     '@v-c/mutate-observer': ^1.0.1
     '@v-c/notification': ^2.0.0
     '@v-c/pagination': ^1.0.0


### PR DESCRIPTION
## Summary

Upgrade `@v-c/menu` to v1.1.3, which replaces the v1.1.2 parse-cache approach (reverted — reference-equality caching is unsafe with Vue's mutable reactive `items`) with two fixes aligned to rc-menu's actual behavior:

- **Lazy mount closed inline submenus** (close #583): mirror rc-menu CSSMotion's `forceRender` off + `removeOnLeave: false` — nothing is mounted until a submenu is opened for the first time, then the DOM is kept and toggled via `v-show`. A 1000+ item menu no longer creates all item components/DOM upfront nor re-patches them per toggle.
- **Single event dispatch** (close #588): user handlers (`onClick`, `onKeyDown`, `onFocus`, `onMouseEnter/Leave`, submenu `onTitleClick` etc.) are no longer also spread onto the DOM node — Vue `mergeProps` stacks same-name listeners (unlike JSX override in React), so item `onClick` fired twice. Private props (`eventkey`/`warnkey`/...) also no longer leak into DOM attributes.

## Test plan

- New `lazy-and-click.test.tsx` (4 specs): closed submenu renders no DOM until first open / DOM kept after close, closed-parent selected highlight, item `onClick` fires exactly once with the info payload, submenu child click vs `onTitleClick` isolation
- Updated menu/layout demo snapshots: closed submenu content removed (~2.2k lines), `eventkey` attributes gone — matches React antd rendering
- menu / dropdown / layout suites pass (190 tests); `@v-c/menu` side has its own lazy-render + event-once specs verified to fail before the fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)