### PR TITLE
docs(icon): categorize new brand icons + mark them as 1.4.0

### DIFF
--- a/docs/src/components/icon-search/Category.vue
+++ b/docs/src/components/icon-search/Category.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   icons: string[]
   theme: ThemeType
   newIcons: string[]
+  newIconVersion?: string
 }>()
 
 const { message } = App.useApp()
@@ -46,6 +47,7 @@ const categoryTitle = computed(() => t(`ui.iconSearch.categories.${props.title}`
         :name="name"
         :theme="theme"
         :is-new="newIcons.includes(name)"
+        :new-icon-version="newIconVersion"
         :just-copied="justCopied"
         @copied="onCopied"
       />

--- a/docs/src/components/icon-search/CopyableIcon.vue
+++ b/docs/src/components/icon-search/CopyableIcon.vue
@@ -9,6 +9,7 @@ type ThemeType = 'Filled' | 'Outlined' | 'TwoTone'
 const props = defineProps<{
   name: string
   isNew: boolean
+  newIconVersion?: string
   theme: ThemeType
   justCopied: string | null
 }>()
@@ -65,11 +66,8 @@ async function handleClick() {
     @click="handleClick"
   >
     <component :is="iconComponent" />
-    <span class="anticon-cls">
-      <a-badge :dot="isNew">
-        {{ name }}
-      </a-badge>
-    </span>
+    <span class="anticon-cls">{{ name }}</span>
+    <span v-if="isNew && newIconVersion" class="new-icon-version">{{ newIconVersion }}</span>
   </li>
 </template>
 
@@ -153,5 +151,23 @@ async function handleClick() {
 
 .anticon-cls :deep(.ant-badge) {
   transition: color 0.3s ease-in-out;
+}
+
+.new-icon-version {
+  position: absolute;
+  top: 8px;
+  inset-inline-end: 8px;
+  padding: 0 6px;
+  font-size: 12px;
+  line-height: 18px;
+  color: #fff;
+  background-color: #1677ff;
+  border-radius: 9px;
+  pointer-events: none;
+}
+
+.icon-item:hover .new-icon-version {
+  background-color: #fff;
+  color: #1677ff;
 }
 </style>

--- a/docs/src/components/icon-search/IconSearch.vue
+++ b/docs/src/components/icon-search/IconSearch.vue
@@ -21,6 +21,43 @@ const { darkMode } = storeToRefs(useAppStore())
 const { t } = useLocale()
 const allIcons = AntdIcons as Record<string, any>
 
+// Icons newly added in this version; marked with a version tag in the list.
+const NEW_ICON_VERSION = '1.4.0'
+const NEW_ICON_NAMES: string[] = [
+  'AnthropicFilled',
+  'ClaudeFilled',
+  'GeminiFilled',
+  'MistralFilled',
+  'DeepSeekFilled',
+  'QwenFilled',
+  'PerplexityFilled',
+  'HuggingFaceFilled',
+  'OllamaFilled',
+  'ReplicateFilled',
+  'ElevenLabsFilled',
+  'TelegramFilled',
+  'MastodonFilled',
+  'ThreadsFilled',
+  'SnapchatFilled',
+]
+const NEW_ICON_ORDER = new Map(NEW_ICON_NAMES.map((name, index) => [name, index]))
+
+function groupNewIcons(icons: string[]) {
+  const firstNewIconIndex = icons.findIndex(iconName => NEW_ICON_ORDER.has(iconName))
+  if (firstNewIconIndex === -1) {
+    return icons
+  }
+  const newIcons = icons
+    .filter(iconName => NEW_ICON_ORDER.has(iconName))
+    .sort((a, b) => (NEW_ICON_ORDER.get(a) ?? 0) - (NEW_ICON_ORDER.get(b) ?? 0))
+  const restIcons = icons.filter(iconName => !NEW_ICON_ORDER.has(iconName))
+  return [
+    ...restIcons.slice(0, firstNewIconIndex),
+    ...newIcons,
+    ...restIcons.slice(firstNewIconIndex),
+  ]
+}
+
 const theme = ref<ThemeType>('Outlined')
 const searchKey = ref('')
 const searchBarAffixed = ref(false)
@@ -128,9 +165,11 @@ const matchedCategories = computed(() => {
   const merged = mergeCategory(namedMatchedCategoryObj, tagMatchedCategoryObj)
   const result = Object.values(merged)
     .map((item) => {
-      item.icons = item.icons
+      const icons = item.icons
         .map(iconName => iconName + theme.value)
         .filter(iconName => allIcons[iconName])
+      // Surface the newly added icons at the top of the brand group.
+      item.icons = item.category === 'logo' ? groupNewIcons(icons) : icons
       return item
     })
     .filter(({ icons }) => !!icons.length)
@@ -190,7 +229,8 @@ function onChangeSearchKey() {
           :title="item.category as CategoriesKeys"
           :theme="theme"
           :icons="item.icons"
-          :new-icons="[]"
+          :new-icons="NEW_ICON_NAMES"
+          :new-icon-version="NEW_ICON_VERSION"
         />
       </template>
       <a-empty v-else style="margin: 2em 0" />

--- a/docs/src/components/icon-search/IconSearch.vue
+++ b/docs/src/components/icon-search/IconSearch.vue
@@ -43,19 +43,15 @@ const NEW_ICON_NAMES: string[] = [
 const NEW_ICON_ORDER = new Map(NEW_ICON_NAMES.map((name, index) => [name, index]))
 
 function groupNewIcons(icons: string[]) {
-  const firstNewIconIndex = icons.findIndex(iconName => NEW_ICON_ORDER.has(iconName))
-  if (firstNewIconIndex === -1) {
-    return icons
-  }
   const newIcons = icons
     .filter(iconName => NEW_ICON_ORDER.has(iconName))
     .sort((a, b) => (NEW_ICON_ORDER.get(a) ?? 0) - (NEW_ICON_ORDER.get(b) ?? 0))
+  if (!newIcons.length) {
+    return icons
+  }
+  // Surface the newly added (1.4.0-badged) icons at the top of the brand group.
   const restIcons = icons.filter(iconName => !NEW_ICON_ORDER.has(iconName))
-  return [
-    ...restIcons.slice(0, firstNewIconIndex),
-    ...newIcons,
-    ...restIcons.slice(firstNewIconIndex),
-  ]
+  return [...newIcons, ...restIcons]
 }
 
 const theme = ref<ThemeType>('Outlined')

--- a/docs/src/components/icon-search/field.ts
+++ b/docs/src/components/icon-search/field.ts
@@ -221,6 +221,22 @@ const logo = [
   'Docker',
   'Baidu',
   'HarmonyOS',
+  // AI / brand icons added in 1.4.0
+  'Anthropic',
+  'Claude',
+  'Gemini',
+  'Mistral',
+  'DeepSeek',
+  'Qwen',
+  'Perplexity',
+  'HuggingFace',
+  'Ollama',
+  'Replicate',
+  'ElevenLabs',
+  'Telegram',
+  'Mastodon',
+  'Threads',
+  'Snapchat',
 ]
 
 const datum = [...direction, ...suggestion, ...editor, ...data, ...logo]


### PR DESCRIPTION
## 问题
图标列表页在 **Filled** 分类下新增的 AI/品牌图标「只显示出来几个」。

**根因**：新增的 AI/品牌图标（Anthropic/Claude/Gemini/DeepSeek/Mistral/Qwen/… ，只有 Filled 变体）没有被加进 `field.ts` 的 `logo`（品牌）分类，于是全部掉进 `other` 兜底桶，在「品牌」区域看不到它们，观感上像是「缺失/只有几个」。

## 修复（对齐 ant-design 的 IconSearch）
1. **`field.ts`**：把新增 AI/品牌图标补进 `logo` 分类，使其归入「品牌」区展示。
2. **`IconSearch.vue`**：新增 `NEW_ICON_NAMES` + `NEW_ICON_VERSION = '1.4.0'`，并用 `groupNewIcons` 将新图标排到品牌分类最前（与 React 一致）。
3. **`Category.vue` / `CopyableIcon.vue`**：透传 `newIconVersion`，对新图标显示 **`1.4.0` 版本角标**（此前只有一个红点，且 `:new-icons` 恒为空）。

学习 ant-design：React 侧用 `NEW_ICON_NAMES` + `NEW_ICON_VERSION='6.5.0'` 标注新图标；本仓对应版本为 **1.4.0**。

## 验证
- `eslint` 干净。
- docs 生产构建 `✓ built`（exit 0）。