### PR TITLE
fix(segmented): the default first selection style is not effective

### DIFF
--- a/packages/antdv-next/src/segmented/index.tsx
+++ b/packages/antdv-next/src/segmented/index.tsx
@@ -163,7 +163,7 @@ const InternalSegmented = defineComponent<
         // Only wrap the option when it actually carries an icon or a custom label,
         // otherwise keep the raw option so we don't render an empty icon wrapper.
         if (hasIcon || hasCustomLabel) {
-          const { label, ...restOption } = _option
+          const { label, icon: _icon, ...restOption } = _option
           const mergedLabel = labelFromSlot.length > 0 ? labelFromSlot : label
           const showLabel = !!(labelFromSlot.length > 0) || !!label
           const icon = getSlotPropsFnRun({}, option, 'icon') ?? iconFromSlot
@@ -194,6 +194,7 @@ const InternalSegmented = defineComponent<
         rootClass,
         block,
         shape,
+        classes,
         ...restProps
       } = props
       const cls = clsx(

--- a/packages/antdv-next/src/segmented/tests/__snapshots__/Segmented.test.tsx.snap
+++ b/packages/antdv-next/src/segmented/tests/__snapshots__/Segmented.test.tsx.snap
@@ -52,9 +52,10 @@ exports[`segmented > should render segmented with mixed options 1`] = `
   >
     <!---->
     <label
-      class="ant-segmented-item"
+      class="ant-segmented-item ant-segmented-item-selected"
     >
       <input
+        checked=""
         class="ant-segmented-item-input"
         name="v-0"
         type="radio"
@@ -114,9 +115,10 @@ exports[`segmented > should render segmented with string options 1`] = `
   >
     <!---->
     <label
-      class="ant-segmented-item"
+      class="ant-segmented-item ant-segmented-item-selected"
     >
       <input
+        checked=""
         class="ant-segmented-item-input"
         name="v-0"
         type="radio"
@@ -176,9 +178,10 @@ exports[`segmented > snapshot > should match snapshot with block and size 1`] = 
   >
     <!---->
     <label
-      class="ant-segmented-item"
+      class="ant-segmented-item ant-segmented-item-selected"
     >
       <input
+        checked=""
         class="ant-segmented-item-input"
         name="v-0"
         type="radio"
@@ -308,9 +311,10 @@ exports[`segmented > snapshot > should match snapshot with round shape 1`] = `
   >
     <!---->
     <label
-      class="ant-segmented-item"
+      class="ant-segmented-item ant-segmented-item-selected"
     >
       <input
+        checked=""
         class="ant-segmented-item-input"
         name="v-0"
         type="radio"
@@ -355,9 +359,10 @@ exports[`segmented > snapshot > should match snapshot with various options 1`] =
   >
     <!---->
     <label
-      class="ant-segmented-item"
+      class="ant-segmented-item ant-segmented-item-selected"
     >
       <input
+        checked=""
         class="ant-segmented-item-input"
         name="v-0"
         type="radio"

--- a/packages/antdv-next/src/segmented/tests/__snapshots__/Segmented.test.tsx.snap
+++ b/packages/antdv-next/src/segmented/tests/__snapshots__/Segmented.test.tsx.snap
@@ -242,7 +242,6 @@ exports[`segmented > snapshot > should match snapshot with icon options 1`] = `
     <!---->
     <label
       class="ant-segmented-item ant-segmented-item-selected"
-      icon="[object Object]"
     >
       <input
         checked=""
@@ -269,7 +268,6 @@ exports[`segmented > snapshot > should match snapshot with icon options 1`] = `
     </label>
     <label
       class="ant-segmented-item"
-      icon="[object Object]"
     >
       <input
         class="ant-segmented-item-input"

--- a/packages/antdv-next/src/segmented/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/segmented/tests/__snapshots__/demo.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
         aria-label="segmented control"
         aria-orientation="horizontal"
         class="ant-segmented semantic-mark-root css-var-v-0 semantic-mark-root css-var-v-0"
-        classes="[object Object]"
         role="radiogroup"
         size="middle"
         tabindex="0"
@@ -28,7 +27,6 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
           <!---->
           <label
             class="ant-segmented-item semantic-mark-item ant-segmented-item-selected"
-            icon="[object Object]"
           >
             <input
               checked=""
@@ -69,7 +67,6 @@ exports[`segmented demo > renders _semantic correctly 1`] = `
           </label>
           <label
             class="ant-segmented-item semantic-mark-item"
-            icon="[object Object]"
           >
             <input
               class="ant-segmented-item-input"
@@ -1307,7 +1304,6 @@ exports[`segmented demo > renders icon-only correctly 1`] = `
       <!---->
       <label
         class="ant-segmented-item ant-segmented-item-selected"
-        icon="[object Object]"
       >
         <input
           checked=""
@@ -1346,7 +1342,6 @@ exports[`segmented demo > renders icon-only correctly 1`] = `
       </label>
       <label
         class="ant-segmented-item"
-        icon="[object Object]"
       >
         <input
           class="ant-segmented-item-input"
@@ -1926,7 +1921,6 @@ exports[`segmented demo > renders style-class correctly 1`] = `
     aria-label="segmented control"
     aria-orientation="horizontal"
     class="ant-segmented custom-segmented-root css-var-root custom-segmented-root css-var-root"
-    classes="[object Object]"
     data-v-0de51c46=""
     role="radiogroup"
     size="middle"
@@ -1939,7 +1933,6 @@ exports[`segmented demo > renders style-class correctly 1`] = `
       <!---->
       <label
         class="ant-segmented-item ant-segmented-item-selected"
-        icon="[object Object]"
       >
         <input
           checked=""
@@ -1980,7 +1973,6 @@ exports[`segmented demo > renders style-class correctly 1`] = `
       </label>
       <label
         class="ant-segmented-item"
-        icon="[object Object]"
       >
         <input
           class="ant-segmented-item-input"
@@ -2020,7 +2012,6 @@ exports[`segmented demo > renders style-class correctly 1`] = `
       </label>
       <label
         class="ant-segmented-item"
-        icon="[object Object]"
       >
         <input
           class="ant-segmented-item-input"
@@ -2064,7 +2055,6 @@ exports[`segmented demo > renders style-class correctly 1`] = `
     aria-label="segmented control"
     aria-orientation="vertical"
     class="ant-segmented ant-segmented-vertical custom-segmented-root ant-segmented-vertical css-var-root custom-segmented-root ant-segmented-vertical css-var-root"
-    classes="[object Object]"
     data-v-0de51c46=""
     role="radiogroup"
     size="middle"
@@ -2077,7 +2067,6 @@ exports[`segmented demo > renders style-class correctly 1`] = `
       <!---->
       <label
         class="ant-segmented-item ant-segmented-item-selected"
-        icon="[object Object]"
         style="text-align: start;"
       >
         <input
@@ -2120,7 +2109,6 @@ exports[`segmented demo > renders style-class correctly 1`] = `
       </label>
       <label
         class="ant-segmented-item"
-        icon="[object Object]"
         style="text-align: start;"
       >
         <input
@@ -2162,7 +2150,6 @@ exports[`segmented demo > renders style-class correctly 1`] = `
       </label>
       <label
         class="ant-segmented-item"
-        icon="[object Object]"
         style="text-align: start;"
       >
         <input
@@ -2318,7 +2305,6 @@ exports[`segmented demo > renders with-icon correctly 1`] = `
       <!---->
       <label
         class="ant-segmented-item ant-segmented-item-selected"
-        icon="[object Object]"
       >
         <input
           checked=""
@@ -2359,7 +2345,6 @@ exports[`segmented demo > renders with-icon correctly 1`] = `
       </label>
       <label
         class="ant-segmented-item"
-        icon="[object Object]"
       >
         <input
           class="ant-segmented-item-input"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,8 +390,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@v-c/segmented':
-      specifier: ^1.0.2
-      version: 1.0.2
+      specifier: ^1.0.3
+      version: 1.0.3
     '@v-c/select':
       specifier: ^1.1.2
       version: 1.1.2
@@ -864,7 +864,7 @@ importers:
         version: 1.1.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/segmented':
         specifier: catalog:vc
-        version: 1.0.2(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.3(vue@3.5.30(typescript@5.9.3))
       '@v-c/select':
         specifier: catalog:vc
         version: 1.1.2(vue@3.5.30(typescript@5.9.3))
@@ -2884,11 +2884,6 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/menu@1.2.0':
-    resolution: {integrity: sha512-iEvRMxit9VlxAGsvcgR1B4hLpi7gIz4dvKbxf4pnClA75OS8J4AGHSdyevtANNHplfJXoi0G3St0dKPKduETbg==}
-    peerDependencies:
-      vue: ^3.0.0
-
   '@v-c/menu@1.2.1':
     resolution: {integrity: sha512-3FLWQF8oLB1Lsj9MkgSHTAZg35p0aqUG0uboJfZ+c4sBB+muLHJbtgokoUXPfkW3bgDSuLmNYk8cBzy7F4PEHg==}
     peerDependencies:
@@ -2965,6 +2960,11 @@ packages:
 
   '@v-c/segmented@1.0.2':
     resolution: {integrity: sha512-g/aWgURMJkytu05AACN3Pd9QKgka4ZQM8tl/y0AcabANldy2hmPIHek0ZH5dDdn5VmK1PhAfUTqtgDS19sLh5w==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@v-c/segmented@1.0.3':
+    resolution: {integrity: sha512-+XHRu0Oou6FSAQUjIPnEQLjQUIDhMYQ4eUh8nRpg/S5BCju32/bh8ycmyqrGpQ2z7o+s2ZjKS5vy2b81Lh6xUw==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -8379,13 +8379,6 @@ snapshots:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@v-c/menu@1.2.0(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@v-c/overflow': 1.1.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/trigger': 1.0.16(vue@3.5.30(typescript@5.9.3))
-      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
-
   '@v-c/menu@1.2.1(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.1.0(vue@3.5.30(typescript@5.9.3))
@@ -8468,6 +8461,11 @@ snapshots:
       - typescript
 
   '@v-c/segmented@1.0.2(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
+  '@v-c/segmented@1.0.3(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@v-c/util': 1.0.19(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
@@ -8917,7 +8915,7 @@ snapshots:
       '@v-c/input': 1.1.0(vue@3.5.30(typescript@5.9.3))
       '@v-c/input-number': 1.0.5(vue@3.5.30(typescript@5.9.3))
       '@v-c/mentions': 1.1.0(vue@3.5.30(typescript@5.9.3))
-      '@v-c/menu': 1.2.0(vue@3.5.30(typescript@5.9.3))
+      '@v-c/menu': 1.2.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/mutate-observer': 1.0.2(vue@3.5.30(typescript@5.9.3))
       '@v-c/notification': 2.0.1(vue@3.5.30(typescript@5.9.3))
       '@v-c/pagination': 1.0.1(vue@3.5.30(typescript@5.9.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -150,7 +150,7 @@ catalogs:
     '@v-c/qrcode': ^1.0.1
     '@v-c/rate': ^1.0.1
     '@v-c/resize-observer': ^1.1.2
-    '@v-c/segmented': ^1.0.2
+    '@v-c/segmented': ^1.0.3
     '@v-c/select': ^1.1.2
     '@v-c/slick': ^1.0.2
     '@v-c/slider': ^1.1.0


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

#### items为["1","2","3"]并且没有设置value与defaultValue时，默认是选择第一个，但是@v-c/segmented中取的是items[0].value，所以拿到的是undefined，将其改为取normalizeOptions转换后的值
#### 为@v-c/segemented透传了非必要的属性classes与icon，dom上呈现classes=”[object Object]"与icon=”[object Object]"
<img width="2166" height="1170" alt="image" src="https://github.com/user-attachments/assets/3bbef619-a4aa-4e1c-b51e-c8dd1c081cd1" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    the default first selection style is not effective       |
| 🇨🇳 Chinese |     默认的第一个选择的样式未生效      |
