### PR TITLE
fix: sync ant-design upstream fixes (#58234 #58214 #58314 #58371 #58339)

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React 主组件库 -> antdv-next 主包"
         }
       ],
-      "last_synced_commit": "b32376a31bf81e0f4d4bf09bf51ba3052313e340",
-      "last_synced_commit_short": "b32376a31b",
-      "last_synced_at": "2026-06-12T08:00:00Z",
+      "last_synced_commit": "66be968055cf8c35f1b18ecc68c4b51c0225a270",
+      "last_synced_commit_short": "66be968055",
+      "last_synced_at": "2026-06-18T00:00:00Z",
       "last_synced_tag": "6.4.4",
-      "sync_count": 11
+      "sync_count": 12
     },
     {
       "name": "cssinjs",

--- a/packages/antdv-next/src/alert/style/index.ts
+++ b/packages/antdv-next/src/alert/style/index.ts
@@ -200,7 +200,7 @@ export const genActionStyle: GenerateStyle<AlertToken, CSSObject> = (token) => {
 
   return {
     [componentCls]: {
-      '&-actions': {
+      [`${componentCls}-actions`]: {
         marginInlineStart: marginXS,
       },
 

--- a/packages/antdv-next/src/dropdown/style/index.ts
+++ b/packages/antdv-next/src/dropdown/style/index.ts
@@ -72,6 +72,7 @@ const genBaseStyle: GenerateStyle<DropdownToken> = (token) => {
     fontSizeIcon,
     controlPaddingHorizontal,
     colorBgElevated,
+    controlHeightLG,
   } = token
 
   return [
@@ -97,8 +98,10 @@ const genBaseStyle: GenerateStyle<DropdownToken> = (token) => {
         },
 
         // Makes vertical dropdowns have a scrollbar once they become taller than the viewport.
+        // Leave some viewport spacing so the menu stays on-screen when the trigger is centered.
+        // https://github.com/ant-design/ant-design/issues/56044
         '&-menu-vertical': {
-          maxHeight: '100vh',
+          maxHeight: `calc(100vh - ${unit(token.calc(controlHeightLG).mul(2.5).equal())})`,
           overflowY: 'auto',
         },
 

--- a/packages/antdv-next/src/pagination/Pagination.tsx
+++ b/packages/antdv-next/src/pagination/Pagination.tsx
@@ -20,6 +20,7 @@ import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools'
 import { devUseWarning, isDev } from '../_util/warning'
 import { useComponentBaseConfig } from '../config-provider/context'
 import { useSize } from '../config-provider/hooks/useSize'
+import useVariant from '../form/hooks/useVariant'
 import useBreakpoint from '../grid/hooks/useBreakpoint'
 import useLocale from '../locale/useLocale'
 import Select from '../select'
@@ -83,6 +84,7 @@ const Pagination = defineComponent<
     const mergedSize = useSize(size)
     const screens = useBreakpoint(responsive as any)
     const isSmall = computed(() => mergedSize.value === 'small' || (!!screens.value?.xs && !mergedSize.value && responsive.value))
+    const [inputVariant, enableInputVariantCls] = useVariant('input')
 
     // =========== Merged Props for Semantic ==========
     const mergedProps = computed(() => {
@@ -249,6 +251,7 @@ const Pagination = defineComponent<
         {
           [`${prefixCls.value}-${align}`]: !!align,
           [`${prefixCls.value}-${mergedSize.value}`]: mergedSize.value,
+          [`${prefixCls.value}-${inputVariant.value}`]: enableInputVariantCls.value && inputVariant.value !== 'outlined',
           /** @deprecated Should be removed in v2 */
           [`${prefixCls.value}-mini`]: isSmall.value,
           [`${prefixCls.value}-rtl`]: direction.value === 'rtl',

--- a/packages/antdv-next/src/pagination/style/index.ts
+++ b/packages/antdv-next/src/pagination/style/index.ts
@@ -329,6 +329,78 @@ const genPaginationSimpleStyle: GenerateStyle<PaginationToken, CSSObject> = (tok
   }
 }
 
+const genPaginationInputVariantStyle: GenerateStyle<PaginationToken, CSSObject> = (token) => {
+  const { componentCls } = token
+  const inputSelector = `${componentCls}-options-quick-jumper input, ${componentCls}-simple-pager input`
+
+  return {
+    [`&${componentCls}-filled`]: {
+      [inputSelector]: {
+        background: token.colorFillTertiary,
+        borderColor: 'transparent',
+
+        '&:hover': {
+          background: token.colorFillSecondary,
+        },
+
+        '&:focus': {
+          borderColor: token.activeBorderColor,
+          outline: 0,
+          backgroundColor: token.activeBg,
+        },
+
+        '&[disabled]': {
+          ...genDisabledStyle(token),
+        },
+      },
+    },
+
+    [`&${componentCls}-borderless`]: {
+      [inputSelector]: {
+        background: 'transparent',
+        border: 'none',
+
+        '&:focus': {
+          outline: 'none',
+          boxShadow: 'none',
+        },
+
+        '&[disabled]': {
+          color: token.colorTextDisabled,
+          cursor: 'not-allowed',
+        },
+      },
+    },
+
+    [`&${componentCls}-underlined`]: {
+      [inputSelector]: {
+        background: token.colorBgContainer,
+        borderWidth: `${unit(token.lineWidth)} 0`,
+        borderStyle: `${token.lineType} none`,
+        borderColor: `transparent transparent ${token.colorBorder} transparent`,
+        borderRadius: 0,
+
+        '&:hover': {
+          borderColor: `transparent transparent ${token.hoverBorderColor} transparent`,
+          backgroundColor: token.hoverBg,
+        },
+
+        '&:focus': {
+          borderColor: `transparent transparent ${token.activeBorderColor} transparent`,
+          outline: 0,
+          backgroundColor: token.activeBg,
+        },
+
+        '&[disabled]': {
+          color: token.colorTextDisabled,
+          boxShadow: 'none',
+          cursor: 'not-allowed',
+        },
+      },
+    },
+  }
+}
+
 const genPaginationJumpStyle: GenerateStyle<PaginationToken, CSSObject> = (token) => {
   const { componentCls, antCls } = token
 
@@ -626,6 +698,9 @@ const genPaginationStyle: GenerateStyle<PaginationToken, CSSObject> = (token) =>
 
       // simple style
       ...genPaginationSimpleStyle(token),
+
+      // input variant style
+      ...genPaginationInputVariantStyle(token),
 
       // size style
       ...genPaginationSmallStyle(token),

--- a/packages/antdv-next/src/table/InternalTable.tsx
+++ b/packages/antdv-next/src/table/InternalTable.tsx
@@ -71,10 +71,23 @@ interface HeaderTableContextValue {
 }
 const HeaderTableContextKey: InjectionKey<Ref<HeaderTableContextValue>> = Symbol('HeaderTableContext')
 
-const HeaderTable = defineComponent({
-  name: 'HeaderTable',
-  inheritAttrs: false,
-  setup(_, { slots, attrs }) {
+export interface HeaderTableProps {}
+
+export interface HeaderTableEmits {
+  [key: string]: (...args: any[]) => void
+}
+
+export interface HeaderTableSlots {
+  default?: () => any
+}
+
+const HeaderTable = defineComponent<
+  HeaderTableProps,
+  HeaderTableEmits,
+  string,
+  SlotsType<HeaderTableSlots>
+>(
+  (_props, { slots, attrs }) => {
     const ctx = inject(HeaderTableContextKey, undefined)
     return () => {
       const { ariaProps, component } = ctx?.value ?? {}
@@ -82,7 +95,11 @@ const HeaderTable = defineComponent({
       return h(Comp, { ...ariaProps, ...attrs }, slots.default?.())
     }
   },
-})
+  {
+    name: 'HeaderTable',
+    inheritAttrs: false,
+  },
+)
 
 export type TableSemanticName = keyof TableSemanticClassNames & keyof TableSemanticStyles
 

--- a/packages/antdv-next/src/table/InternalTable.tsx
+++ b/packages/antdv-next/src/table/InternalTable.tsx
@@ -63,14 +63,24 @@ const EMPTY_LIST: AnyObject[] = []
 
 // Aria props are injected into the scroll header `<table>` so screen readers
 // can still read them when the header is rendered in a separate fixed table.
-const HeaderTableAriaKey: InjectionKey<Ref<Record<string, any>>> = Symbol('HeaderTableAria')
+// `component` keeps any consumer-provided `components.header.table` so the
+// escape hatch is preserved while aria props are merged on top.
+interface HeaderTableContextValue {
+  ariaProps?: Record<string, any>
+  component?: any
+}
+const HeaderTableContextKey: InjectionKey<Ref<HeaderTableContextValue>> = Symbol('HeaderTableContext')
 
 const HeaderTable = defineComponent({
   name: 'HeaderTable',
   inheritAttrs: false,
   setup(_, { slots, attrs }) {
-    const ariaProps = inject(HeaderTableAriaKey, undefined)
-    return () => h('table', { ...ariaProps?.value, ...attrs }, slots.default?.())
+    const ctx = inject(HeaderTableContextKey, undefined)
+    return () => {
+      const { ariaProps, component } = ctx?.value ?? {}
+      const Comp = component ?? 'table'
+      return h(Comp, { ...ariaProps, ...attrs }, slots.default?.())
+    }
   },
 })
 
@@ -264,7 +274,10 @@ const InternalTable = defineComponent<
     // header table via a custom `components.header.table` (#58339).
     const ariaProps = computed(() => pickAttrs(attrs, { aria: true }) as Record<string, any>)
     const hasAriaProps = computed(() => Object.keys(ariaProps.value).length > 0)
-    provide(HeaderTableAriaKey, ariaProps)
+    provide(HeaderTableContextKey, computed<HeaderTableContextValue>(() => ({
+      ariaProps: ariaProps.value,
+      component: props.components?.header?.table,
+    })))
     const mergedComponents = computed(() => {
       const components = props.components
       if (!hasAriaProps.value) {

--- a/packages/antdv-next/src/table/InternalTable.tsx
+++ b/packages/antdv-next/src/table/InternalTable.tsx
@@ -1,5 +1,5 @@
 import type { Reference, TableProps as VcTableProps } from '@v-c/table'
-import type { CSSProperties, SlotsType } from 'vue'
+import type { CSSProperties, InjectionKey, Ref, SlotsType } from 'vue'
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks'
 import type { Breakpoint } from '../_util/responsiveObserver.ts'
 import type { AnyObject, VueNode } from '../_util/type.ts'
@@ -27,9 +27,10 @@ import type {
 } from './interface.ts'
 import VcTable, { INTERNAL_HOOKS, VirtualTable as VcVirtualTable } from '@v-c/table'
 import { clsx } from '@v-c/util'
+import pickAttrs from '@v-c/util/dist/pickAttrs'
 import { getAttrStyleAndClass } from '@v-c/util/dist/props-util'
 import { omit } from 'es-toolkit'
-import { computed, defineComponent, shallowRef, watch, watchEffect } from 'vue'
+import { computed, defineComponent, h, inject, provide, shallowRef, watch, watchEffect } from 'vue'
 import { useMergeSemantic, useToArr, useToProps } from '../_util/hooks'
 import scrollTo from '../_util/scrollTo.ts'
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools.ts'
@@ -59,6 +60,19 @@ import { TableMeasureRowContextProvider } from './TableMeasureRowContext.ts'
 import { convertColumnsToColumnProps } from './utils.ts'
 
 const EMPTY_LIST: AnyObject[] = []
+
+// Aria props are injected into the scroll header `<table>` so screen readers
+// can still read them when the header is rendered in a separate fixed table.
+const HeaderTableAriaKey: InjectionKey<Ref<Record<string, any>>> = Symbol('HeaderTableAria')
+
+const HeaderTable = defineComponent({
+  name: 'HeaderTable',
+  inheritAttrs: false,
+  setup(_, { slots, attrs }) {
+    const ariaProps = inject(HeaderTableAriaKey, undefined)
+    return () => h('table', { ...ariaProps?.value, ...attrs }, slots.default?.())
+  },
+})
 
 export type TableSemanticName = keyof TableSemanticClassNames & keyof TableSemanticStyles
 
@@ -245,6 +259,25 @@ const InternalTable = defineComponent<
     } = useComponentBaseConfig('table', props, ['bodyCell', 'headerCell', 'rowKey', 'scroll', 'column'])
 
     const configCtx = useConfig()
+
+    // Aria props passed to <a-table> land in attrs; re-apply them to the scroll
+    // header table via a custom `components.header.table` (#58339).
+    const ariaProps = computed(() => pickAttrs(attrs, { aria: true }) as Record<string, any>)
+    const hasAriaProps = computed(() => Object.keys(ariaProps.value).length > 0)
+    provide(HeaderTableAriaKey, ariaProps)
+    const mergedComponents = computed(() => {
+      const components = props.components
+      if (!hasAriaProps.value) {
+        return components
+      }
+      return {
+        ...components,
+        header: {
+          ...components?.header,
+          table: HeaderTable,
+        },
+      } as typeof components
+    })
 
     const { classes, styles } = toPropsRefs(props, 'classes', 'styles')
 
@@ -817,6 +850,7 @@ const InternalTable = defineComponent<
               {...virtualProps}
               {...tableProps.value}
               {...restAttrs}
+              components={mergedComponents.value}
               ref={tblRef}
               columns={mergedColumns.value as any}
               data={pageData.value as any}

--- a/packages/antdv-next/src/table/style/ellipsis.ts
+++ b/packages/antdv-next/src/table/style/ellipsis.ts
@@ -10,6 +10,7 @@ const genEllipsisStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
     [`${componentCls}-wrapper`]: {
       [`${componentCls}-cell-ellipsis`]: {
         ...textEllipsis,
+        overflow: 'clip',
         wordBreak: 'keep-all',
 
         // Fixed first or last should special process
@@ -20,6 +21,7 @@ const genEllipsisStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           overflow: 'visible',
           [`${componentCls}-cell-content`]: {
             ...textEllipsis,
+            overflow: 'clip',
             display: 'block',
           },
         },


### PR DESCRIPTION
## 概述

同步上游 [ant-design/ant-design](https://github.com/ant-design/ant-design) 自 `6.4.4` (commit `b32376a31b`) 之后的若干 fix。

## 同步内容

| 上游 PR | 组件 | 说明 |
|---------|------|------|
| [#58234](https://github.com/ant-design/ant-design/pull/58234) | Table | 单元格点击时为 `cell-ellipsis` / `cell-content` 增加 `overflow: clip`，避免点击省略号单元格时浏览器滚动导致省略内容消失 |
| [#58214](https://github.com/ant-design/ant-design/pull/58214) | Dropdown | 纵向菜单 `max-height` 由 `100vh` 改为 `calc(100vh - controlHeightLG * 2.5)`，触发器居中时菜单不溢出视口 |
| [#58314](https://github.com/ant-design/ant-design/pull/58314) | Alert | `&-actions` 改为完整选择器 `${componentCls}-actions`，修复 hashed 样式下 actions 间距丢失 |
| [#58371](https://github.com/ant-design/ant-design/pull/58371) | Pagination | quick jumper / simple pager input 支持 `filled` / `borderless` / `underlined` variant |
| [#58339](https://github.com/ant-design/ant-design/pull/58339) | Table | 将 aria 属性透传到滚动表头 `<table>`（通过 `components.header.table` + provide/inject 实现，对齐 React 的 Context 方案） |

## React → Vue3 适配说明

- **#58339**：React 用 `HeaderTableContext` + `React.useMemo` 保持自定义 header table 组件身份稳定。Vue 侧用模块级 `HeaderTable` 组件 + `provide/inject` 注入 aria props，`mergedComponents` 仅在存在 aria 属性时覆盖 `components.header.table`，避免重复挂载滚动表头。
- **#58371**：复用 antdv-next 既有的 `form/hooks/useVariant`（返回 ref），class 拼接逻辑与 React 一致：`enableInputVariantCls && inputVariant !== 'outlined'`。

## 测试

- `pnpm -F antdv-next test table pagination dropdown alert` —— 315 passed
- ESLint 通过；无新增类型错误（typecheck 残留报错为仓库既有问题）