### PR TITLE
chore(deps): upgrade vc chain — table 1.1.6 (cell memo) + virtual-list 1.0.9 (height perf)

### DIFF
--- a/packages/antdv-next/src/table/InternalTable.tsx
+++ b/packages/antdv-next/src/table/InternalTable.tsx
@@ -192,6 +192,7 @@ export interface TableProps<RecordType = AnyObject>
   styles?: TableStylesType<RecordType>
   dropdownPrefixCls?: string
   dataSource?: VcTableProps<RecordType>['data']
+  column?: Partial<ColumnType<RecordType>>
   columns?: ColumnsType<RecordType>
   pagination?: false | TablePaginationConfig
   loading?: boolean | SpinProps
@@ -360,8 +361,8 @@ const InternalTable = defineComponent<
     })
 
     const baseColumns = useFilledColumns(
-      rawColumns,
-      computed(() => (props.column ?? (contextColumn as any)?.value) as any),
+      rawColumns as any,
+      computed(() => (props.column ?? contextColumn.value)),
     )
 
     const needResponsive = computed(() => baseColumns.value.some((col: any) => col.responsive))

--- a/packages/antdv-next/src/table/tests/Table.loadingMemo.test.tsx
+++ b/packages/antdv-next/src/table/tests/Table.loadingMemo.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import Table from '..'
+import { mount } from '/@tests/utils'
+
+const columns = [
+  { title: 'Name', dataIndex: 'name', key: 'name' },
+  { title: 'Age', dataIndex: 'age', key: 'age' },
+]
+
+const data = [
+  { key: '1', name: 'John', age: 32 },
+  { key: '2', name: 'Jim', age: 42 },
+  { key: '3', name: 'Joe', age: 22 },
+]
+
+describe('table loading memoization', () => {
+  it('does not re-run bodyCell when toggling loading', async () => {
+    const bodyCell = vi.fn(({ text }: any) => text)
+
+    const wrapper = mount(Table, {
+      props: { columns, dataSource: data, loading: false },
+      slots: {
+        bodyCell: (scope: any) => bodyCell(scope),
+      },
+    })
+    await nextTick()
+
+    const initial = bodyCell.mock.calls.length
+    expect(initial).toBeGreaterThan(0)
+
+    await wrapper.setProps({ loading: true })
+    await nextTick()
+    expect(bodyCell.mock.calls.length).toBe(initial)
+
+    await wrapper.setProps({ loading: false })
+    await nextTick()
+    expect(bodyCell.mock.calls.length).toBe(initial)
+  })
+
+  it('still re-runs bodyCell when the data changes', async () => {
+    const bodyCell = vi.fn(({ text }: any) => text)
+
+    const wrapper = mount(Table, {
+      props: { columns, dataSource: data, loading: false },
+      slots: {
+        bodyCell: (scope: any) => bodyCell(scope),
+      },
+    })
+    await nextTick()
+    const initial = bodyCell.mock.calls.length
+
+    await wrapper.setProps({
+      dataSource: [...data.slice(0, 2), { key: '3', name: 'Joe-next', age: 23 }],
+    })
+    await nextTick()
+    expect(bodyCell.mock.calls.length).toBeGreaterThan(initial)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,8 +330,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@v-c/cascader':
-      specifier: ^1.1.0
-      version: 1.1.0
+      specifier: ^1.1.1
+      version: 1.1.1
     '@v-c/checkbox':
       specifier: ^1.0.1
       version: 1.0.1
@@ -390,8 +390,8 @@ catalogs:
       specifier: ^1.0.2
       version: 1.0.2
     '@v-c/select':
-      specifier: ^1.1.1
-      version: 1.1.1
+      specifier: ^1.1.2
+      version: 1.1.2
     '@v-c/slick':
       specifier: ^1.0.2
       version: 1.0.2
@@ -405,8 +405,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@v-c/table':
-      specifier: ^1.1.5
-      version: 1.1.5
+      specifier: ^1.1.6
+      version: 1.1.6
     '@v-c/tabs':
       specifier: ^1.1.0
       version: 1.1.0
@@ -420,17 +420,17 @@ catalogs:
       specifier: ^1.1.0
       version: 1.1.0
     '@v-c/tree':
-      specifier: ^1.1.0
-      version: 1.1.0
+      specifier: ^1.1.1
+      version: 1.1.1
     '@v-c/tree-select':
-      specifier: ^1.1.0
-      version: 1.1.0
+      specifier: ^1.1.1
+      version: 1.1.1
     '@v-c/upload':
       specifier: ^1.0.0
       version: 1.0.0
     '@v-c/virtual-list':
-      specifier: ^1.0.8
-      version: 1.0.8
+      specifier: ^1.0.9
+      version: 1.0.9
 
 overrides:
   '@v-c/portal': ^1.0.8
@@ -798,7 +798,7 @@ importers:
         version: 1.0.1
       '@v-c/cascader':
         specifier: catalog:vc
-        version: 1.1.0(vue@3.5.30(typescript@5.9.3))
+        version: 1.1.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/checkbox':
         specifier: catalog:vc
         version: 1.0.1(vue@3.5.30(typescript@5.9.3))
@@ -861,7 +861,7 @@ importers:
         version: 1.0.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/select':
         specifier: catalog:vc
-        version: 1.1.1(vue@3.5.30(typescript@5.9.3))
+        version: 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/slick':
         specifier: catalog:vc
         version: 1.0.2(vue@3.5.30(typescript@5.9.3))
@@ -876,7 +876,7 @@ importers:
         version: 1.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/table':
         specifier: catalog:vc
-        version: 1.1.5(vue@3.5.30(typescript@5.9.3))
+        version: 1.1.6(vue@3.5.30(typescript@5.9.3))
       '@v-c/tabs':
         specifier: catalog:vc
         version: 1.1.0(vue@3.5.30(typescript@5.9.3))
@@ -891,10 +891,10 @@ importers:
         version: 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/tree':
         specifier: catalog:vc
-        version: 1.1.0(vue@3.5.30(typescript@5.9.3))
+        version: 1.1.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/tree-select':
         specifier: catalog:vc
-        version: 1.1.0(vue@3.5.30(typescript@5.9.3))
+        version: 1.1.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/trigger':
         specifier: ^1.0.16
         version: 1.0.16(vue@3.5.30(typescript@5.9.3))
@@ -906,7 +906,7 @@ importers:
         version: 1.0.19(vue@3.5.30(typescript@5.9.3))
       '@v-c/virtual-list':
         specifier: catalog:vc
-        version: 1.0.8(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.9(vue@3.5.30(typescript@5.9.3))
       '@vueuse/core':
         specifier: catalog:prod
         version: 14.2.1(vue@3.5.30(typescript@5.9.3))
@@ -2828,6 +2828,11 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
+  '@v-c/cascader@1.1.1':
+    resolution: {integrity: sha512-KeQdt/9dV7NN+zqvTNLl5eDJNTEL+p1o0mimMbkHH4sCkgzHYY0nxKtBRpDh1uzeSjqiN8YKxx9VvuzVeDkaOg==}
+    peerDependencies:
+      vue: ^3.0.0
+
   '@v-c/checkbox@1.0.1':
     resolution: {integrity: sha512-+QsE/0VfU6oeglwuHWYxRNTn3+eV08iG0uN/upDmqSGznezInzfUClh+t4acd/OxyJVtuob0WKsg/vPlT6WRWw==}
     peerDependencies:
@@ -2962,6 +2967,11 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
+  '@v-c/select@1.1.2':
+    resolution: {integrity: sha512-3auONNdNmDHe6eh+5HOfyXhAZ4XB8HZy6MAhHGsDrYM6Mh0HBDMDSjts10/rHO6HncnK7hcyuX+nbVqpnefaTg==}
+    peerDependencies:
+      vue: ^3.0.0
+
   '@v-c/slick@1.0.2':
     resolution: {integrity: sha512-8BbPxJgYST+tio9jyeFQgJb/3XSFhfWZN8Am7YVYeqsYsvn3g8wu61UZNSjlkp9ArOEe+ujOgX4izfDHeXh4RA==}
     peerDependencies:
@@ -2982,13 +2992,13 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/table@1.1.4':
-    resolution: {integrity: sha512-rfJtpLR1rUfm5j4GixWZmiXIWrjSUtiZTfibl37xCvvWs7JFtfcBLeVlnFJuKbVOVp8bUSdhwOzvhwXrkEM0hg==}
+  '@v-c/table@1.1.5':
+    resolution: {integrity: sha512-AZ54zLJRrVGp0g9tZSJNNmgvBRRTCEyFfCAzQ2B0gW0LAAjNQ0rek18oBeJz5RkPW9L9Btart8HeGTp9WC/i7A==}
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/table@1.1.5':
-    resolution: {integrity: sha512-AZ54zLJRrVGp0g9tZSJNNmgvBRRTCEyFfCAzQ2B0gW0LAAjNQ0rek18oBeJz5RkPW9L9Btart8HeGTp9WC/i7A==}
+  '@v-c/table@1.1.6':
+    resolution: {integrity: sha512-BkHqjwk1VI06pyJzzzz3uKAvVaU3M7oR8gW9mR0rZLG0SJwcccp/X7kvMytNXWYb94f/awwu4rqT3Og+hFbI5Q==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3017,8 +3027,18 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
+  '@v-c/tree-select@1.1.1':
+    resolution: {integrity: sha512-jh0Wnj7iO8Exm5DFZHvfkdK1Jowxgs2bZ7/0C/2et9Ko9uUEEbJiDKxtEEKiiUNM8pRyUVVEYMNyndA1/HtMFw==}
+    peerDependencies:
+      vue: ^3.0.0
+
   '@v-c/tree@1.1.0':
     resolution: {integrity: sha512-V7O0MHQqPL9eo3WGrM/+HmMoGsrca5jSPZs4GbhshTHKrQvFF38KjOs5xM4CxJBNaVSQzN2iGLUbrZYeiU/9Tw==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@v-c/tree@1.1.1':
+    resolution: {integrity: sha512-TIdW6DG92dC0gk02zjiqF0zKwRGccF0OQw8iOfBgLNk277HpLPLebUEN50VPGnTFB36Smc51/o4tCr1X6Bozwg==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3039,6 +3059,11 @@ packages:
 
   '@v-c/virtual-list@1.0.8':
     resolution: {integrity: sha512-lsc0+AiOaIiG74EvzXSALq2bCwjmFlLDvKjyWXQPwz/9VA3NPkCbMvukA8HgCWvDALvmL0ejnvjc/907b8d8lA==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@v-c/virtual-list@1.0.9':
+    resolution: {integrity: sha512-Yjbjux9HYDWNPAAJkZuc49DSbkJ2KR5Hft2IzMR9v70FSqzYMbMZVKMVu+k1z86xdlcutT8WObpKMLlRXjdHFg==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -8309,6 +8334,13 @@ snapshots:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
+  '@v-c/cascader@1.1.1(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@v-c/select': 1.1.2(vue@3.5.30(typescript@5.9.3))
+      '@v-c/tree': 1.1.1(vue@3.5.30(typescript@5.9.3))
+      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
   '@v-c/checkbox@1.0.1(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
@@ -8464,6 +8496,14 @@ snapshots:
       '@v-c/virtual-list': 1.0.8(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
+  '@v-c/select@1.1.2(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@v-c/overflow': 1.1.0(vue@3.5.30(typescript@5.9.3))
+      '@v-c/trigger': 1.0.16(vue@3.5.30(typescript@5.9.3))
+      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
+      '@v-c/virtual-list': 1.0.9(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
   '@v-c/slick@1.0.2(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
@@ -8485,18 +8525,18 @@ snapshots:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@v-c/table@1.1.4(vue@3.5.30(typescript@5.9.3))':
+  '@v-c/table@1.1.5(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.8(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@v-c/table@1.1.5(vue@3.5.30(typescript@5.9.3))':
+  '@v-c/table@1.1.6(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      '@v-c/virtual-list': 1.0.8(vue@3.5.30(typescript@5.9.3))
+      '@v-c/virtual-list': 1.0.9(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@v-c/tabs@1.1.0(vue@3.5.30(typescript@5.9.3))':
@@ -8535,10 +8575,23 @@ snapshots:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
+  '@v-c/tree-select@1.1.1(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@v-c/select': 1.1.2(vue@3.5.30(typescript@5.9.3))
+      '@v-c/tree': 1.1.1(vue@3.5.30(typescript@5.9.3))
+      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
   '@v-c/tree@1.1.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.8(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
+  '@v-c/tree@1.1.1(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
+      '@v-c/virtual-list': 1.0.9(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@v-c/trigger@1.0.16(vue@3.5.30(typescript@5.9.3))':
@@ -8558,6 +8611,12 @@ snapshots:
       vue: 3.5.30(typescript@5.9.3)
 
   '@v-c/virtual-list@1.0.8(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@v-c/resize-observer': 1.1.2(vue@3.5.30(typescript@5.9.3))
+      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
+  '@v-c/virtual-list@1.0.9(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
@@ -8923,7 +8982,7 @@ snapshots:
       '@v-c/slider': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/steps': 1.0.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/switch': 1.0.1(vue@3.5.30(typescript@5.9.3))
-      '@v-c/table': 1.1.4(vue@3.5.30(typescript@5.9.3))
+      '@v-c/table': 1.1.5(vue@3.5.30(typescript@5.9.3))
       '@v-c/tabs': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/textarea': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/tooltip': 1.0.3(vue@3.5.30(typescript@5.9.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,8 +405,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@v-c/table':
-      specifier: ^1.1.4
-      version: 1.1.4
+      specifier: ^1.1.5
+      version: 1.1.5
     '@v-c/tabs':
       specifier: ^1.1.0
       version: 1.1.0
@@ -608,7 +608,7 @@ importers:
         version: link:../packages/cssinjs
       '@antdv-next/happy-work-theme':
         specifier: catalog:prod
-        version: 1.0.0(antdv-next@1.3.5(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.0(antdv-next@1.3.6(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       '@antdv-next/icons':
         specifier: catalog:prod
         version: 1.0.6(vue@3.5.30(typescript@5.9.3))
@@ -626,7 +626,7 @@ importers:
         version: 14.2.1(vue@3.5.30(typescript@5.9.3))
       antdv-style:
         specifier: catalog:prod
-        version: 1.0.0-rc.1(antdv-next@1.3.5(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.0-rc.1(antdv-next@1.3.6(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       dayjs:
         specifier: catalog:prod
         version: 1.11.20
@@ -876,7 +876,7 @@ importers:
         version: 1.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/table':
         specifier: catalog:vc
-        version: 1.1.4(vue@3.5.30(typescript@5.9.3))
+        version: 1.1.5(vue@3.5.30(typescript@5.9.3))
       '@v-c/tabs':
         specifier: catalog:vc
         version: 1.1.0(vue@3.5.30(typescript@5.9.3))
@@ -2886,18 +2886,8 @@ packages:
   '@v-c/mini-decimal@1.0.1':
     resolution: {integrity: sha512-76wZLdlkI017iDlaZMNOWZyDCv29YVabUJn5urQgIKtW4dnI5AkNXWtmLyhl/mu/OS7ZGisRi5ai/558QhLQxQ==}
 
-  '@v-c/mutate-observer@1.0.1':
-    resolution: {integrity: sha512-84+9KGORX8LY9u+K0DEGyRwRCJaky0sjRkXxBC7X/jahHJl8NQGQ0Gxve5IVwaxRTfZ9eftlRmHs90JD6Utfqg==}
-    peerDependencies:
-      vue: ^3.0.0
-
   '@v-c/mutate-observer@1.0.2':
     resolution: {integrity: sha512-btnmj0NezMcQ/vOlTlP9p47NBOa8q/CIYdDMrpM3W0JrmAHrkAUD7hiWypLXyBuiEko+SQc3U07rcm8StQ5qFA==}
-    peerDependencies:
-      vue: ^3.0.0
-
-  '@v-c/notification@2.0.0':
-    resolution: {integrity: sha512-m/DeTTZf7l0t6ROYNoP6UPUTdbo8SQDU8x6KPeo/9BgpfhOsIp2FcAnzkfb8NXxYzVJyyFTrWxX5IFM3gw6Zcg==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -2939,18 +2929,8 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/progress@1.0.0':
-    resolution: {integrity: sha512-kWDTU1uXnPDMmoezwyAECxuSH+WKn92OjSdk/GgDbQgZ0qNy9woOiRe5fOsrcy61agHdJxzf0MvsUy1b6bZVlA==}
-    peerDependencies:
-      vue: ^3.0.0
-
   '@v-c/progress@1.0.1':
     resolution: {integrity: sha512-ZTaXBYfAASPSk9MD/tu3eZUCnB1UhK6s0G/F0AkNwvzPiVcR2kiiDZO12YpfmdZwUjcrg8U7miAg89aSUZ/aPw==}
-    peerDependencies:
-      vue: ^3.0.0
-
-  '@v-c/qrcode@1.0.0':
-    resolution: {integrity: sha512-OSMrYDhP/NQiUcO6J0X2X8BskHPRqX/E/F9npH3oayZgjCo5Aom+63Ja3J0u6SOmKP1JgLSgjrm5karc0671jw==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3004,6 +2984,11 @@ packages:
 
   '@v-c/table@1.1.4':
     resolution: {integrity: sha512-rfJtpLR1rUfm5j4GixWZmiXIWrjSUtiZTfibl37xCvvWs7JFtfcBLeVlnFJuKbVOVp8bUSdhwOzvhwXrkEM0hg==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@v-c/table@1.1.5':
+    resolution: {integrity: sha512-AZ54zLJRrVGp0g9tZSJNNmgvBRRTCEyFfCAzQ2B0gW0LAAjNQ0rek18oBeJz5RkPW9L9Btart8HeGTp9WC/i7A==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3310,8 +3295,8 @@ packages:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
-  antdv-next@1.3.5:
-    resolution: {integrity: sha512-hGaBUje7JC1Fla6SsQzR7Am71u/Kc6PU8aGBLUSePamcyPkjlC1tymeYeF6oPB6au4LgOXoUzE19Qojaie3wQg==}
+  antdv-next@1.3.6:
+    resolution: {integrity: sha512-ZoBTTRg+Jyb/D2tTWgwMa8vdl5IRVnQYVt5dQ1ttmesQ1zMrdkLMEOzYBGA4LGBL5D7Wcz9ZAHIEYiuZL2CPhw==}
 
   antdv-style@1.0.0-rc.1:
     resolution: {integrity: sha512-CRu+zwJ0nRy3u9vpWm1odesX9Xk1kgvYrGR/enLNbn6yfY8HEgIIvRkeXASIHoaVMDi2E8Jozi+1lGOfiVg0LQ==}
@@ -6489,10 +6474,10 @@ snapshots:
       stylis: 4.3.6
       vue: 3.5.30(typescript@5.9.3)
 
-  '@antdv-next/happy-work-theme@1.0.0(antdv-next@1.3.5(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+  '@antdv-next/happy-work-theme@1.0.0(antdv-next@1.3.6(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@ant-design/fast-color': 3.0.1
-      antdv-next: 1.3.5(vue@3.5.30(typescript@5.9.3))
+      antdv-next: 1.3.6(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@antdv-next/icons@1.0.6(vue@3.5.30(typescript@5.9.3))':
@@ -8394,20 +8379,9 @@ snapshots:
 
   '@v-c/mini-decimal@1.0.1': {}
 
-  '@v-c/mutate-observer@1.0.1(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@v-c/resize-observer': 1.1.2(vue@3.5.30(typescript@5.9.3))
-      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
-
   '@v-c/mutate-observer@1.0.2(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.2(vue@3.5.30(typescript@5.9.3))
-      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@v-c/notification@2.0.0(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
@@ -8442,17 +8416,7 @@ snapshots:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@v-c/progress@1.0.0(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
-
   '@v-c/progress@1.0.1(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@v-c/qrcode@1.0.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
@@ -8522,6 +8486,13 @@ snapshots:
       vue: 3.5.30(typescript@5.9.3)
 
   '@v-c/table@1.1.4(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@v-c/resize-observer': 1.1.2(vue@3.5.30(typescript@5.9.3))
+      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
+      '@v-c/virtual-list': 1.0.8(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
+  '@v-c/table@1.1.5(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
@@ -8919,7 +8890,7 @@ snapshots:
 
   ansis@4.2.0: {}
 
-  antdv-next@1.3.5(vue@3.5.30(typescript@5.9.3)):
+  antdv-next@1.3.6(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@ant-design/colors': 8.0.1
       '@ant-design/fast-color': 3.0.1
@@ -8938,12 +8909,12 @@ snapshots:
       '@v-c/input-number': 1.0.5(vue@3.5.30(typescript@5.9.3))
       '@v-c/mentions': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/menu': 1.2.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/mutate-observer': 1.0.1(vue@3.5.30(typescript@5.9.3))
-      '@v-c/notification': 2.0.0(vue@3.5.30(typescript@5.9.3))
+      '@v-c/mutate-observer': 1.0.2(vue@3.5.30(typescript@5.9.3))
+      '@v-c/notification': 2.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/pagination': 1.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/picker': 1.1.3(dayjs@1.11.20)(vue@3.5.30(typescript@5.9.3))
-      '@v-c/progress': 1.0.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/qrcode': 1.0.0(vue@3.5.30(typescript@5.9.3))
+      '@v-c/progress': 1.0.1(vue@3.5.30(typescript@5.9.3))
+      '@v-c/qrcode': 1.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/rate': 1.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/resize-observer': 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/segmented': 1.0.2(vue@3.5.30(typescript@5.9.3))
@@ -8974,10 +8945,10 @@ snapshots:
       - moment
       - vue
 
-  antdv-style@1.0.0-rc.1(antdv-next@1.3.5(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
+  antdv-style@1.0.0-rc.1(antdv-next@1.3.6(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@emotion/css': 11.13.5
-      antdv-next: 1.3.5(vue@3.5.30(typescript@5.9.3))
+      antdv-next: 1.3.6(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -128,7 +128,7 @@ catalogs:
     '@types/throttle-debounce': ^5.0.2
   vc:
     '@v-c/async-validator': ^1.0.1
-    '@v-c/cascader': ^1.1.0
+    '@v-c/cascader': ^1.1.1
     '@v-c/checkbox': ^1.0.1
     '@v-c/collapse': ^1.0.0
     '@v-c/color-picker': ^1.0.6
@@ -150,22 +150,22 @@ catalogs:
     '@v-c/rate': ^1.0.1
     '@v-c/resize-observer': ^1.1.2
     '@v-c/segmented': ^1.0.2
-    '@v-c/select': ^1.1.1
+    '@v-c/select': ^1.1.2
     '@v-c/slick': ^1.0.2
     '@v-c/slider': ^1.1.0
     '@v-c/steps': ^1.0.0
     '@v-c/switch': ^1.0.1
-    '@v-c/table': ^1.1.5
+    '@v-c/table': ^1.1.6
     '@v-c/tabs': ^1.1.0
     '@v-c/textarea': ^1.1.0
     '@v-c/tooltip': ^1.0.3
     '@v-c/tour': ^1.1.0
-    '@v-c/tree': ^1.1.0
-    '@v-c/tree-select': ^1.1.0
+    '@v-c/tree': ^1.1.1
+    '@v-c/tree-select': ^1.1.1
     '@v-c/trigger': ^1.0.16
     '@v-c/upload': ^1.0.0
     '@v-c/util': ^1.0.19
-    '@v-c/virtual-list': ^1.0.8
+    '@v-c/virtual-list': ^1.0.9
 
 onlyBuiltDependencies:
   - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -155,7 +155,7 @@ catalogs:
     '@v-c/slider': ^1.1.0
     '@v-c/steps': ^1.0.0
     '@v-c/switch': ^1.0.1
-    '@v-c/table': ^1.1.4
+    '@v-c/table': ^1.1.5
     '@v-c/tabs': ^1.1.0
     '@v-c/textarea': ^1.1.0
     '@v-c/tooltip': ^1.0.3


### PR DESCRIPTION
## 背景

升级整条 vc 依赖链,落地两个性能修复。

### 1. `@v-c/table` 1.1.6 — 单元格渲染 memo
切换表格 `loading`(或任何无关的祖先重渲染)时,每个单元格的 `render`/`bodyCell` 都会被重新执行。根因是 `Cell` 没有任何 memo。1.1.6(承接 1.1.5)在 `Cell` 内对渲染输出做 memo(默认 `computed` 自动追踪;配 `shouldCellUpdate` 时走显式比较;`column` 用 `toRaw` 规避上游列对象 identity churn),并把 `shouldCellUpdate` 透传给普通行的 `Cell`——对齐 rc-table 的 `useCellRender` + `React.memo(Cell)`。
close #590 

### 2. `@v-c/virtual-list` 1.0.9 — 测高 perf
虚拟滚动里 `useHeights` 给**每一行**都挂了 `ResizeObserver`,每行 resize 都触发整批 `collectHeight`(`offsetParent`/`offsetHeight`/`getComputedStyle`),造成反复强制同步布局 reflow(大表上单行 ~250ms)。1.0.9 移除逐行 observer,改由已有的**容器级** observer(Filler `onInnerResize` + holder)驱动测高,对齐 rc-virtual-list。

## 改动

- `pnpm-workspace.yaml` catalog `vc`:
  - `@v-c/virtual-list` `^1.0.8 → ^1.0.9`
  - `@v-c/table` `^1.1.4 → ^1.1.6`
  - `@v-c/select` `^1.1.1 → ^1.1.2`
  - `@v-c/tree` `^1.1.0 → ^1.1.1`
  - `@v-c/cascader` `^1.1.0 → ^1.1.1`
  - `@v-c/tree-select` `^1.1.0 → ^1.1.1`
- `pnpm-lock.yaml`:对应 install
- 新增 `Table.loadingMemo.test.tsx`:回归——切换 `loading` 不重跑 `bodyCell`,数据变化仍重跑

## 效果

- 切换 `loading` / 分页等无关重渲染:不再重跑单元格 `render`/`bodyCell`
- 数据变化(增删改 / 重新赋值 dataSource,即排序筛选):仍正确重渲染;原地修改响应式 record 仍更新
- 虚拟表格/列表:测高的强制 reflow 由每行一次收敛为每提交一次

## 测试(基于真实发布版本,无 patch)

- antdv-next:table 176 / select 65 / tree 106(+2 既有 skip)/ tree-select 32 —— **全绿**
- 上游 `@v-c/*`:virtual-list 15 / table 19 / select 13 / tree 2 —— 全绿(含普通表格与虚拟表格 memo、测高对齐用例)