### PR TITLE
fix(input-otp): prevent duplicate onChange trigger and spurious autofocus attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Snapshot files — disable EOL conversion to avoid CRLF/LF churn
+*.snap -text

--- a/packages/antdv-next/src/input/OTP/OTPInput.tsx
+++ b/packages/antdv-next/src/input/OTP/OTPInput.tsx
@@ -88,9 +88,6 @@ const OTPInput = defineComponent<
           onMouseup={() => syncSelection()}
           aria-label={`OTP Input ${props.index + 1}`}
           v-slots={slots}
-          {...{
-            'onUpdate:value': (value: string) => props.onChange(props.index, value ?? ''),
-          }}
         />
       </span>
     )

--- a/packages/antdv-next/src/input/OTP/index.tsx
+++ b/packages/antdv-next/src/input/OTP/index.tsx
@@ -240,7 +240,7 @@ const OTP = defineComponent<
                 value={valueCells.value[index] || ''}
                 onChange={handleInputChange}
                 onActiveChange={handleActiveChange}
-                autoFocus={index === 0 && props.autoFocus}
+                autoFocus={index === 0 ? props.autoFocus : undefined}
                 mask={props.mask}
                 type={props.type}
                 inputMode={props.inputMode}

--- a/packages/antdv-next/src/input/tests/__snapshots__/OTP.test.tsx.snap
+++ b/packages/antdv-next/src/input/tests/__snapshots__/OTP.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`otp > rtl render > component should be rendered correctly in RTL direct
       <!---->
       <input
         aria-label="OTP Input 2"
-        autofocus="false"
         class="ant-input ant-input-rtl ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -44,7 +43,6 @@ exports[`otp > rtl render > component should be rendered correctly in RTL direct
       <!---->
       <input
         aria-label="OTP Input 3"
-        autofocus="false"
         class="ant-input ant-input-rtl ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -59,7 +57,6 @@ exports[`otp > rtl render > component should be rendered correctly in RTL direct
       <!---->
       <input
         aria-label="OTP Input 4"
-        autofocus="false"
         class="ant-input ant-input-rtl ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -74,7 +71,6 @@ exports[`otp > rtl render > component should be rendered correctly in RTL direct
       <!---->
       <input
         aria-label="OTP Input 5"
-        autofocus="false"
         class="ant-input ant-input-rtl ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -89,7 +85,6 @@ exports[`otp > rtl render > component should be rendered correctly in RTL direct
       <!---->
       <input
         aria-label="OTP Input 6"
-        autofocus="false"
         class="ant-input ant-input-rtl ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"

--- a/packages/antdv-next/src/input/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/input/tests/__snapshots__/demo.test.tsx.snap
@@ -900,7 +900,6 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
           <!---->
           <input
             aria-label="OTP Input 2"
-            autofocus="false"
             class="ant-input ant-input-outlined ant-otp-input semantic-mark-input css-var-v-0 ant-input-css-var"
             size="1"
             type="text"
@@ -919,7 +918,6 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
           <!---->
           <input
             aria-label="OTP Input 3"
-            autofocus="false"
             class="ant-input ant-input-outlined ant-otp-input semantic-mark-input css-var-v-0 ant-input-css-var"
             size="1"
             type="text"
@@ -938,7 +936,6 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
           <!---->
           <input
             aria-label="OTP Input 4"
-            autofocus="false"
             class="ant-input ant-input-outlined ant-otp-input semantic-mark-input css-var-v-0 ant-input-css-var"
             size="1"
             type="text"
@@ -957,7 +954,6 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
           <!---->
           <input
             aria-label="OTP Input 5"
-            autofocus="false"
             class="ant-input ant-input-outlined ant-otp-input semantic-mark-input css-var-v-0 ant-input-css-var"
             size="1"
             type="text"
@@ -976,7 +972,6 @@ exports[`input demo > renders _semantic-otp correctly 1`] = `
           <!---->
           <input
             aria-label="OTP Input 6"
-            autofocus="false"
             class="ant-input ant-input-outlined ant-otp-input semantic-mark-input css-var-v-0 ant-input-css-var"
             size="1"
             type="text"
@@ -4351,7 +4346,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 2"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4366,7 +4360,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 3"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4381,7 +4374,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 4"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4396,7 +4388,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 5"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4411,7 +4402,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 6"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4458,7 +4448,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 2"
-        autofocus="false"
         class="ant-input ant-input-disabled ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         disabled=""
         size="1"
@@ -4474,7 +4463,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 3"
-        autofocus="false"
         class="ant-input ant-input-disabled ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         disabled=""
         size="1"
@@ -4490,7 +4478,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 4"
-        autofocus="false"
         class="ant-input ant-input-disabled ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         disabled=""
         size="1"
@@ -4506,7 +4493,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 5"
-        autofocus="false"
         class="ant-input ant-input-disabled ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         disabled=""
         size="1"
@@ -4522,7 +4508,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 6"
-        autofocus="false"
         class="ant-input ant-input-disabled ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         disabled=""
         size="1"
@@ -4569,7 +4554,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 2"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4584,7 +4568,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 3"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4599,7 +4582,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 4"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4614,7 +4596,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 5"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4629,7 +4610,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 6"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4644,7 +4624,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 7"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4659,7 +4638,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 8"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4705,7 +4683,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 2"
-        autofocus="false"
         class="ant-input ant-input-filled ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4720,7 +4697,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 3"
-        autofocus="false"
         class="ant-input ant-input-filled ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4735,7 +4711,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 4"
-        autofocus="false"
         class="ant-input ant-input-filled ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4750,7 +4725,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 5"
-        autofocus="false"
         class="ant-input ant-input-filled ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4765,7 +4739,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 6"
-        autofocus="false"
         class="ant-input ant-input-filled ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4811,7 +4784,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 2"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4826,7 +4798,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 3"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4841,7 +4812,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 4"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4856,7 +4826,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 5"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4871,7 +4840,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 6"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4923,7 +4891,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 2"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4944,7 +4911,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 3"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4965,7 +4931,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 4"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -4986,7 +4951,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 5"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -5007,7 +4971,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 6"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -5061,7 +5024,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 2"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -5084,7 +5046,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 3"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -5107,7 +5068,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 4"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -5130,7 +5090,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 5"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -5153,7 +5112,6 @@ exports[`input demo > renders otp correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 6"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         type="text"
@@ -6557,7 +6515,6 @@ exports[`input demo > renders style-class correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 2"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         style="border-color: rgb(110, 140, 251); width: 32px;"
@@ -6577,7 +6534,6 @@ exports[`input demo > renders style-class correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 3"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         style="border-color: rgb(110, 140, 251); width: 32px;"
@@ -6597,7 +6553,6 @@ exports[`input demo > renders style-class correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 4"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         style="border-color: rgb(110, 140, 251); width: 32px;"
@@ -6617,7 +6572,6 @@ exports[`input demo > renders style-class correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 5"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         style="border-color: rgb(110, 140, 251); width: 32px;"
@@ -6637,7 +6591,6 @@ exports[`input demo > renders style-class correctly 1`] = `
       <!---->
       <input
         aria-label="OTP Input 6"
-        autofocus="false"
         class="ant-input ant-input-outlined ant-otp-input css-var-root ant-input-css-var"
         size="1"
         style="border-color: rgb(110, 140, 251); width: 32px;"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     projects: [
-      './packages/*',
+      './packages/antdv-next',
+      './packages/cssinjs',
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   prevent duplicate onChange trigger and spurious autofocus attributes  |
| 🇨🇳 Chinese |   修复重复触发 onChange 及多余的 autofocus 属性导致默认选中第二个输入框   |
