### PR TITLE
fix(collapse): sync with antd v6 so expandIconPlacement takes effect

### DIFF
--- a/docs/src/pages/components/collapse/index.en-US.md
+++ b/docs/src/pages/components/collapse/index.en-US.md
@@ -46,10 +46,10 @@ Common props ref：[Common props](/docs/vue/common-props)
 | rootClass | Root container class | string | - | - |
 | bordered | Toggles rendering of the border around the collapse block | boolean | true | - |
 | expandIcon | Allow to customize collapse icon | (panelProps: PanelProps) =&gt; any | - | - |
-| expandIconPlacement | Set expand icon placement | ExpandIconPlacement | `start` | - |
+| expandIconPlacement | Set expand icon placement | `start` \| `end` | `start` | - |
 | ghost | Make the collapse borderless and its background transparent | boolean | false | - |
 | size | Set the size of collapse | SizeType | `middle` | - |
-| collapsible | Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself | CollapsibleType | - | - |
+| collapsible | Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself | `header` \| `icon` \| `disabled` | - | - |
 | labelRender | Custom render label | (params: &#123; item: CollapseItemType, index: number &#125;) =&gt; any | - | - |
 | contentRender | Custom render content | (params: &#123; item: CollapseItemType, index: number &#125;) =&gt; any | - | - |
 | classes | Customize class for each semantic structure inside the component. Supports object or function. | CollapseClassNamesType | - | - |
@@ -81,7 +81,7 @@ Deprecated: when using items, prefer configuring panels with `items`.
 | header | - | VueNode | - | - |
 | showArrow | - | boolean | true | - |
 | extra | - | VueNode | - | - |
-| collapsible | Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself | CollapsibleType | - | - |
+| collapsible | Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself | `header` \| `icon` \| `disabled` | - | - |
 
 ## Types
 
@@ -90,7 +90,7 @@ Deprecated: when using items, prefer configuring panels with `items`.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | classes | Semantic structure class | Record&lt;[SemanticDOM](#semantic-dom), string&gt; | - | - |
-| collapsible | Specify whether the panel be collapsible or the trigger area of collapsible | CollapsibleType | - | - |
+| collapsible | Specify whether the panel be collapsible or the trigger area of collapsible | `header` \| `icon` \| `disabled` | - | - |
 | content | Body area content | VueNode | - | - |
 | extra | The extra element in the corner | VueNode | - | - |
 | forceRender | Forced render of content on panel, instead of lazy rendering after clicking on header | boolean | false | - |

--- a/docs/src/pages/components/collapse/index.zh-CN.md
+++ b/docs/src/pages/components/collapse/index.zh-CN.md
@@ -46,10 +46,10 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 | rootClass | 根节点 class | string | - | - |
 | bordered | 带边框风格的折叠面板 | boolean | true | - |
 | expandIcon | 自定义切换图标 | (panelProps: PanelProps) =&gt; any | - | - |
-| expandIconPlacement | 设置图标位置 | ExpandIconPlacement | `start` | - |
+| expandIconPlacement | 设置图标位置 | `start` \| `end` | `start` | - |
 | ghost | 使折叠面板透明且无边框 | boolean | false | - |
 | size | 设置折叠面板大小 | SizeType | `middle` | - |
-| collapsible | 所有子面板是否可折叠或指定可折叠触发区域 | CollapsibleType | - | - |
+| collapsible | 所有子面板是否可折叠或指定可折叠触发区域 | `header` \| `icon` \| `disabled` | - | - |
 | labelRender | 自定义渲染label | (params: &#123; item: CollapseItemType, index: number &#125;) =&gt; any | - | - |
 | contentRender | 自定义渲染内容 | (params: &#123; item: CollapseItemType, index: number &#125;) =&gt; any | - | - |
 | classes | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | CollapseClassNamesType | - | - |

--- a/packages/antdv-next/src/collapse/Collapse.tsx
+++ b/packages/antdv-next/src/collapse/Collapse.tsx
@@ -131,7 +131,13 @@ const Collapse = defineComponent<
     const rootPrefixCls = getPrefixCls()
     const [hashId, cssVarCls] = useStyle(prefixCls)
     const mergedPlacement = computed(() => props.expandIconPlacement ?? 'start')
-    const mergedProps = computed(() => props)
+    // =========== Merged Props for Semantic ===========
+    const mergedProps = computed<CollapseProps>(() => ({
+      ...props,
+      size: mergedSize.value,
+      bordered: props.bordered ?? true,
+      expandIconPlacement: mergedPlacement.value,
+    }))
     const [mergedClassNames, mergedStyles] = useMergeSemantic<
       CollapseClassNamesType,
       CollapseStylesType,
@@ -183,7 +189,7 @@ const Collapse = defineComponent<
     return () => {
       const { bordered, ghost, rootClass, destroyOnHidden } = props
       const collapseClassName = classNames(
-        `${prefixCls.value}-icon-position-${mergedPlacement.value}`,
+        `${prefixCls.value}-icon-placement-${mergedPlacement.value}`,
         {
           [`${prefixCls.value}-borderless`]: !bordered,
           [`${prefixCls.value}-rtl`]: direction.value === 'rtl',

--- a/packages/antdv-next/src/collapse/tests/Collapse.test.tsx
+++ b/packages/antdv-next/src/collapse/tests/Collapse.test.tsx
@@ -106,14 +106,18 @@ describe('collapse', () => {
   })
 
   // ==================== expandIconPlacement ====================
+  // The class name must stay `-icon-placement-*` (antd v6 naming): the style in
+  // style/index.ts targets `&-icon-placement-end` to move the icon via `order`.
   it('should default expandIconPlacement to start', () => {
     const wrapper = mount(Collapse, { props: { items: basicItems } })
-    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-icon-position-start')
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-icon-placement-start')
   })
 
   it('should support expandIconPlacement=end', () => {
     const wrapper = mount(Collapse, { props: { items: basicItems, expandIconPlacement: 'end' } })
-    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-icon-position-end')
+    expect(wrapper.find('.ant-collapse').classes()).toContain('ant-collapse-icon-placement-end')
+    // The icon node the style selector relies on must exist inside the header
+    expect(wrapper.find('.ant-collapse-header .ant-collapse-expand-icon').exists()).toBe(true)
   })
 
   // ==================== bordered ====================

--- a/packages/antdv-next/src/collapse/tests/__snapshots__/Collapse.test.tsx.snap
+++ b/packages/antdv-next/src/collapse/tests/__snapshots__/Collapse.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`collapse > rtl render > component should be rendered correctly in RTL d
   data-v-app=""
 >
   <div
-    class="ant-collapse ant-collapse-icon-position-start ant-collapse-rtl css-var-root"
+    class="ant-collapse ant-collapse-icon-placement-start ant-collapse-rtl css-var-root"
   />
 </div>
 `;
 
 exports[`collapse > should match snapshot 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+  class="ant-collapse ant-collapse-icon-placement-start css-var-root"
 >
   <div
     class="ant-collapse-item ant-collapse-item-active"

--- a/packages/antdv-next/src/collapse/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/collapse/tests/__snapshots__/demo.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`collapse demo > renders _semantic correctly 1`] = `
         style="position: absolute; inset: 0; margin: 32px;"
       >
         <div
-          class="ant-collapse ant-collapse-icon-position-start css-var-v-0 semantic-mark-root"
+          class="ant-collapse ant-collapse-icon-placement-start css-var-v-0 semantic-mark-root"
         >
           <div
             class="ant-collapse-item ant-collapse-item-active"
@@ -746,7 +746,7 @@ exports[`collapse demo > renders _semantic correctly 1`] = `
 
 exports[`collapse demo > renders accordion correctly 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+  class="ant-collapse ant-collapse-icon-placement-start css-var-root"
   role="tablist"
 >
   <div
@@ -904,7 +904,7 @@ exports[`collapse demo > renders accordion correctly 1`] = `
 
 exports[`collapse demo > renders basic correctly 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+  class="ant-collapse ant-collapse-icon-placement-start css-var-root"
 >
   <div
     class="ant-collapse-item ant-collapse-item-active"
@@ -1074,7 +1074,7 @@ exports[`collapse demo > renders basic correctly 1`] = `
 
 exports[`collapse demo > renders borderless correctly 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start ant-collapse-borderless css-var-root"
+  class="ant-collapse ant-collapse-icon-placement-start ant-collapse-borderless css-var-root"
 >
   <div
     class="ant-collapse-item ant-collapse-item-active"
@@ -1251,7 +1251,7 @@ exports[`collapse demo > renders collapsible correctly 1`] = `
     class="ant-space-item"
   >
     <div
-      class="ant-collapse ant-collapse-icon-position-start css-var-root"
+      class="ant-collapse ant-collapse-icon-placement-start css-var-root"
     >
       <div
         class="ant-collapse-item ant-collapse-item-active"
@@ -1327,7 +1327,7 @@ exports[`collapse demo > renders collapsible correctly 1`] = `
     class="ant-space-item"
   >
     <div
-      class="ant-collapse ant-collapse-icon-position-start css-var-root"
+      class="ant-collapse ant-collapse-icon-placement-start css-var-root"
     >
       <div
         class="ant-collapse-item ant-collapse-item-active"
@@ -1399,7 +1399,7 @@ exports[`collapse demo > renders collapsible correctly 1`] = `
     class="ant-space-item"
   >
     <div
-      class="ant-collapse ant-collapse-icon-position-start css-var-root"
+      class="ant-collapse ant-collapse-icon-placement-start css-var-root"
     >
       <div
         class="ant-collapse-item ant-collapse-item-disabled"
@@ -1459,7 +1459,7 @@ exports[`collapse demo > renders collapsible correctly 1`] = `
 
 exports[`collapse demo > renders custom correctly 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start ant-collapse-borderless css-var-root"
+  class="ant-collapse ant-collapse-icon-placement-start ant-collapse-borderless css-var-root"
   style="background: rgb(255, 255, 255);"
 >
   <div
@@ -1636,7 +1636,7 @@ exports[`collapse demo > renders extra correctly 1`] = `
   data-v-app=""
 >
   <div
-    class="ant-collapse ant-collapse-icon-position-start css-var-root"
+    class="ant-collapse ant-collapse-icon-placement-start css-var-root"
   >
     <div
       class="ant-collapse-item ant-collapse-item-active"
@@ -1934,7 +1934,7 @@ exports[`collapse demo > renders extra correctly 1`] = `
 
 exports[`collapse demo > renders ghost correctly 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost css-var-root"
+  class="ant-collapse ant-collapse-icon-placement-start ant-collapse-ghost css-var-root"
 >
   <div
     class="ant-collapse-item ant-collapse-item-active"
@@ -2104,7 +2104,7 @@ exports[`collapse demo > renders ghost correctly 1`] = `
 
 exports[`collapse demo > renders mix correctly 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+  class="ant-collapse ant-collapse-icon-placement-start css-var-root"
 >
   <div
     class="ant-collapse-item"
@@ -2261,7 +2261,7 @@ exports[`collapse demo > renders mix correctly 1`] = `
 
 exports[`collapse demo > renders noarrow correctly 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+  class="ant-collapse ant-collapse-icon-placement-start css-var-root"
 >
   <div
     class="ant-collapse-item ant-collapse-item-active"
@@ -2359,7 +2359,7 @@ exports[`collapse demo > renders noarrow correctly 1`] = `
 
 exports[`collapse demo > renders sfc correctly 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start css-var-root"
+  class="ant-collapse ant-collapse-icon-placement-start css-var-root"
 >
   <div
     class="ant-collapse-item ant-collapse-item-active"
@@ -2509,7 +2509,7 @@ exports[`collapse demo > renders size correctly 1`] = `
     />
   </div>
   <div
-    class="ant-collapse ant-collapse-icon-position-start css-var-root"
+    class="ant-collapse ant-collapse-icon-placement-start css-var-root"
   >
     <div
       class="ant-collapse-item"
@@ -2579,7 +2579,7 @@ exports[`collapse demo > renders size correctly 1`] = `
     />
   </div>
   <div
-    class="ant-collapse ant-collapse-icon-position-start ant-collapse-small css-var-root"
+    class="ant-collapse ant-collapse-icon-placement-start ant-collapse-small css-var-root"
   >
     <div
       class="ant-collapse-item"
@@ -2649,7 +2649,7 @@ exports[`collapse demo > renders size correctly 1`] = `
     />
   </div>
   <div
-    class="ant-collapse ant-collapse-icon-position-start ant-collapse-large css-var-root"
+    class="ant-collapse ant-collapse-icon-placement-start ant-collapse-large css-var-root"
   >
     <div
       class="ant-collapse-item"
@@ -2710,7 +2710,7 @@ exports[`collapse demo > renders style-class correctly 1`] = `
   class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <div
-    class="ant-collapse ant-collapse-icon-position-start css-var-root demo-collapse-root"
+    class="ant-collapse ant-collapse-icon-placement-start css-var-root demo-collapse-root"
     style="background-color: rgb(250, 250, 250); border: 1px solid rgb(224, 224, 224); border-radius: 8px;"
   >
     <div
@@ -2879,7 +2879,7 @@ exports[`collapse demo > renders style-class correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-collapse ant-collapse-icon-position-start ant-collapse-large css-var-root demo-collapse-root"
+    class="ant-collapse ant-collapse-icon-placement-start ant-collapse-large css-var-root demo-collapse-root"
     style="background-color: rgb(255, 255, 255); border: 1px solid rgb(105, 111, 199); border-radius: 8px;"
   >
     <div


### PR DESCRIPTION
## Summary

Sync Collapse with antd v6 (`components/collapse/Collapse.tsx`). Full comparison result: the ported style file and `@v-c/collapse` DOM structure already match antd v6; two divergences were found in the component layer and are fixed here:

- **`expandIconPlacement` had no effect**: the root class was still the antd v5 name `-icon-position-*`, while the ported v6 style targets `&-icon-placement-end` (moves the icon with `order: 1`). The selector never matched, so the icon stayed at the start. Renamed to `-icon-placement-*` per antd v6 (`Collapse.tsx:169`).
- **Semantic props not normalized**: antd merges resolved `size` / `bordered` / `expandIconPlacement` into the props handed to `useMergeSemantic` (`Collapse.tsx:124-129`); we passed raw props, so semantic classNames/styles callbacks saw `undefined` instead of resolved values.

Non-changes (verified equivalent): size classes, style merge order, `destroyOnHidden` pass-through, expand icon rendering/cloning; antd's `leavedClassName: -panel-hidden` motion option is covered by `v-show` in `@v-c/collapse`; deprecated `expandIconPosition` / `destroyInactivePanel` aliases intentionally dropped per repo convention.

The old placement tests asserted the stale v5 class name and locked the bug in — assertions updated to the v6 name plus a check that the `-expand-icon` node targeted by the style exists.

## Test plan

- collapse suites pass (69 tests, 3 files); 15 demo/unit snapshots updated — diff is purely the `icon-position-*` → `icon-placement-*` rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)