### PR TITLE
fix: segmented empty icon, dropdown menu classes/styles passthrough, form rules typing

### DIFF
--- a/packages/antdv-next/src/border-beam/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/border-beam/tests/__snapshots__/demo.test.tsx.snap
@@ -154,15 +154,9 @@ exports[`border-beam demo > renders customized-color correctly 1`] = `
         />
         <div
           class="ant-segmented-item-label"
+          title="Ocean"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
-          <span>
-            Ocean
-          </span>
+          Ocean
         </div>
       </label>
       <label
@@ -175,15 +169,9 @@ exports[`border-beam demo > renders customized-color correctly 1`] = `
         />
         <div
           class="ant-segmented-item-label"
+          title="Sunset"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
-          <span>
-            Sunset
-          </span>
+          Sunset
         </div>
       </label>
       <label
@@ -196,15 +184,9 @@ exports[`border-beam demo > renders customized-color correctly 1`] = `
         />
         <div
           class="ant-segmented-item-label"
+          title="Aurora"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
-          <span>
-            Aurora
-          </span>
+          Aurora
         </div>
       </label>
       <label
@@ -217,15 +199,9 @@ exports[`border-beam demo > renders customized-color correctly 1`] = `
         />
         <div
           class="ant-segmented-item-label"
+          title="Forest"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
-          <span>
-            Forest
-          </span>
+          Forest
         </div>
       </label>
       <label
@@ -238,15 +214,9 @@ exports[`border-beam demo > renders customized-color correctly 1`] = `
         />
         <div
           class="ant-segmented-item-label"
+          title="Ember"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
-          <span>
-            Ember
-          </span>
+          Ember
         </div>
       </label>
       <label
@@ -259,15 +229,9 @@ exports[`border-beam demo > renders customized-color correctly 1`] = `
         />
         <div
           class="ant-segmented-item-label"
+          title="Nebula"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
-          <span>
-            Nebula
-          </span>
+          Nebula
         </div>
       </label>
     </div>

