### PR TITLE
chore: sync ant-design upstream to 88ef5cff (8 fixes + docs/demos)

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React 主组件库 -> antdv-next 主包"
         }
       ],
-      "last_synced_commit": "8b5c356f0c952d125df966d64c1ff92e531c238b",
-      "last_synced_commit_short": "8b5c356f0c",
-      "last_synced_at": "2026-06-03T08:30:00Z",
+      "last_synced_commit": "88ef5cff9ae20adb68b753810de7d5264f0137b4",
+      "last_synced_commit_short": "88ef5cff9a",
+      "last_synced_at": "2026-06-11T01:45:00Z",
       "last_synced_tag": "6.4.3",
-      "sync_count": 9
+      "sync_count": 10
     },
     {
       "name": "cssinjs",

--- a/docs/src/pages/components/alert/demo/_semantic.vue
+++ b/docs/src/pages/components/alert/demo/_semantic.vue
@@ -32,14 +32,14 @@ const semantics = computed(() => [
         :classes="classes"
       >
         <template #action>
-          <a-space direction="vertical">
-            <a-button size="small" type="primary">
+          <a-flex vertical gap="small" :style="{ minWidth: '80px' }">
+            <a-button size="small" type="primary" block>
               Accept
             </a-button>
-            <a-button size="small" danger ghost>
+            <a-button size="small" danger ghost block>
               Decline
             </a-button>
-          </a-space>
+          </a-flex>
         </template>
       </a-alert>
     </template>

--- a/docs/src/pages/components/alert/demo/action.vue
+++ b/docs/src/pages/components/alert/demo/action.vue
@@ -39,11 +39,9 @@ Custom action.
     closable
   >
     <template #action>
-      <a-space>
-        <a-button size="small" type="text">
-          Done
-        </a-button>
-      </a-space>
+      <a-button size="small" type="text">
+        Done
+      </a-button>
     </template>
   </a-alert>
   <br>
@@ -54,14 +52,14 @@ Custom action.
     closable
   >
     <template #action>
-      <a-space direction="vertical">
-        <a-button size="small" type="primary">
+      <a-flex vertical gap="small" :style="{ minWidth: '80px' }">
+        <a-button size="small" type="primary" block>
           Accept
         </a-button>
-        <a-button size="small" danger ghost>
+        <a-button size="small" danger ghost block>
           Decline
         </a-button>
-      </a-space>
+      </a-flex>
     </template>
   </a-alert>
 </template>

--- a/docs/src/pages/components/calendar/demo/lunar.vue
+++ b/docs/src/pages/components/calendar/demo/lunar.vue
@@ -168,7 +168,7 @@ function onSelect(value) {
   box-sizing: border-box;
 }
 .dateCell:hover::before {
-  background: rgba(0, 0, 0, 0.04);
+  background: v-bind('token.controlItemBgHover');
 }
 .current {
   color: v-bind('token.colorTextLightSolid');
@@ -208,7 +208,7 @@ function onSelect(value) {
   padding: 5px 0;
 }
 .monthCell:hover {
-  background: rgba(0, 0, 0, 0.04);
+  background: v-bind('token.controlItemBgHover');
 }
 .monthCellCurrent {
   color: v-bind('token.colorTextLightSolid');

--- a/docs/src/pages/components/card/demo/flexible-content.vue
+++ b/docs/src/pages/components/card/demo/flexible-content.vue
@@ -7,7 +7,7 @@ You can use `a-card-meta` to support more flexible content.
 </docs>
 
 <template>
-  <a-card hoverable style="width: 240px">
+  <a-card hoverable variant="borderless" style="width: 240px">
     <template #cover>
       <img
         draggable="false"

--- a/docs/src/pages/components/config-provider/index.en-US.md
+++ b/docs/src/pages/components/config-provider/index.en-US.md
@@ -80,7 +80,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 
 ### ConfigProvider.config() {#config}
 
-Setting `Modal`, `Message`, `Notification` static config. Not work on hooks.
+Setting `Modal`, `Message`, `Notification` static config. Does not work on hooks.
 
 ```ts
 import { App, ConfigProvider } from 'antdv-next'

--- a/docs/src/pages/components/image/index.en-US.md
+++ b/docs/src/pages/components/image/index.en-US.md
@@ -77,7 +77,7 @@ Other Property ref [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/
 | mask | preview mask effect | boolean \| \{ enabled?: boolean, blur?: boolean \} | true | - |
 | maxScale | Maximum zoom scale | number | 50 | - |
 | minScale | Minimum zoom scale | number | 1 | - |
-| movable | Whether it is movable | boolean | true | - |
+| movable | Whether the preview image can be dragged when it is larger than the viewport | boolean | true | - |
 | open | Whether to display preview | boolean | - | - |
 | rootClassName | Root DOM class name for preview; applies to both image and preview wrapper | string | - | - |
 | scaleStep | Each step's zoom multiplier is 1 + scaleStep | number | 0.5 | - |
@@ -109,7 +109,7 @@ Other Property ref [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/
 | mask | preview mask effect | boolean \| \{ enabled?: boolean, blur?: boolean \} | true | - |
 | minScale | Minimum zoom scale | number | 1 | - |
 | maxScale | Maximum zoom scale | number | 50 | - |
-| movable | Whether movable | boolean | true | - |
+| movable | Whether the preview image can be dragged when it is larger than the viewport | boolean | true | - |
 | open | Whether to display preview | boolean | - | - |
 | styles | Custom semantic structure styles | Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | - |
 | scaleStep | Each step's zoom multiplier is 1 + scaleStep | number | 0.5 | - |

--- a/docs/src/pages/components/image/index.zh-CN.md
+++ b/docs/src/pages/components/image/index.zh-CN.md
@@ -78,7 +78,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | mask | 预览遮罩效果 | boolean \| \{ enabled?: boolean, blur?: boolean \} | true | - |
 | maxScale | 最大缩放倍数 | number | 50 | - |
 | minScale | 最小缩放倍数 | number | 1 | - |
-| movable | 是否可移动 | boolean | true | - |
+| movable | 预览图片大于视口时是否可拖拽移动 | boolean | true | - |
 | open | 是否显示预览 | boolean | - | - |
 | rootClassName | 预览图的根 DOM 类名，会同时作用在图片和预览层最外侧 | string | - | - |
 | scaleStep | `1 + scaleStep` 为缩放放大的每步倍数 | number | 0.5 | - |
@@ -110,7 +110,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | mask | 预览遮罩效果 | boolean \| \{ enabled?: boolean, blur?: boolean \} | true | - |
 | minScale | 最小缩放倍数 | number | 1 | - |
 | maxScale | 最大放大倍数 | number | 50 | - |
-| movable | 是否可移动 | boolean | true | - |
+| movable | 预览图片大于视口时是否可拖拽移动 | boolean | true | - |
 | open | 是否显示预览 | boolean | - | - |
 | styles | 自定义语义化结构样式 | Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | - |
 | scaleStep | `1 + scaleStep` 为缩放放大的每步倍数 | number | 0.5 | - |

--- a/docs/src/pages/components/input/demo/style-class.vue
+++ b/docs/src/pages/components/input/demo/style-class.vue
@@ -49,6 +49,9 @@ const stylesFnPassword: InputPasswordProps['styles'] = (info) => {
 const stylesFnOTP: InputOTPProps['styles'] = (info) => {
   if (info.props.size === 'middle') {
     return {
+      root: {
+        borderWidth: 0,
+      },
       input: {
         borderColor: '#6E8CFB',
         width: '32px',
@@ -61,7 +64,7 @@ const stylesFnOTP: InputOTPProps['styles'] = (info) => {
 const stylesFnSearch: InputSearchProps['styles'] = (info) => {
   if (info.props.size === 'large') {
     return {
-      root: { color: '#4DA8DA' },
+      root: { color: '#4DA8DA', borderWidth: 0 },
       input: { color: '#4DA8DA', borderColor: '#4DA8DA' },
       prefix: { color: '#4DA8DA' },
       suffix: { color: '#4DA8DA' },

--- a/docs/src/pages/components/radio/demo/radiogroup-more.vue
+++ b/docs/src/pages/components/radio/demo/radiogroup-more.vue
@@ -7,25 +7,39 @@ Vertical Radio.Group, with more radios.
 </docs>
 
 <script setup lang="ts">
+import type { RadioGroupProps } from 'antdv-next'
 import { shallowRef } from 'vue'
 
 const val = shallowRef(1)
+
+const buttonOptions: RadioGroupProps['options'] = [
+  { label: 'Apple', value: 'Apple', class: 'label-1' },
+  { label: 'Pear', value: 'Pear', class: 'label-2' },
+  { label: 'Orange', value: 'Orange', title: 'Orange', class: 'label-3' },
+]
 </script>
 
 <template>
-  <a-radio-group v-model:value="val" vertical>
-    <a-radio :value="1">
-      Option A
-    </a-radio>
-    <a-radio :value="2">
-      Option B
-    </a-radio>
-    <a-radio :value="3">
-      Option C
-    </a-radio>
-    <a-radio :value="4">
-      More...
-      <a-input v-if="val === 4" style="width: 100px; margin-left: 10px" />
-    </a-radio>
-  </a-radio-group>
+  <a-flex align="start" gap="large">
+    <div style="flex: 1">
+      <a-radio-group v-model:value="val" vertical>
+        <a-radio :value="1">
+          Option A
+        </a-radio>
+        <a-radio :value="2">
+          Option B
+        </a-radio>
+        <a-radio :value="3">
+          Option C
+        </a-radio>
+        <a-radio :value="4">
+          More...
+          <a-input v-if="val === 4" style="width: 100px; margin-left: 10px" />
+        </a-radio>
+      </a-radio-group>
+    </div>
+    <div style="flex: 1">
+      <a-radio-group :options="buttonOptions" option-type="button" vertical />
+    </div>
+  </a-flex>
 </template>

--- a/docs/src/pages/components/upload/index.en-US.md
+++ b/docs/src/pages/components/upload/index.en-US.md
@@ -60,7 +60,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | classes | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: \{ props \})=> Record<[SemanticDOM](#semantic-dom), string> | - | - |
 | data | Uploading extra params or function which can return uploading extra params | object \| (file) => object \| Promise&lt;object> | - | - |
 | directory | Support upload whole directory ([caniuse](https://caniuse.com/#feat=input-file-directory)) | boolean | false | - |
-| disabled | Disable upload button | boolean | false | When customizing Upload children, please pass the disabled attribute to the child node at the same time to ensure the disabled rendering effect is consistent. |
+| disabled | Disable upload button. When customizing Upload children, please pass the `disabled` attribute to the child node at the same time to ensure the disabled rendering effect is consistent. | boolean | false | - |
 | fileList | List of files that have been uploaded (controlled). Here is a common issue [#2423](https://github.com/ant-design/ant-design/issues/2423) when using it, support `v-model:file-list` | [UploadFile](#uploadfile)\[] | - | - |
 | headers | Set request headers, valid above IE10 | object | - | - |
 | iconRender | Custom show icon | (file: UploadFile, listType?: UploadListType) => VueNode | - | - |

--- a/docs/src/pages/components/upload/index.zh-CN.md
+++ b/docs/src/pages/components/upload/index.zh-CN.md
@@ -61,7 +61,7 @@ demo:
 | classes | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: \{ props \})=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | data | 上传所需额外参数或返回上传额外参数的方法 | object\|(file) => object \| Promise&lt;object> | - |  |
 | directory | 支持上传文件夹（[caniuse](https://caniuse.com/#feat=input-file-directory)） | boolean | false |  |
-| disabled | 是否禁用 | boolean | false | 对于自定义 Upload children 时请将 disabled 属性同时传给 child node 确保 disabled 渲染效果保持一致 |
+| disabled | 是否禁用。对于自定义 Upload children 时，请同时将 `disabled` 属性传给 child node，以确保禁用状态的渲染效果保持一致 | boolean | false |  |
 | fileList | 已经上传的文件列表（受控），使用此参数时，如果遇到 `onChange` 只调用一次的问题，请参考 [#2423](https://github.com/ant-design/ant-design/issues/2423)，支持 `v-model:file-list` | [UploadFile](#uploadfile)\[] | - |  |
 | headers | 设置上传的请求头部，IE10 以上有效 | object | - |  |
 | iconRender | 自定义显示 icon | (file: UploadFile, listType?: UploadListType) => VueNode | - |  |

--- a/packages/antdv-next/src/_util/is.ts
+++ b/packages/antdv-next/src/_util/is.ts
@@ -1,0 +1,5 @@
+import isNonNullable from './isNonNullable'
+
+export function isRenderable<T>(val: T): val is Exclude<NonNullable<T>, false | ''> {
+  return isNonNullable(val) && (val as unknown) !== false && (val as unknown) !== ''
+}

--- a/packages/antdv-next/src/alert/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/alert/tests/__snapshots__/demo.test.tsx.snap
@@ -68,64 +68,55 @@ exports[`alert demo > renders _semantic correctly 1`] = `
             class="ant-alert-actions semantic-mark-actions"
           >
             <div
-              class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-v-0"
+              class="ant-flex css-var-v-0 ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+              style="min-width: 80px;"
             >
-              <div
-                class="ant-space-item"
+              <button
+                class="ant-btn css-var-v-0 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm ant-btn-block"
+                type="button"
               >
-                <button
-                  class="ant-btn css-var-v-0 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
-                  type="button"
+                <transition-stub
+                  appear="false"
+                  css="true"
+                  enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
+                  enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
+                  entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
+                  leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+                  leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
+                  leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+                  name="ant-btn-loading-icon-motion"
+                  persisted="false"
                 >
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
-                    enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
-                    entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
-                    leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
-                    leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
-                    leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
-                    name="ant-btn-loading-icon-motion"
-                    persisted="false"
-                  >
-                    <!---->
-                  </transition-stub>
-                  <span>
-                     Accept 
-                  </span>
                   <!---->
-                </button>
-              </div>
-              <!---->
-              <div
-                class="ant-space-item"
+                </transition-stub>
+                <span>
+                   Accept 
+                </span>
+                <!---->
+              </button>
+              <button
+                class="ant-btn css-var-v-0 ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-background-ghost ant-btn-block"
+                type="button"
               >
-                <button
-                  class="ant-btn css-var-v-0 ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-background-ghost"
-                  type="button"
+                <transition-stub
+                  appear="false"
+                  css="true"
+                  enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
+                  enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
+                  entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
+                  leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+                  leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
+                  leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+                  name="ant-btn-loading-icon-motion"
+                  persisted="false"
                 >
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
-                    enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
-                    entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
-                    leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
-                    leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
-                    leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
-                    name="ant-btn-loading-icon-motion"
-                    persisted="false"
-                  >
-                    <!---->
-                  </transition-stub>
-                  <span>
-                     Decline 
-                  </span>
                   <!---->
-                </button>
-              </div>
-              <!---->
+                </transition-stub>
+                <span>
+                   Decline 
+                </span>
+                <!---->
+              </button>
             </div>
           </div>
           <button
@@ -1299,38 +1290,29 @@ exports[`alert demo > renders action correctly 1`] = `
       <div
         class="ant-alert-actions"
       >
-        <div
-          class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+        <button
+          class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm"
+          type="button"
         >
-          <div
-            class="ant-space-item"
+          <transition-stub
+            appear="false"
+            css="true"
+            enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
+            enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
+            entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
+            leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+            leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
+            leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+            name="ant-btn-loading-icon-motion"
+            persisted="false"
           >
-            <button
-              class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm"
-              type="button"
-            >
-              <transition-stub
-                appear="false"
-                css="true"
-                enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
-                enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
-                entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
-                leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
-                leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
-                leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
-                name="ant-btn-loading-icon-motion"
-                persisted="false"
-              >
-                <!---->
-              </transition-stub>
-              <span>
-                 Done 
-              </span>
-              <!---->
-            </button>
-          </div>
+            <!---->
+          </transition-stub>
+          <span>
+             Done 
+          </span>
           <!---->
-        </div>
+        </button>
       </div>
       <button
         class="ant-alert-close-icon"
@@ -1394,64 +1376,55 @@ exports[`alert demo > renders action correctly 1`] = `
         class="ant-alert-actions"
       >
         <div
-          class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+          class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          style="min-width: 80px;"
         >
-          <div
-            class="ant-space-item"
+          <button
+            class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm ant-btn-block"
+            type="button"
           >
-            <button
-              class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
-              type="button"
+            <transition-stub
+              appear="false"
+              css="true"
+              enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
+              enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
+              entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
+              leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+              leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
+              leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+              name="ant-btn-loading-icon-motion"
+              persisted="false"
             >
-              <transition-stub
-                appear="false"
-                css="true"
-                enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
-                enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
-                entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
-                leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
-                leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
-                leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
-                name="ant-btn-loading-icon-motion"
-                persisted="false"
-              >
-                <!---->
-              </transition-stub>
-              <span>
-                 Accept 
-              </span>
               <!---->
-            </button>
-          </div>
-          <!---->
-          <div
-            class="ant-space-item"
+            </transition-stub>
+            <span>
+               Accept 
+            </span>
+            <!---->
+          </button>
+          <button
+            class="ant-btn css-var-root ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-background-ghost ant-btn-block"
+            type="button"
           >
-            <button
-              class="ant-btn css-var-root ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-background-ghost"
-              type="button"
+            <transition-stub
+              appear="false"
+              css="true"
+              enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
+              enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
+              entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
+              leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+              leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
+              leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+              name="ant-btn-loading-icon-motion"
+              persisted="false"
             >
-              <transition-stub
-                appear="false"
-                css="true"
-                enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
-                enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
-                entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
-                leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
-                leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
-                leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
-                name="ant-btn-loading-icon-motion"
-                persisted="false"
-              >
-                <!---->
-              </transition-stub>
-              <span>
-                 Decline 
-              </span>
               <!---->
-            </button>
-          </div>
-          <!---->
+            </transition-stub>
+            <span>
+               Decline 
+            </span>
+            <!---->
+          </button>
         </div>
       </div>
       <button

--- a/packages/antdv-next/src/auto-complete/index.tsx
+++ b/packages/antdv-next/src/auto-complete/index.tsx
@@ -5,6 +5,7 @@ import type { InputStatus } from '../_util/statusUtils'
 import type { VueNode } from '../_util/type'
 import type {
   InternalSelectProps,
+  SearchConfig,
   SelectPopupSemanticClassNames,
   SelectPopupSemanticStyles,
   SelectProps,
@@ -90,6 +91,9 @@ export interface AutoCompleteProps extends
     | 'styles'
     | 'getInputElement'
     | 'getRawInputElement'
+    | 'showSearch'
+    | 'optionFilterProp'
+    | 'filterSort'
     | RcEventKeys
   >,
   /* @vue-ignore */
@@ -111,6 +115,7 @@ export interface AutoCompleteProps extends
   popupRender?: (menu: VueNode) => any
   /** @deprecated Please use `styles.popup.root` instead */
   dropdownStyle?: CSSProperties
+  showSearch?: boolean | Pick<SearchConfig, 'filterOption' | 'onSearch'>
 }
 
 export interface AutoCompleteEmits {

--- a/packages/antdv-next/src/card/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/card/tests/__snapshots__/demo.test.tsx.snap
@@ -1520,7 +1520,7 @@ exports[`card demo > renders component-token correctly 1`] = `
 
 exports[`card demo > renders flexible-content correctly 1`] = `
 <div
-  class="ant-card ant-card-bordered ant-card-hoverable css-var-root"
+  class="ant-card ant-card-hoverable css-var-root"
   style="width: 240px;"
 >
   <!---->

--- a/packages/antdv-next/src/config-provider/tests/icon-style.test.tsx
+++ b/packages/antdv-next/src/config-provider/tests/icon-style.test.tsx
@@ -1,0 +1,28 @@
+import { createCache, extractStyle, StyleProvider } from '@antdv-next/cssinjs'
+import { describe, expect, it } from 'vitest'
+import { createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import ConfigProvider from '..'
+
+describe('configProvider icon style', () => {
+  // https://github.com/ant-design/ant-design/issues/52412
+  it('should keep spin animation styles when multiple icon prefixes coexist', async () => {
+    const cache = createCache()
+    const app = createSSRApp({
+      render: () =>
+        h(StyleProvider, { cache, mock: 'server' }, {
+          default: () => [
+            h(ConfigProvider, null, { default: () => h('span') }),
+            h(ConfigProvider, { iconPrefixCls: 'customicon' }, { default: () => h('span') }),
+          ],
+        }),
+    })
+
+    await renderToString(app)
+
+    const styleText = extractStyle(cache, { plain: true })
+
+    expect(styleText).toContain('.anticon-spin{animation-name:loadingCircle;')
+    expect(styleText).toContain('.customicon-spin{animation-name:loadingCircle;')
+  })
+})

--- a/packages/antdv-next/src/input/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/input/tests/__snapshots__/demo.test.tsx.snap
@@ -6529,6 +6529,7 @@ exports[`input demo > renders style-class correctly 1`] = `
     data-v-769a5a90=""
     name="otp-fn"
     role="group"
+    style="border-width: 0px;"
   >
     <span
       class="ant-otp-input-wrapper"
@@ -6649,7 +6650,7 @@ exports[`input demo > renders style-class correctly 1`] = `
   <div
     class="ant-space-compact css-var-root ant-input-search css-var-root ant-input-search-large effect"
     data-v-769a5a90=""
-    style="color: rgb(77, 168, 218);"
+    style="color: rgb(77, 168, 218); border-width: 0px;"
   >
     <input
       class="ant-input ant-input-lg ant-input-outlined ant-input-compact-item ant-input-compact-first-item css-var-root ant-input-css-var"

--- a/packages/antdv-next/src/locale/en_GB.ts
+++ b/packages/antdv-next/src/locale/en_GB.ts
@@ -70,7 +70,7 @@ const localeValues: Locale = {
     downloadFile: 'Download file',
   },
   Empty: {
-    description: 'No Data',
+    description: 'No data',
   },
   Icon: {
     icon: 'icon',
@@ -130,6 +130,17 @@ const localeValues: Locale = {
         mismatch: '${label} does not match the pattern ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR code expired',
+    refresh: 'Refresh',
+    scanned: 'Scanned',
+  },
+  ColorPicker: {
+    presetEmpty: 'Empty',
+    transparent: 'Transparent',
+    singleColor: 'Single',
+    gradientColor: 'Gradient',
   },
 }
 

--- a/packages/antdv-next/src/menu/style/vertical.ts
+++ b/packages/antdv-next/src/menu/style/vertical.ts
@@ -174,6 +174,7 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
             [`> ${componentCls}-inline-collapsed-noicon`]: {
               fontSize: fontSizeLG,
               textAlign: 'center',
+              width: '100%',
             },
           },
         },
@@ -184,7 +185,7 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
           > ${componentCls}-submenu > ${componentCls}-submenu-title`]: {
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center',
+          justifyContent: 'flex-start',
           insetInlineStart: 0,
           paddingInline: `calc(50% - ${unit(token.calc(collapsedIconSize).div(2).equal())} - ${unit(
             itemMarginInline,

--- a/packages/antdv-next/src/menu/tests/index.test.tsx
+++ b/packages/antdv-next/src/menu/tests/index.test.tsx
@@ -280,7 +280,7 @@ describe('menu', () => {
       .map(style => style.innerHTML)
       .join('\n')
 
-    expect(dynamicStyleText).toMatch(/ant-menu-inline-collapsed[\s\S]*justify-content:center/)
+    expect(dynamicStyleText).toMatch(/ant-menu-inline-collapsed[\s\S]*justify-content:flex-start/)
     expect(dynamicStyleText).toMatch(/ant-menu-inline-collapsed[\s\S]*ant-menu-title-content\{width:0;opacity:0;overflow:hidden/)
 
     wrapper.unmount()

--- a/packages/antdv-next/src/popconfirm/PurePanel.tsx
+++ b/packages/antdv-next/src/popconfirm/PurePanel.tsx
@@ -5,6 +5,7 @@ import { ExclamationCircleFilled } from '@antdv-next/icons'
 import { clsx } from '@v-c/util'
 import { computed, defineComponent } from 'vue'
 import ActionButton from '../_util/ActionButton'
+import { isRenderable } from '../_util/is.ts'
 import Button from '../button'
 import { useComponentBaseConfig, useConfig } from '../config-provider/context'
 import defaultLocale from '../locale/en_US'
@@ -92,12 +93,12 @@ export const Overlay = defineComponent<OverlayProps>(
               </span>
             )}
             <div class={`${prefixCls}-message-text`}>
-              {title && (
+              {isRenderable(title) && (
                 <div class={clsx(`${prefixCls}-title`, classes?.title)} style={styles?.title}>
                   {title}
                 </div>
               )}
-              {description && (
+              {isRenderable(description) && (
                 <div class={clsx(`${prefixCls}-description`, classes?.content)} style={styles?.content}>
                   {description}
                 </div>

--- a/packages/antdv-next/src/popconfirm/tests/Popconfirm.test.tsx
+++ b/packages/antdv-next/src/popconfirm/tests/Popconfirm.test.tsx
@@ -64,6 +64,22 @@ describe('popconfirm', () => {
     wrapper.unmount()
   })
 
+  it('should render title when it is the number 0', async () => {
+    const wrapper = mount(Popconfirm, {
+      props: { title: 0, open: true },
+      slots: {
+        default: () => <span>show me your code</span>,
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+    await nextTick()
+    const titleNode = document.querySelector('.ant-popconfirm-title')
+    expect(titleNode).not.toBe(null)
+    expect(titleNode?.textContent).toContain('0')
+    wrapper.unmount()
+  })
+
   it('ConfigProvider tooltip config should not leak into Popconfirm', async () => {
     const wrapper = mount(ConfigProvider, {
       props: {

--- a/packages/antdv-next/src/popover/PurePanel.tsx
+++ b/packages/antdv-next/src/popover/PurePanel.tsx
@@ -12,6 +12,7 @@ import { filterEmpty } from '@v-c/util/dist/props-util'
 import { omit } from 'es-toolkit'
 import { computed, defineComponent } from 'vue'
 import { useMergeSemantic, useToArr, useToProps } from '../_util/hooks'
+import { isRenderable } from '../_util/is.ts'
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools.ts'
 import { useComponentBaseConfig } from '../config-provider/context.ts'
 import useStyle from './style'
@@ -30,17 +31,17 @@ export const Overlay = defineComponent<OverlayProps>(
       const { prefixCls, classes, styles } = props
       const title = getSlotPropsFnRun(slots, props, 'title')
       const content = getSlotPropsFnRun(slots, props, 'content')
-      if (!title && !content) {
+      if (!isRenderable(title) && !isRenderable(content)) {
         return null
       }
       return (
         <>
-          {title && (
+          {isRenderable(title) && (
             <div class={clsx(`${prefixCls}-title`, classes?.title)} style={styles?.title}>
               {title}
             </div>
           )}
-          {content && (
+          {isRenderable(content) && (
             <div class={clsx(`${prefixCls}-content`, classes?.content)} style={styles?.content}>
               {content}
             </div>

--- a/packages/antdv-next/src/popover/index.tsx
+++ b/packages/antdv-next/src/popover/index.tsx
@@ -12,6 +12,7 @@ import {
   useToArr,
   useToProps,
 } from '../_util/hooks'
+import { isRenderable } from '../_util/is.ts'
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools.ts'
 import { useComponentBaseConfig } from '../config-provider/context'
 import Tooltip from '../tooltip'
@@ -182,7 +183,7 @@ const InternalPopover = defineComponent<
           open={open.value}
           onOpenChange={onInternalOpenChange}
           overlay={
-            titleNode || contentNode
+            isRenderable(titleNode) || isRenderable(contentNode)
               ? (
                   <Overlay
                     prefixCls={prefixCls.value}

--- a/packages/antdv-next/src/popover/tests/Popover.test.tsx
+++ b/packages/antdv-next/src/popover/tests/Popover.test.tsx
@@ -85,6 +85,25 @@ describe('popover', () => {
     expect(document.querySelector('.ant-popover-content')?.textContent).toContain('Popover Content')
   })
 
+  it('should display overlay when the content is the number 0', async () => {
+    mount(Popover, {
+      attachTo: document.body,
+      props: {
+        content: 0,
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: {
+        default: () => <span>show me your code</span>,
+      },
+    })
+    await flushPopoverTimer()
+    const popup = document.querySelector('.ant-popover')
+    expect(popup).not.toBe(null)
+    expect(popup?.textContent).toContain('0')
+  })
+
   it('renders title and content via slots', async () => {
     mount(Popover, {
       attachTo: document.body,

--- a/packages/antdv-next/src/radio/style/index.ts
+++ b/packages/antdv-next/src/radio/style/index.ts
@@ -108,8 +108,50 @@ interface RadioToken extends FullToken<'Radio'> {
 // ============================== Styles ==============================
 // styles from RadioGroup only
 const getGroupRadioStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
-  const { componentCls, antCls } = token
+  const { componentCls, antCls, lineWidth, borderRadius, borderRadiusLG, borderRadiusSM, calc } = token
   const groupPrefixCls = `${componentCls}-group`
+  const buttonWrapperCls = `${componentCls}-button-wrapper`
+  const badgeCls = `${antCls}-badge`
+
+  const genVerticalBadgeButtonStyle = (radius: number): CSSObject => ({
+    [`> ${badgeCls}`]: {
+      width: 'auto',
+    },
+
+    [`> ${badgeCls} > ${buttonWrapperCls}`]: {
+      width: '100%',
+    },
+
+    [`> ${badgeCls}:not(:last-child)`]: {
+      marginBlockEnd: calc(lineWidth).mul(-1).equal(),
+    },
+
+    [`> ${badgeCls} > ${buttonWrapperCls}:not(:last-child)`]: {
+      marginBlockEnd: 0,
+    },
+
+    [`> ${badgeCls}:first-child > ${buttonWrapperCls}`]: {
+      borderStartStartRadius: radius,
+      borderStartEndRadius: radius,
+      borderEndStartRadius: 0,
+      borderEndEndRadius: 0,
+    },
+
+    [`> ${badgeCls}:last-child > ${buttonWrapperCls}`]: {
+      borderStartStartRadius: 0,
+      borderStartEndRadius: 0,
+      borderEndStartRadius: radius,
+      borderEndEndRadius: radius,
+    },
+
+    [`> ${badgeCls}:not(:first-child):not(:last-child) > ${buttonWrapperCls}`]: {
+      borderRadius: 0,
+    },
+
+    [`> ${badgeCls}:first-child:last-child > ${buttonWrapperCls}`]: {
+      borderRadius: radius,
+    },
+  })
 
   return {
     [groupPrefixCls]: {
@@ -139,8 +181,22 @@ const getGroupRadioStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         flexDirection: 'column',
         rowGap: token.marginXS,
 
+        [`&:has(> ${buttonWrapperCls}, > ${badgeCls} > ${buttonWrapperCls})`]: {
+          rowGap: 0,
+        },
+
         [`${componentCls}-wrapper`]: {
           marginInlineEnd: 0,
+        },
+
+        ...genVerticalBadgeButtonStyle(borderRadius),
+
+        [`&${groupPrefixCls}-large`]: {
+          ...genVerticalBadgeButtonStyle(borderRadiusLG),
+        },
+
+        [`&${groupPrefixCls}-small`]: {
+          ...genVerticalBadgeButtonStyle(borderRadiusSM),
         },
       },
     },
@@ -429,6 +485,65 @@ const getRadioButtonStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         '&:last-child': {
           borderStartEndRadius: borderRadiusSM,
           borderEndEndRadius: borderRadiusSM,
+        },
+      },
+
+      [`${componentCls}-group-vertical > &`]: {
+        marginInlineEnd: 0,
+        borderRadius: 0,
+
+        '&:not(:last-child)': {
+          marginBlockEnd: calc(lineWidth).mul(-1).equal(),
+        },
+
+        '&:first-child': {
+          borderStartStartRadius: borderRadius,
+          borderStartEndRadius: borderRadius,
+          borderEndStartRadius: 0,
+          borderEndEndRadius: 0,
+        },
+
+        '&:last-child': {
+          borderStartStartRadius: 0,
+          borderStartEndRadius: 0,
+          borderEndStartRadius: borderRadius,
+          borderEndEndRadius: borderRadius,
+        },
+
+        '&:first-child:last-child': {
+          borderRadius,
+        },
+      },
+
+      [`${componentCls}-group-vertical${componentCls}-group-large > &`]: {
+        '&:first-child': {
+          borderStartStartRadius: borderRadiusLG,
+          borderStartEndRadius: borderRadiusLG,
+        },
+
+        '&:last-child': {
+          borderEndStartRadius: borderRadiusLG,
+          borderEndEndRadius: borderRadiusLG,
+        },
+
+        '&:first-child:last-child': {
+          borderRadius: borderRadiusLG,
+        },
+      },
+
+      [`${componentCls}-group-vertical${componentCls}-group-small > &`]: {
+        '&:first-child': {
+          borderStartStartRadius: borderRadiusSM,
+          borderStartEndRadius: borderRadiusSM,
+        },
+
+        '&:last-child': {
+          borderEndStartRadius: borderRadiusSM,
+          borderEndEndRadius: borderRadiusSM,
+        },
+
+        '&:first-child:last-child': {
+          borderRadius: borderRadiusSM,
         },
       },
 

--- a/packages/antdv-next/src/radio/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/radio/tests/__snapshots__/demo.test.tsx.snap
@@ -1484,81 +1484,152 @@ exports[`radio demo > renders radiogroup-block correctly 1`] = `
 
 exports[`radio demo > renders radiogroup-more correctly 1`] = `
 <div
-  class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var ant-radio-group-vertical"
+  class="ant-flex css-var-root ant-flex-align-start ant-flex-gap-large"
 >
-  <label
-    class="ant-radio-wrapper ant-radio-wrapper-checked css-var-root ant-radio-css-var"
+  <div
+    style="flex: 1 1 0%;"
   >
-    <span
-      class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
-      name="v-0"
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var ant-radio-group-vertical"
     >
-      <input
-        checked=""
-        class="ant-radio-input"
-        type="radio"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-       Option A 
-    </span>
-  </label>
-  <label
-    class="ant-radio-wrapper css-var-root ant-radio-css-var"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-root ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+          name="v-0"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            type="radio"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+           Option A 
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-root ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target ant-wave-target"
+          name="v-0"
+        >
+          <input
+            class="ant-radio-input"
+            type="radio"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+           Option B 
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-root ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target ant-wave-target"
+          name="v-0"
+        >
+          <input
+            class="ant-radio-input"
+            type="radio"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+           Option C 
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-root ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target ant-wave-target"
+          name="v-0"
+        >
+          <input
+            class="ant-radio-input"
+            type="radio"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+           More... 
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    style="flex: 1 1 0%;"
   >
-    <span
-      class="ant-radio ant-wave-target ant-wave-target"
-      name="v-0"
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var ant-radio-group-vertical"
     >
-      <input
-        class="ant-radio-input"
-        type="radio"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-       Option B 
-    </span>
-  </label>
-  <label
-    class="ant-radio-wrapper css-var-root ant-radio-css-var"
-  >
-    <span
-      class="ant-radio ant-wave-target ant-wave-target"
-      name="v-0"
-    >
-      <input
-        class="ant-radio-input"
-        type="radio"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-       Option C 
-    </span>
-  </label>
-  <label
-    class="ant-radio-wrapper css-var-root ant-radio-css-var"
-  >
-    <span
-      class="ant-radio ant-wave-target ant-wave-target"
-      name="v-0"
-    >
-      <input
-        class="ant-radio-input"
-        type="radio"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-       More... 
-    </span>
-  </label>
+      <label
+        class="ant-radio-button-wrapper label-1 css-var-root ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+          name="v-1"
+        >
+          <input
+            class="ant-radio-button-input"
+            type="radio"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Apple
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper label-2 css-var-root ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+          name="v-1"
+        >
+          <input
+            class="ant-radio-button-input"
+            type="radio"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Pear
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper label-3 css-var-root ant-radio-css-var"
+        title="Orange"
+      >
+        <span
+          class="ant-radio-button"
+          name="v-1"
+        >
+          <input
+            class="ant-radio-button-input"
+            type="radio"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Orange
+        </span>
+      </label>
+    </div>
+  </div>
 </div>
 `;
 

--- a/packages/antdv-next/src/select/index.tsx
+++ b/packages/antdv-next/src/select/index.tsx
@@ -39,6 +39,8 @@ import useShowArrow from './useShowArrow'
 
 type RawValue = string | number
 
+export type { SearchConfig } from '@v-c/select'
+
 export interface LabeledValue {
   key?: string
   value: RawValue

--- a/packages/antdv-next/src/spin/index.tsx
+++ b/packages/antdv-next/src/spin/index.tsx
@@ -151,7 +151,7 @@ const Spin = defineComponent<
         spinning: spinning.value,
         fullscreen: props.fullscreen,
         percent: mergedPercent.value,
-      }
+      } as SpinProps
     })
     // ========================= Style ==========================
     const [mergedClassNames, mergedStyles] = useMergeSemantic<

--- a/packages/antdv-next/src/style/index.tsx
+++ b/packages/antdv-next/src/style/index.tsx
@@ -1,7 +1,7 @@
 import type { CSSObject } from '@antdv-next/cssinjs'
 import type { AliasToken, GenerateStyle } from '../theme/internal'
 
-import { unit } from '@antdv-next/cssinjs'
+import { Keyframes, unit } from '@antdv-next/cssinjs'
 
 export const textEllipsis: CSSObject = {
   overflow: 'hidden',
@@ -48,6 +48,12 @@ export function resetIcon(): CSSObject {
     },
   }
 }
+
+const loadingCircle = new Keyframes('loadingCircle', {
+  '100%': {
+    transform: 'rotate(360deg)',
+  },
+})
 
 export function clearFix(): CSSObject {
   return {
@@ -156,6 +162,13 @@ export function genIconStyle(iconPrefixCls: string): CSSObject {
       [`.${iconPrefixCls} .${iconPrefixCls}-icon`]: {
         display: 'block',
       },
+    },
+
+    [`.${iconPrefixCls}-spin`]: {
+      animationName: loadingCircle,
+      animationDuration: '1s',
+      animationIterationCount: 'infinite',
+      animationTimingFunction: 'linear',
     },
   }
 }

--- a/packages/antdv-next/src/theme/util/alias.ts
+++ b/packages/antdv-next/src/theme/util/alias.ts
@@ -152,9 +152,9 @@ export default function formatToken(derivativeToken: RawMergedToken): AliasToken
       0 9px 28px 8px ${getShadowColor(0.05)}
     `,
     boxShadowTertiary: `
-      0 1px 2px 0 ${getShadowColor(0.03)},
-      0 1px 6px -1px ${getShadowColor(0.02)},
-      0 2px 4px 0 ${getShadowColor(0.02)}
+      0 1px 2px 0 ${getShadowColor(0.05)},
+      0 1px 6px -1px ${getShadowColor(0.03)},
+      0 2px 4px 0 ${getShadowColor(0.03)}
     `,
 
     screenXS,

--- a/packages/antdv-next/src/tour/style/index.ts
+++ b/packages/antdv-next/src/tour/style/index.ts
@@ -226,6 +226,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
               backgroundColor: colorPrimary,
 
               '&:hover': {
+                color: colorTextLightSolid,
                 backgroundColor: primaryPrevBtnBg,
                 borderColor: 'transparent',
               },


### PR DESCRIPTION
## 概述

继续同步 ant-design 上游代码,范围 `8b5c356f0c..88ef5cff9a`(46 个上游 commit,筛选出 20 个需同步 PR)。

## 同步内容

### 代码修复
- **#58296** fix: Popover/Popconfirm 的 title/content 为数字 `0` 时仍渲染(新增 `_util/is.ts` 的 `isRenderable`,含测试)
- **#58104** fix(auto-complete): 收窄 `showSearch` 类型,防止不支持的 Select props 泄漏
- **#58317** fix(radio): 垂直 Radio.Button 组边框折叠与圆角(含 Badge 包裹、large/small 尺寸)
- **#58311** fix(tour): 上一步按钮 hover 文字颜色保持可读
- **#58271** fix(menu): 折叠动画播放前图标不再跳到中间
- **#58253** fix: `genIconStyle` 注册 spin keyframes,多 icon 前缀共存时动画正常(含测试)
- **#58224** fix(locale): en_GB 对齐 en_US(Empty 大小写、补 QRCode/ColorPicker)
- **#58205** style: 加深 `boxShadowTertiary` 提升浅色背景可见性

### 文档 / Demo
- **#58318** Image `movable` 行为说明
- **#58283** Upload `disabled` API 表格修正
- **#58304** ConfigProvider.config() 英文 typo
- **#58313** Alert action demo 改用 Flex 布局
- **#58229** Calendar lunar demo hover 色改用 `controlItemBgHover` token
- **#58218** Input style-class demo 增加 `borderWidth: 0`
- 同步 `.sync-upstream.json` 至 `88ef5cff9a`

### 跳过项(不适用)
#58306/#58252/#58186/#58292 及 CI/依赖/站点专属改动;#58265+#58290+#58278(全局配置文档列)工作量大,另行立项。

## 测试

- 全量测试 4475 通过;仅 calendar/date-picker 共 15 个快照失败,为本地时区(UTC-7)与快照生成环境不一致的存量问题,与本次改动无关
- 受影响组件快照已更新(radio/alert/input/card),menu 测试断言同步更新为新行为

🤖 Generated with [Claude Code](https://claude.com/claude-code)