### PR TITLE
docs: add component meta block (import / feedback / docs / version)

### DIFF
--- a/docs/src/components/docs/component-meta.vue
+++ b/docs/src/components/docs/component-meta.vue
@@ -39,12 +39,38 @@ const slug = computed(() => {
 const component = computed(() => props.frontmatter?.title)
 const version = computed(() => props.frontmatter?.tag)
 
-const show = computed(() => props.frontmatter?.category === 'Components' && !!component.value && !!slug.value)
+// Some pages don't map 1:1 to a single named export or source directory, so
+// override the import snippet / source path for those (keyed by docs slug).
+const IMPORT_OVERRIDES: Record<string, string> = {
+  icon: `import { AntDesignOutlined } from '@antdv-next/icons'`,
+  grid: `import { Row, Col } from 'antdv-next'`,
+  message: `import { message } from 'antdv-next'`,
+  notification: `import { notification } from 'antdv-next'`,
+}
+const SOURCE_OVERRIDES: Record<string, { repo?: string, dir: string }> = {
+  'qr-code': { dir: 'qrcode' },
+  'icon': { repo: 'antdv-next/icons', dir: 'src' },
+}
 
-const importCode = computed(() => `import { ${component.value} } from 'antdv-next'`)
+const show = computed(() =>
+  props.frontmatter?.category === 'Components'
+  && props.frontmatter?.showImport !== false
+  && !!component.value
+  && !!slug.value)
 
-const sourceUrl = computed(() => `https://github.com/${REPO}/tree/main/packages/antdv-next/src/${slug.value}`)
-const abbrSource = computed(() => `packages/antdv-next/src/${slug.value}`)
+const importCode = computed(() =>
+  IMPORT_OVERRIDES[slug.value] ?? `import { ${component.value} } from 'antdv-next'`)
+
+const sourceRepo = computed(() => SOURCE_OVERRIDES[slug.value]?.repo ?? REPO)
+const sourcePath = computed(() => {
+  const override = SOURCE_OVERRIDES[slug.value]
+  if (override) {
+    return override.repo ? override.dir : `packages/antdv-next/src/${override.dir}`
+  }
+  return `packages/antdv-next/src/${slug.value}`
+})
+const sourceUrl = computed(() => `https://github.com/${sourceRepo.value}/tree/main/${sourcePath.value}`)
+const abbrSource = computed(() => sourceRepo.value === REPO ? sourcePath.value : sourceRepo.value)
 const editUrl = computed(() =>
   `https://github.com/${REPO}/edit/main/docs/src/pages/components/${slug.value}/index.${isZhCN.value ? 'zh-CN' : 'en-US'}.md`)
 const llmsUrl = computed(() => `/components/${slug.value}${isZhCN.value ? '-cn' : ''}.md`)

--- a/docs/src/components/docs/component-meta.vue
+++ b/docs/src/components/docs/component-meta.vue
@@ -1,0 +1,165 @@
+<script lang="ts" setup>
+import type { Frontmatter } from '@/composables/doc-page.ts'
+import {
+  BugOutlined,
+  EditOutlined,
+  FileTextOutlined,
+  GithubOutlined,
+  HistoryOutlined,
+  IssuesCloseOutlined,
+  LoadingOutlined,
+} from '@antdv-next/icons'
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useIssueCount } from '@/composables/use-issue-count.ts'
+
+defineOptions({ name: 'ComponentMeta' })
+
+const props = defineProps<{
+  frontmatter?: Frontmatter
+}>()
+
+const REPO = 'antdv-next/antdv-next'
+
+const route = useRoute()
+
+const isZhCN = computed(() => route.path.endsWith('-cn'))
+
+const locale = computed(() => (isZhCN.value
+  ? { import: '使用', copy: '复制', copied: '已复制', source: '反馈', docs: '文档', edit: '编辑此页', changelog: '更新日志', version: '版本', issueNew: '提交问题', issueOpen: '待解决' }
+  : { import: 'Import', copy: 'Copy', copied: 'Copied', source: 'GitHub', docs: 'Docs', edit: 'Edit this page', changelog: 'Changelog', version: 'Version', issueNew: 'Issue', issueOpen: 'Open issues' }))
+
+// docs folder slug, e.g. `/components/date-picker-cn` -> `date-picker`
+const slug = computed(() => {
+  const segments = route.path.split('/').filter(Boolean)
+  const last = segments[segments.length - 1] ?? ''
+  return last.replace(/-cn$/, '')
+})
+
+const component = computed(() => props.frontmatter?.title)
+const version = computed(() => props.frontmatter?.tag)
+
+const show = computed(() => props.frontmatter?.category === 'Components' && !!component.value && !!slug.value)
+
+const importCode = computed(() => `import { ${component.value} } from 'antdv-next'`)
+
+const sourceUrl = computed(() => `https://github.com/${REPO}/tree/main/packages/antdv-next/src/${slug.value}`)
+const abbrSource = computed(() => `packages/antdv-next/src/${slug.value}`)
+const editUrl = computed(() =>
+  `https://github.com/${REPO}/edit/main/docs/src/pages/components/${slug.value}/index.${isZhCN.value ? 'zh-CN' : 'en-US'}.md`)
+const llmsUrl = computed(() => `/components/${slug.value}${isZhCN.value ? '-cn' : ''}.md`)
+const changelogUrl = computed(() => `/components/changelog${isZhCN.value ? '-cn' : ''}`)
+
+const isVersion = computed(() => !!version.value && /^\d+\.\d+\.\d+$/.test(version.value))
+
+const { issueCount, loading, issueNewUrl, issueSearchUrl } = useIssueCount({
+  repo: REPO,
+  enabled: () => show.value,
+  titleKeywords: () => [props.frontmatter?.title, props.frontmatter?.subtitle].filter(Boolean) as string[],
+})
+
+const copied = ref(false)
+async function onCopy() {
+  try {
+    await navigator.clipboard.writeText(importCode.value)
+    copied.value = true
+  }
+  catch {
+    copied.value = false
+  }
+}
+function onOpenChange(open: boolean) {
+  if (open) {
+    copied.value = false
+  }
+}
+</script>
+
+<template>
+  <template v-if="show">
+    <a-descriptions
+      size="small"
+      :colon="false"
+      :column="1"
+      class="component-meta"
+      style="margin-top: 16px"
+      :styles="{ label: { paddingInlineEnd: '16px', width: '56px' } }"
+    >
+      <a-descriptions-item :label="locale.import">
+        <a-tooltip placement="right" :title="copied ? locale.copied : locale.copy" @open-change="onOpenChange">
+          <a-typography-text class="component-meta-code" style="cursor: pointer" @click="onCopy">
+            {{ importCode }}
+          </a-typography-text>
+        </a-tooltip>
+      </a-descriptions-item>
+
+      <a-descriptions-item :label="locale.source">
+        <a-flex justify="flex-start" align="center" gap="small">
+          <a-typography-link class="component-meta-code" :href="sourceUrl" target="_blank">
+            <GithubOutlined class="component-meta-icon" />
+            <span>{{ abbrSource }}</span>
+          </a-typography-link>
+          <a-typography-link class="component-meta-code" :href="issueNewUrl" target="_blank">
+            <BugOutlined class="component-meta-icon" />
+            <span>{{ locale.issueNew }}</span>
+          </a-typography-link>
+          <a-typography-link class="component-meta-code" :href="issueSearchUrl" target="_blank">
+            <IssuesCloseOutlined class="component-meta-icon" />
+            <span>
+              {{ locale.issueOpen }}
+              <LoadingOutlined v-if="loading" />
+              <template v-else-if="issueCount !== undefined">{{ issueCount }}</template>
+            </span>
+          </a-typography-link>
+        </a-flex>
+      </a-descriptions-item>
+
+      <a-descriptions-item :label="locale.docs">
+        <a-flex justify="flex-start" align="center" gap="small">
+          <a-typography-link class="component-meta-code" :href="editUrl" target="_blank">
+            <EditOutlined class="component-meta-icon" />
+            <span>{{ locale.edit }}</span>
+          </a-typography-link>
+          <a-typography-link class="component-meta-code" :href="llmsUrl" target="_blank" rel="noopener noreferrer">
+            <FileTextOutlined class="component-meta-icon" />
+            <span>LLMs.md</span>
+          </a-typography-link>
+          <router-link class="component-meta-code" :to="changelogUrl">
+            <HistoryOutlined class="component-meta-icon" />
+            <span>{{ locale.changelog }}</span>
+          </router-link>
+        </a-flex>
+      </a-descriptions-item>
+
+      <a-descriptions-item v-if="isVersion" :label="locale.version">
+        <a-typography-text class="component-meta-code">
+          {{ isZhCN ? `自 ${version} 起支持` : `supported since ${version}` }}
+        </a-typography-text>
+      </a-descriptions-item>
+    </a-descriptions>
+    <a-divider />
+  </template>
+</template>
+
+<style scoped>
+.component-meta :deep(.component-meta-code) {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  column-gap: var(--ant-padding-xxs);
+  border-radius: var(--ant-border-radius-sm);
+  padding-inline: var(--ant-padding-xxs);
+  transition: all var(--ant-motion-duration-slow);
+  font-family: var(--ant-font-family-code, monospace);
+  color: var(--ant-color-text-secondary);
+}
+.component-meta :deep(.component-meta-code:hover) {
+  background: var(--ant-control-item-bg-hover);
+}
+.component-meta :deep(a.component-meta-code:hover) {
+  text-decoration: underline;
+}
+.component-meta-icon {
+  margin-inline-end: 4px;
+}
+</style>

--- a/docs/src/components/docs/heading.vue
+++ b/docs/src/components/docs/heading.vue
@@ -17,6 +17,10 @@ const props = defineProps<{
 const pageInfo = usePageInfo()
 const frontmatter = computed(() => props?.frontmatter ?? pageInfo.frontmatter)
 
+// On component pages the edit link is already provided by <ComponentMeta> below,
+// so only show the title-level edit link on other doc pages.
+const showTitleEdit = computed(() => frontmatter.value?.category !== 'Components')
+
 const route = useRoute()
 const githubUrl = computed(() => {
   const path = route.path
@@ -33,7 +37,7 @@ const githubUrl = computed(() => {
     <a-space>
       <span>{{ frontmatter?.title }}</span>
       <span>{{ frontmatter?.subtitle }}</span>
-      <a-tooltip destroy-on-hidden title="在 GitHub 上编辑此页">
+      <a-tooltip v-if="showTitleEdit" destroy-on-hidden title="在 GitHub 上编辑此页">
         <a
           :href="githubUrl" class="relative top--2px inline-block decoration-none align-mid ml-xs"
           rel="noopener noreferrer" target="_blank"

--- a/docs/src/components/docs/heading.vue
+++ b/docs/src/components/docs/heading.vue
@@ -4,6 +4,7 @@ import { EditOutlined } from '@antdv-next/icons'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { usePageInfo } from '@/composables/doc-page.ts'
+import ComponentMeta from './component-meta.vue'
 
 defineOptions({
   name: 'DocHeading',
@@ -43,4 +44,5 @@ const githubUrl = computed(() => {
     </a-space>
   </a-typography-title>
   {{ frontmatter?.description }}
+  <ComponentMeta :frontmatter="frontmatter" />
 </template>

--- a/docs/src/components/docs/heading.vue
+++ b/docs/src/components/docs/heading.vue
@@ -17,9 +17,12 @@ const props = defineProps<{
 const pageInfo = usePageInfo()
 const frontmatter = computed(() => props?.frontmatter ?? pageInfo.frontmatter)
 
-// On component pages the edit link is already provided by <ComponentMeta> below,
-// so only show the title-level edit link on other doc pages.
-const showTitleEdit = computed(() => frontmatter.value?.category !== 'Components')
+// The edit link is provided by <ComponentMeta> only when it actually renders
+// (component pages with showImport !== false). Keep the title-level edit link
+// everywhere else — including `category: Components` pages that opt out via
+// `showImport: false` (e.g. the overview page).
+const showTitleEdit = computed(() =>
+  frontmatter.value?.category !== 'Components' || frontmatter.value?.showImport === false)
 
 const route = useRoute()
 const githubUrl = computed(() => {

--- a/docs/src/composables/use-issue-count.ts
+++ b/docs/src/composables/use-issue-count.ts
@@ -1,0 +1,67 @@
+import { computed, ref, watch } from 'vue'
+
+export interface UseIssueCountOptions {
+  repo: string
+  /** Reactive getter: whether the request should run. */
+  enabled?: () => boolean
+  /** Reactive getter: keywords matched against issue titles. */
+  titleKeywords?: () => string[]
+}
+
+/**
+ * Fetch the open-issue count for a component from the GitHub search API.
+ * Vue port of ant-design's `useIssueCount`.
+ */
+export function useIssueCount(options: UseIssueCountOptions) {
+  const { repo, enabled, titleKeywords } = options
+
+  const issueCount = ref<number | undefined>(undefined)
+  const loading = ref(false)
+
+  const keywords = computed(() => (titleKeywords?.() ?? []).filter(Boolean))
+
+  const searchUrl = computed(() => {
+    const tokens = keywords.value.map(k => encodeURIComponent(k))
+    const orExpr = tokens.length > 0 ? tokens.join('%20OR%20') : ''
+    const titlePart = orExpr ? `in:title+(${orExpr})` : 'in:title'
+    return `https://api.github.com/search/issues?q=repo:${repo}+is:issue+is:open+${titlePart}`
+  })
+
+  const issueNewUrl = `https://github.com/${repo}/issues/new/choose`
+
+  const issueSearchUrl = computed(() => {
+    const groupExpr = keywords.value.length > 0
+      ? `(${keywords.value.map(k => `is:issue in:title ${k}`).join(' OR ')})`
+      : ''
+    const qRaw = `is:open ${groupExpr}`.trim()
+    return `https://github.com/${repo}/issues?q=${encodeURIComponent(qRaw)}`
+  })
+
+  watch(
+    () => [enabled?.() ?? true, searchUrl.value] as const,
+    async ([isEnabled, url]) => {
+      if (typeof window === 'undefined' || !isEnabled) {
+        return
+      }
+      loading.value = true
+      try {
+        const res = await fetch(url, { headers: { Accept: 'application/vnd.github+json' } })
+        const data = await res.json()
+        issueCount.value = typeof data?.total_count === 'number' && !Number.isNaN(data.total_count)
+          ? data.total_count
+          : 0
+      }
+      catch {
+        issueCount.value = undefined
+      }
+      finally {
+        loading.value = false
+      }
+    },
+    { immediate: true },
+  )
+
+  return { issueCount, loading, issueNewUrl, issueSearchUrl }
+}
+
+export default useIssueCount

--- a/docs/src/composables/use-issue-count.ts
+++ b/docs/src/composables/use-issue-count.ts
@@ -46,10 +46,16 @@ export function useIssueCount(options: UseIssueCountOptions) {
       loading.value = true
       try {
         const res = await fetch(url, { headers: { Accept: 'application/vnd.github+json' } })
+        // On rate-limit (403) / validation (422) errors the body has no
+        // `total_count`; leave the count unset instead of showing a fake 0.
+        if (!res.ok) {
+          issueCount.value = undefined
+          return
+        }
         const data = await res.json()
         issueCount.value = typeof data?.total_count === 'number' && !Number.isNaN(data.total_count)
           ? data.total_count
-          : 0
+          : undefined
       }
       catch {
         issueCount.value = undefined


### PR DESCRIPTION
对齐 ant-design 组件文档页的「组件元信息」块（`ComponentMeta`），在每个组件页标题下方展示：

- **使用**：`import { X } from 'antdv-next'`，点击复制（tooltip 复制/已复制）
- **反馈**：源码链接（`packages/antdv-next/src/<slug>`）、提交问题、待解决 issue 数（GitHub search API）
- **文档**：编辑此页、LLMs.md（`/components/<slug>.md`）、更新日志（changelog 页）
- **版本**：frontmatter `tag` 为 semver 时显示「自 X 起支持」

实现：
- `docs/src/composables/use-issue-count.ts` —— ant-design `useIssueCount` 的 Vue 移植（fetch GitHub `search/issues` 读 `total_count`，SSR 安全）
- `docs/src/components/docs/component-meta.vue` —— `<a-descriptions>` 块，中英文随路由 `-cn` 切换，仅 `category: Components` 页显示
- 接入 `docs/src/components/docs/heading.vue`（标题+描述下方）

与 React 的差异：跳过「设计指南」（antdv 无设计规范站）；更新日志用全局 changelog 页（antdv 无 per-component changelog）。

docs 生产构建通过（`✓ built`）。