--- a/packages/antdv-next/src/dropdown/dropdown.tsx
+++ b/packages/antdv-next/src/dropdown/dropdown.tsx
@@ -273,17 +273,20 @@ const Dropdown = defineComponent<
         if (menu?.items) {
           overlayNode = (
             <Menu
-              {...menu}
+              {...omit(menu, ['classes', 'styles', 'rootClass'])}
               onClick={(menu: MenuInfo) => {
                 emit('menuClick', menu)
               }}
+              rootClass={clsx(menu?.rootClass)}
               classes={{
+                ...menu?.classes,
                 ...menuClassNames,
                 subMenu: {
                   ...menuClassNames,
                 },
               }}
               styles={{
+                ...menu?.styles,
                 ...menuStyles,
                 subMenu: {
                   ...menuStyles,

--- a/packages/antdv-next/src/dropdown/tests/Dropdown.test.tsx
+++ b/packages/antdv-next/src/dropdown/tests/Dropdown.test.tsx
@@ -100,6 +100,46 @@ describe('dropdown', () => {
     expect(items.length).toBe(3)
   })
 
+  // https://github.com/antdv-next/antdv-next/issues/599
+  it('should forward menu.classes and menu.styles to the underlying Menu', async () => {
+    mount(Dropdown, {
+      attachTo: document.body,
+      props: {
+        menu: {
+          ...menu,
+          classes: { root: 'ant-pro-menu' },
+          styles: { root: { width: '160px' } },
+        },
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: { default: () => <span>trigger</span> },
+    })
+    await flushDropdownTimer()
+    const menuEl = document.querySelector<HTMLElement>('.ant-dropdown-menu')
+    expect(menuEl).toBeTruthy()
+    expect(menuEl!.classList.contains('ant-pro-menu')).toBe(true)
+    expect(menuEl!.style.width).toBe('160px')
+  })
+
+  it('should forward menu.rootClass to the underlying Menu', async () => {
+    mount(Dropdown, {
+      attachTo: document.body,
+      props: {
+        menu: { ...menu, rootClass: 'custom-menu-root' },
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: { default: () => <span>trigger</span> },
+    })
+    await flushDropdownTimer()
+    const menuEl = document.querySelector<HTMLElement>('.ant-dropdown-menu')
+    expect(menuEl).toBeTruthy()
+    expect(menuEl!.classList.contains('custom-menu-root')).toBe(true)
+  })
+
   // =================== Placement ===================
 
   it('should default placement to bottomLeft in LTR', () => {

--- a/packages/antdv-next/src/form/Form.tsx
+++ b/packages/antdv-next/src/form/Form.tsx
@@ -12,7 +12,7 @@ import type {
   FieldData,
   InternalNamePath,
   NamePath,
-  Rule,
+  RulesMap,
   ValidateErrorEntity,
   ValidateMessages,
   ValidateOptions,
@@ -93,7 +93,7 @@ export interface FormProps extends ComponentBaseProps,
   variant?: Variant
   validateMessages?: ValidateMessages
   model?: Record<string, any>
-  rules?: Record<string, Rule[]>
+  rules?: RulesMap
   validateTrigger?: string | string[] | false
   preserve?: boolean
   clearOnDestroy?: boolean

--- a/packages/antdv-next/src/form/context.tsx
+++ b/packages/antdv-next/src/form/context.tsx
@@ -6,7 +6,7 @@ import type { FormLayout, FormSemanticName, RequiredMark } from './Form'
 import type { FeedbackIcons, ValidateStatus } from './FormItem'
 import type { ColPropsWithClass, FormTooltipProps } from './FormItemLabel'
 import type { FormLabelAlign } from './interface'
-import type { InternalNamePath, Meta, NamePath, Rule, ValidateMessages } from './types.ts'
+import type { InternalNamePath, Meta, NamePath, Rule, RulesMap, ValidateMessages } from './types.ts'
 import { computed, defineComponent, inject, provide, ref } from 'vue'
 
 /** Form Context. Set top form style and pass to Form Item usage. */
@@ -35,7 +35,7 @@ export interface FormContextProps {
   requiredMark?: RequiredMark
   feedbackIcons?: FeedbackIcons
   model?: Record<string, any>
-  rules?: Record<string, Rule[]>
+  rules?: RulesMap
   validateTrigger?: string | string[] | false
   validateMessages?: ValidateMessages
   preserve?: boolean

--- a/packages/antdv-next/src/form/tests/form-level-rules.test.tsx
+++ b/packages/antdv-next/src/form/tests/form-level-rules.test.tsx
@@ -1,0 +1,120 @@
+import type { FormInstance } from '..'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, nextTick, reactive, shallowRef } from 'vue'
+import Form, { FormItem } from '..'
+import { flushPromises, mount } from '/@tests/utils'
+
+async function flushForm() {
+  await nextTick()
+  await flushPromises()
+  await nextTick()
+}
+
+describe('form-level (global) rules', () => {
+  it('applies form-level rules keyed by field name', async () => {
+    const formRef = shallowRef<FormInstance>()
+    const model = reactive({ username: '' })
+
+    const wrapper = mount(defineComponent(() => () => (
+      <Form
+        ref={formRef as any}
+        model={model}
+        rules={{ username: [{ required: true, message: 'Username required' }] }}
+      >
+        <FormItem name="username">
+          <input class="username-input" value={model.username} />
+        </FormItem>
+      </Form>
+    )), { attachTo: document.body })
+
+    await flushForm()
+    await expect(formRef.value!.validateFields()).rejects.toMatchObject({
+      errorFields: [{ name: ['username'], errors: ['Username required'] }],
+    })
+
+    wrapper.unmount()
+  })
+
+  it('merges form-level rules with FormItem rules', async () => {
+    const formRef = shallowRef<FormInstance>()
+    const model = reactive({ username: 'ab' })
+
+    const wrapper = mount(defineComponent(() => () => (
+      <Form
+        ref={formRef as any}
+        model={model}
+        rules={{ username: [{ required: true, message: 'Username required' }] }}
+      >
+        <FormItem name="username" rules={[{ min: 3, message: 'Too short' }]}>
+          <input class="username-input" value={model.username} />
+        </FormItem>
+      </Form>
+    )), { attachTo: document.body })
+
+    await flushForm()
+    await expect(formRef.value!.validateFields()).rejects.toMatchObject({
+      errorFields: [{ name: ['username'], errors: ['Too short'] }],
+    })
+
+    wrapper.unmount()
+  })
+
+  it('applies form-level rules to nested object path', async () => {
+    const formRef = shallowRef<FormInstance>()
+    const model = reactive({ user: { email: '' } })
+
+    const wrapper = mount(defineComponent(() => () => (
+      <Form
+        ref={formRef as any}
+        model={model}
+        rules={{ user: { email: [{ required: true, message: 'Email required' }] } }}
+      >
+        <FormItem name={['user', 'email']}>
+          <input class="email-input" value={model.user.email} />
+        </FormItem>
+      </Form>
+    )), { attachTo: document.body })
+
+    await flushForm()
+    await expect(formRef.value!.validateFields()).rejects.toMatchObject({
+      errorFields: [{ name: ['user', 'email'], errors: ['Email required'] }],
+    })
+
+    wrapper.unmount()
+  })
+
+  it('supports array/index-keyed rules: rules={{ list: { 0: [...], 1: [...] } }}', async () => {
+    const formRef = shallowRef<FormInstance>()
+    const model = reactive({ list: ['', ''] })
+
+    const wrapper = mount(defineComponent(() => () => (
+      <Form
+        ref={formRef as any}
+        model={model}
+        rules={{
+          list: {
+            0: [{ required: true, message: 'Item 0 required' }],
+            1: [{ required: true, message: 'Item 1 required' }],
+          },
+        }}
+      >
+        <FormItem name={['list', 0]}>
+          <input class="list-0" value={model.list[0]} />
+        </FormItem>
+        <FormItem name={['list', 1]}>
+          <input class="list-1" value={model.list[1]} />
+        </FormItem>
+      </Form>
+    )), { attachTo: document.body })
+
+    await flushForm()
+    await expect(formRef.value!.validateFields()).rejects.toMatchObject({
+      errorFields: [
+        { name: ['list', 0], errors: ['Item 0 required'] },
+        { name: ['list', 1], errors: ['Item 1 required'] },
+      ],
+    })
+
+    wrapper.unmount()
+  })
+})

--- a/packages/antdv-next/src/form/types.ts
+++ b/packages/antdv-next/src/form/types.ts
@@ -103,6 +103,19 @@ export type RuleObject = AggregationRule | ArrayRule
 
 export type Rule = RuleObject | RuleRender
 
+/**
+ * Form-level rules map keyed by field name.
+ *
+ * Values are resolved against a field's `namePath` via `getValue`, so the map
+ * mirrors the data structure and supports nested objects and array indexes:
+ * - flat:    `{ username: [...] }`
+ * - nested:  `{ user: { email: [...] } }`
+ * - indexed: `{ list: { 0: [...], 1: [...] } }`
+ */
+export interface RulesMap {
+  [key: string | number]: Rule[] | RulesMap
+}
+
 export interface ValidateErrorEntity<Values = any> {
   message: string
   values: Values

--- a/packages/antdv-next/src/progress/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/progress/tests/__snapshots__/demo.test.tsx.snap
@@ -1578,15 +1578,9 @@ exports[`progress demo > renders dashboard correctly 1`] = `
           />
           <div
             class="ant-segmented-item-label"
+            title="50"
           >
-            <span
-              class="ant-segmented-item-icon"
-            >
-              <!---->
-            </span>
-            <span>
-              50
-            </span>
+            50
           </div>
         </label>
         <label
@@ -1599,15 +1593,9 @@ exports[`progress demo > renders dashboard correctly 1`] = `
           />
           <div
             class="ant-segmented-item-label"
+            title="100"
           >
-            <span
-              class="ant-segmented-item-icon"
-            >
-              <!---->
-            </span>
-            <span>
-              100
-            </span>
+            100
           </div>
         </label>
       </div>
@@ -1637,15 +1625,9 @@ exports[`progress demo > renders dashboard correctly 1`] = `
           />
           <div
             class="ant-segmented-item-label"
+            title="start"
           >
-            <span
-              class="ant-segmented-item-icon"
-            >
-              <!---->
-            </span>
-            <span>
-              start
-            </span>
+            start
           </div>
         </label>
         <label
@@ -1658,15 +1640,9 @@ exports[`progress demo > renders dashboard correctly 1`] = `
           />
           <div
             class="ant-segmented-item-label"
+            title="end"
           >
-            <span
-              class="ant-segmented-item-icon"
-            >
-              <!---->
-            </span>
-            <span>
-              end
-            </span>
+            end
           </div>
         </label>
         <label
@@ -1679,15 +1655,9 @@ exports[`progress demo > renders dashboard correctly 1`] = `
           />
           <div
             class="ant-segmented-item-label"
+            title="top"
           >
-            <span
-              class="ant-segmented-item-icon"
-            >
-              <!---->
-            </span>
-            <span>
-              top
-            </span>
+            top
           </div>
         </label>
         <label
@@ -1701,15 +1671,9 @@ exports[`progress demo > renders dashboard correctly 1`] = `
           />
           <div
             class="ant-segmented-item-label"
+            title="bottom"
           >
-            <span
-              class="ant-segmented-item-icon"
-            >
-              <!---->
-            </span>
-            <span>
-              bottom
-            </span>
+            bottom
           </div>
         </label>
       </div>

--- a/packages/antdv-next/src/segmented/index.tsx
+++ b/packages/antdv-next/src/segmented/index.tsx
@@ -154,26 +154,32 @@ const InternalSegmented = defineComponent<
         const iconRender = slots.iconRender || props.iconRender
         const _option = typeof option === 'object' ? option : { value: option }
         let iconFromSlot = iconRender ? iconRender(_option) : null
-        iconFromSlot = filterEmpty(Array.isArray(iconFromSlot) ? iconFromSlot : [iconFromSlot])
+        iconFromSlot = filterEmpty(Array.isArray(iconFromSlot) ? iconFromSlot : [iconFromSlot]).filter(Boolean)
         const labelRender = slots.labelRender || props.labelRender
         let labelFromSlot = labelRender ? labelRender(_option) : null
         labelFromSlot = filterEmpty(Array.isArray(labelFromSlot) ? labelFromSlot : [labelFromSlot]).filter(Boolean)
-        if (isSegmentedLabeledOptionWithIcon(option, iconFromSlot)) {
-          const { label, ...restOption } = option
-          labelFromSlot = labelFromSlot.length > 0 ? labelFromSlot : label
-          const showLabel = !!(labelFromSlot && labelFromSlot.length > 0) || !!label
+        const hasIcon = isSegmentedLabeledOptionWithIcon(option, iconFromSlot)
+        const hasCustomLabel = labelFromSlot.length > 0
+        // Only wrap the option when it actually carries an icon or a custom label,
+        // otherwise keep the raw option so we don't render an empty icon wrapper.
+        if (hasIcon || hasCustomLabel) {
+          const { label, ...restOption } = _option
+          const mergedLabel = labelFromSlot.length > 0 ? labelFromSlot : label
+          const showLabel = !!(labelFromSlot.length > 0) || !!label
           const icon = getSlotPropsFnRun({}, option, 'icon') ?? iconFromSlot
           return {
             ...restOption,
             label: (
               <>
-                <span
-                  class={clsx(`${prefixCls.value}-item-icon`, mergedClassNames.value?.icon)}
-                  style={mergedStyles.value?.icon}
-                >
-                  {icon}
-                </span>
-                {showLabel && <span>{labelFromSlot}</span>}
+                {hasIcon && (
+                  <span
+                    class={clsx(`${prefixCls.value}-item-icon`, mergedClassNames.value?.icon)}
+                    style={mergedStyles.value?.icon}
+                  >
+                    {icon}
+                  </span>
+                )}
+                {showLabel && <span>{mergedLabel}</span>}
               </>
             ),
           }

--- a/packages/antdv-next/src/segmented/tests/Segmented.test.tsx
+++ b/packages/antdv-next/src/segmented/tests/Segmented.test.tsx
@@ -251,6 +251,33 @@ describe('segmented', () => {
       })
       expect(wrapper.find(`.${prefixCls}-item-icon`).exists()).toBe(true)
     })
+
+    // https://github.com/antdv-next/antdv-next/issues/600
+    it('should not render icon wrapper when option has no icon', () => {
+      const wrapper = mount(Segmented, {
+        props: {
+          options: [
+            { label: '年', value: 'year' },
+            { label: '月', value: 'month' },
+            { label: '日', value: 'day' },
+          ],
+        },
+      })
+      expect(wrapper.findAll(`.${prefixCls}-item-icon`)).toHaveLength(0)
+    })
+
+    it('should only render icon wrapper for options that have an icon', () => {
+      const wrapper = mount(Segmented, {
+        props: {
+          options: [
+            { label: 'List', value: 'List', icon: h('span', { class: 'has-icon' }, 'ic') },
+            { label: 'Kanban', value: 'Kanban' },
+          ],
+        },
+      })
+      expect(wrapper.findAll(`.${prefixCls}-item-icon`)).toHaveLength(1)
+      expect(wrapper.find('.has-icon').exists()).toBe(true)
+    })
   })
 
   // ===================== Slots =====================

--- a/packages/antdv-next/src/segmented/tests/__snapshots__/Segmented.test.tsx.snap
+++ b/packages/antdv-next/src/segmented/tests/__snapshots__/Segmented.test.tsx.snap
@@ -76,15 +76,9 @@ exports[`segmented > should render segmented with mixed options 1`] = `
       />
       <div
         class="ant-segmented-item-label"
+        title="Weekly"
       >
-        <span
-          class="ant-segmented-item-icon"
-        >
-          <!---->
-        </span>
-        <span>
-          Weekly
-        </span>
+        Weekly
       </div>
     </label>
     <label
@@ -385,15 +379,9 @@ exports[`segmented > snapshot > should match snapshot with various options 1`] =
       />
       <div
         class="ant-segmented-item-label"
+        title="Weekly"
       >
-        <span
-          class="ant-segmented-item-icon"
-        >
-          <!---->
-        </span>
-        <span>
-          Weekly
-        </span>
+        Weekly
       </div>
     </label>
     <label
@@ -407,15 +395,9 @@ exports[`segmented > snapshot > should match snapshot with various options 1`] =
       />
       <div
         class="ant-segmented-item-label"
+        title="Monthly"
       >
-        <span
-          class="ant-segmented-item-icon"
-        >
-          <!---->
-        </span>
-        <span>
-          Monthly
-        </span>
+        Monthly
       </div>
     </label>
   </div>

--- a/packages/antdv-next/src/segmented/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/segmented/tests/__snapshots__/demo.test.tsx.snap
@@ -828,11 +828,7 @@ exports[`segmented demo > renders custom correctly 1`] = `
         <div
           class="ant-segmented-item-label"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
+          <!---->
           <span>
             <div
               style="padding: 4px;"
@@ -863,11 +859,7 @@ exports[`segmented demo > renders custom correctly 1`] = `
         <div
           class="ant-segmented-item-label"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
+          <!---->
           <span>
             <div
               style="padding: 4px;"
@@ -898,11 +890,7 @@ exports[`segmented demo > renders custom correctly 1`] = `
         <div
           class="ant-segmented-item-label"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
+          <!---->
           <span>
             <div
               style="padding: 4px;"
@@ -950,11 +938,7 @@ exports[`segmented demo > renders custom correctly 1`] = `
         <div
           class="ant-segmented-item-label"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
+          <!---->
           <span>
             <div
               style="padding: 4px;"
@@ -980,11 +964,7 @@ exports[`segmented demo > renders custom correctly 1`] = `
         <div
           class="ant-segmented-item-label"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
+          <!---->
           <span>
             <div
               style="padding: 4px;"
@@ -1010,11 +990,7 @@ exports[`segmented demo > renders custom correctly 1`] = `
         <div
           class="ant-segmented-item-label"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
+          <!---->
           <span>
             <div
               style="padding: 4px;"
@@ -1040,11 +1016,7 @@ exports[`segmented demo > renders custom correctly 1`] = `
         <div
           class="ant-segmented-item-label"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
+          <!---->
           <span>
             <div
               style="padding: 4px;"
@@ -1169,15 +1141,9 @@ exports[`segmented demo > renders disabled correctly 1`] = `
         />
         <div
           class="ant-segmented-item-label"
+          title="Weekly"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
-          <span>
-            Weekly
-          </span>
+          Weekly
         </div>
       </label>
       <label
@@ -1206,15 +1172,9 @@ exports[`segmented demo > renders disabled correctly 1`] = `
         />
         <div
           class="ant-segmented-item-label"
+          title="Quarterly"
         >
-          <span
-            class="ant-segmented-item-icon"
-          >
-            <!---->
-          </span>
-          <span>
-            Quarterly
-          </span>
+          Quarterly
         </div>
       </label>
       <label

--- a/packages/antdv-next/src/table/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/table/tests/__snapshots__/demo.test.tsx.snap
@@ -33136,15 +33136,9 @@ exports[`table demo > renders virtual-list correctly 1`] = `
                 />
                 <div
                   class="ant-segmented-item-label"
+                  title="None"
                 >
-                  <span
-                    class="ant-segmented-item-icon"
-                  >
-                    <!---->
-                  </span>
-                  <span>
-                    None
-                  </span>
+                  None
                 </div>
               </label>
               <label
@@ -33157,15 +33151,9 @@ exports[`table demo > renders virtual-list correctly 1`] = `
                 />
                 <div
                   class="ant-segmented-item-label"
+                  title="Less"
                 >
-                  <span
-                    class="ant-segmented-item-icon"
-                  >
-                    <!---->
-                  </span>
-                  <span>
-                    Less
-                  </span>
+                  Less
                 </div>
               </label>
               <label
@@ -33179,15 +33167,9 @@ exports[`table demo > renders virtual-list correctly 1`] = `
                 />
                 <div
                   class="ant-segmented-item-label"
+                  title="Lot"
                 >
-                  <span
-                    class="ant-segmented-item-icon"
-                  >
-                    <!---->
-                  </span>
-                  <span>
-                    Lot
-                  </span>
+                  Lot
                 </div>
               </label>
             </div>


### PR DESCRIPTION
## 概述

修复两个 issue,并优化 Form 全局 rules 的类型。已对照 React ant-design 源码核对行为。

## 改动

### 1. fix(segmented): 无 icon 的选项不再渲染空 icon wrapper — Closes #600

`[{ label: '年', value: 'year' }]` 这类没有 `icon` 的选项,仍会渲染空的 `<span class="ant-segmented-item-icon">`。

**根因**:`filterEmpty([null])` 会保留 `null`(length=1),导致 icon 判定为真。原逻辑中"自定义 label 渲染"又搭在 icon 判定上。

**修复**:仅当选项有 icon **或**有自定义 label 时才包装;icon `<span>` 只在确实有 icon 时渲染。与 React 一致(React 仅当 `option.icon` 为真才渲染 icon span)。`iconRender`/`labelRender` 是 antdv-next 的 Vue 扩展,已保留并有测试覆盖。

### 2. fix(dropdown): 透传 menu 的 classes/styles/rootClass 到 Menu — Closes #599

`<Dropdown :menu="{ classes: { root: 'ant-pro-menu' }, styles: { root: { width: '160px' } } }">` 中的 `classes`/`styles` 透传不到 Menu。

**根因**:显式的 `classes=`/`styles=` 把展开的 `{...menu}` 整体覆盖了。

**修复**:将 `menu.classes`/`menu.styles` 与 Dropdown 自身语义类合并(Dropdown 对其管辖的非 root 键仍胜出,优先级与 React 一致),并显式透传 `menu.rootClass`。

### 3. refactor(form): 全局 rules 类型改为递归 RulesMap

Form 级 `rules` 运行时本就通过 namePath + getValue 解析,嵌套对象与数组下标 key 已可用。将扁平的 `Record<string, Rule[]>` 改为递归 `RulesMap`,使 `{ user: { email: [...] } }` 与 `{ list: { 0: [...] } }` 无需 `as any` 即可通过类型检查。

## 测试

- 新增 `Segmented` 用例:无 icon 不渲染 wrapper、混合选项只为有 icon 项渲染。
- 新增 `Dropdown` 用例:menu.classes/styles 透传、menu.rootClass 透传。
- 新增 `form-level-rules.test.tsx`:flat / nested / indexed 三种全局 rules 写法。
- segmented + dropdown + form 共 **289 测试全过**;lint 通过,改动文件类型干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)