### PR TITLE
fix(deps): bump @v-c/util to ^1.0.21 to fix Select dropdown misalign in Space.Compact (vue 3.5.39)

### DIFF
--- a/packages/antdv-next/src/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/packages/antdv-next/src/date-picker/generatePicker/generateSinglePicker.tsx
@@ -273,7 +273,7 @@ function generatePicker<DateType extends AnyObject = AnyObject>(generateConfig: 
         expose({
           focus: (options?: FocusOptions) => innerRef.value?.focus?.(options),
           blur: () => innerRef.value?.blur?.(),
-          nativeElement: computed(() => () => innerRef.value?.nativeElement),
+          nativeElement: computed(() => innerRef.value?.nativeElement),
         })
 
         return () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,7 +437,7 @@ overrides:
   '@v-c/portal': ^1.0.8
   '@v-c/resize-observer': ^1.1.3
   '@v-c/trigger': ^1.0.18
-  '@v-c/util': ^1.0.20
+  '@v-c/util': ^1.0.21
   vite: ^8.1.3
 
 importers:
@@ -488,8 +488,8 @@ importers:
         specifier: ^1.0.18
         version: 1.0.18(vue@3.5.39(typescript@5.9.3))
       '@v-c/util':
-        specifier: ^1.0.20
-        version: 1.0.20(vue@3.5.39(typescript@5.9.3))
+        specifier: ^1.0.21
+        version: 1.0.21(vue@3.5.39(typescript@5.9.3))
       '@vitejs/plugin-vue':
         specifier: catalog:dev
         version: 6.0.7(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
@@ -906,8 +906,8 @@ importers:
         specifier: catalog:vc
         version: 1.0.0(vue@3.5.39(typescript@5.9.3))
       '@v-c/util':
-        specifier: ^1.0.20
-        version: 1.0.20(vue@3.5.39(typescript@5.9.3))
+        specifier: ^1.0.21
+        version: 1.0.21(vue@3.5.39(typescript@5.9.3))
       '@v-c/virtual-list':
         specifier: catalog:vc
         version: 1.0.9(vue@3.5.39(typescript@5.9.3))
@@ -946,8 +946,8 @@ importers:
         specifier: catalog:prod
         version: 0.7.5
       '@v-c/util':
-        specifier: ^1.0.20
-        version: 1.0.20(vue@3.5.39(typescript@5.9.3))
+        specifier: ^1.0.21
+        version: 1.0.21(vue@3.5.39(typescript@5.9.3))
       csstype:
         specifier: catalog:prod
         version: 3.2.3
@@ -3075,8 +3075,8 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/util@1.0.20':
-    resolution: {integrity: sha512-IFsS520e1WaJXnZn6l0a+/lxa4CogOyg2heBBcAQSreIqIbPUzwSPes1123ScHCqAoBe8yAtZk3zHf5OVFBAGQ==}
+  '@v-c/util@1.0.21':
+    resolution: {integrity: sha512-OoWD9SHR9E4jHiP4YzQbYlpp4r9cCvR5QXEtLb8iO4xIc86/noR5f98m307kicULdte3MR4uK+O2sEoo5I2f0g==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -6526,7 +6526,7 @@ snapshots:
     dependencies:
       '@emotion/hash': 0.8.0
       '@emotion/unitless': 0.7.5
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       csstype: 3.2.3
       stylis: 4.4.0
       vue: 3.5.39(typescript@5.9.3)
@@ -6541,7 +6541,7 @@ snapshots:
     dependencies:
       '@ant-design/colors': 7.2.1
       '@ant-design/icons-svg': 4.5.0
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@antdv-next/unocss@1.1.1(unocss@66.7.4(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0)))':
@@ -8389,64 +8389,64 @@ snapshots:
     dependencies:
       '@v-c/select': 1.1.4(vue@3.5.39(typescript@5.9.3))
       '@v-c/tree': 1.1.1(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/checkbox@1.0.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/collapse@1.0.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/color-picker@1.0.6(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@ant-design/fast-color': 3.0.1
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/dialog@1.2.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/drawer@1.0.6(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/dropdown@1.0.3(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/image@1.0.12(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/input-number@1.0.5(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/input': 1.1.0(vue@3.5.39(typescript@5.9.3))
       '@v-c/mini-decimal': 1.0.1
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/input@1.1.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/input@1.1.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/mentions@1.1.1(vue@3.5.39(typescript@5.9.3))':
@@ -8455,14 +8455,14 @@ snapshots:
       '@v-c/menu': 1.2.2(vue@3.5.39(typescript@5.9.3))
       '@v-c/textarea': 1.1.0(vue@3.5.39(typescript@5.9.3))
       '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/menu@1.2.2(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.1.0(vue@3.5.39(typescript@5.9.3))
       '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/mini-decimal@1.0.1': {}
@@ -8470,23 +8470,23 @@ snapshots:
   '@v-c/mutate-observer@1.0.2(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/notification@2.0.2(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/overflow@1.1.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/pagination@1.0.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/picker@1.2.1(dayjs@1.11.21)(vue@3.5.39(typescript@5.9.3))':
@@ -8494,34 +8494,34 @@ snapshots:
       '@v-c/overflow': 1.1.0(vue@3.5.39(typescript@5.9.3))
       '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
       '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
     optionalDependencies:
       dayjs: 1.11.21
 
   '@v-c/portal@1.0.8(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/progress@1.0.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/qrcode@1.0.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/rate@1.0.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/resize-observer@1.1.3(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       resize-observer-polyfill: 1.5.1
       vue: 3.5.39(typescript@5.9.3)
 
@@ -8543,42 +8543,42 @@ snapshots:
 
   '@v-c/segmented@1.0.3(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/select@1.1.4(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.1.0(vue@3.5.39(typescript@5.9.3))
       '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.9(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/slick@1.0.2(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       es-toolkit: 1.49.0
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/slider@1.1.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/steps@1.0.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/switch@1.0.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/table@1.1.6(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.9(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
@@ -8588,39 +8588,39 @@ snapshots:
       '@v-c/menu': 1.2.2(vue@3.5.39(typescript@5.9.3))
       '@v-c/overflow': 1.1.0(vue@3.5.39(typescript@5.9.3))
       '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/textarea@1.1.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/input': 1.1.0(vue@3.5.39(typescript@5.9.3))
       '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/tooltip@1.0.4(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/tour@1.1.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.39(typescript@5.9.3))
       '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/tree-select@1.1.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/select': 1.1.4(vue@3.5.39(typescript@5.9.3))
       '@v-c/tree': 1.1.1(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/tree@1.1.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.9(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
@@ -8628,22 +8628,22 @@ snapshots:
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.39(typescript@5.9.3))
       '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/upload@1.0.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
-  '@v-c/util@1.0.20(vue@3.5.39(typescript@5.9.3))':
+  '@v-c/util@1.0.21(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/virtual-list@1.0.9(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@vitejs/plugin-vue-jsx@5.1.6(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))':
@@ -9019,7 +9019,7 @@ snapshots:
       '@v-c/tree-select': 1.1.1(vue@3.5.39(typescript@5.9.3))
       '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
       '@v-c/upload': 1.0.0(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.9(vue@3.5.39(typescript@5.9.3))
       '@vueuse/core': 14.3.0(vue@3.5.39(typescript@5.9.3))
       dayjs: 1.11.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -166,7 +166,7 @@ catalogs:
     '@v-c/tree-select': ^1.1.1
     '@v-c/trigger': ^1.0.18
     '@v-c/upload': ^1.0.0
-    '@v-c/util': ^1.0.20
+    '@v-c/util': ^1.0.21
     '@v-c/virtual-list': ^1.0.9
 
 onlyBuiltDependencies:


### PR DESCRIPTION
## 问题

在 `<a-space-compact>` 中组合 Select + Input 时，Select 第一次打开下拉框会出现横向错位（动画结束后被重对齐修正，表现为闪一下）。vue 3.5.38 正常，3.5.39 复现。

## 根因

- Select 传入带参的 `getPopupContainer`，Trigger 的 Popup 首次渲染时 `show=false` 返回 `null`，其 `$el` 是注释占位节点，位于 compact 行内 select 根元素之后。
- `@v-c/util` 的 `resolveToElement` 对注释 `$el` 走 `nextElementSibling` fallback，恰好取到 compact 行里相邻的 `ant-input`，`popupEle` 被指向了错误元素。
- vue 3.5.39 起 function ref 执行时暂停依赖追踪（vuejs/core#14985），ref 不再被响应式重调用，错误元素无法像 3.5.38 那样被自动纠正；`onPrepare` 因 `popupEle` 非空也不再兜底 seed。
- prepare 阶段对齐把 input 当 popup 计算 → 首帧 `left` 偏移 ~170px，测量 placeholder 还会插入 compact flex 行造成挤压。

只有 Space.Compact 能复现，是因为占位注释的 `nextElementSibling` 恰好是同父级相邻元素；普通布局下取到 `null` 会走正确的重试 + seed 路径。

## 修复

`@v-c/util@1.0.21`：当组件已暴露元素契约（`nativeElement` / `el` / `getElement`）但尚未兑现时，跳过相邻节点猜测，返回 `null` 交给 `createElementRef` 的 nextTick 重试与 `onPrepare` seed 处理。

本 PR 将 catalog 中 `@v-c/util` 升至 `^1.0.21` 并更新 lockfile（overrides 已保证全依赖树 dedupe 到单实例）。

## 验证

浏览器实测 docs 的 space compact demo（每 16ms 采样 dropdown `style.left`）：

| | 首帧位置 | 结果 |
|---|---|---|
| 修复前 | `left: 531.6px`（宽 472）持续 ~200ms 后跳回 `left: 360px` | ❌ 错位闪动 |
| 修复后 | `left: 360px`（宽 321）一帧到位，无中间错误帧 | ✅ |

multiple 与单选模式均验证；vue-components 侧 util/trigger/select 79 个单测全部通过。

Ref #623

## 附带修复：date-picker 暴露的 nativeElement 是函数

升级后 `tooltip.test.tsx > should works for date picker` 失败，暴露出主项目一个既有 bug：`generateSinglePicker` 的 expose 多写了一层箭头——

```diff
- nativeElement: computed(() => () => innerRef.value?.nativeElement)
+ nativeElement: computed(() => innerRef.value?.nativeElement)
```

解包后拿到的是函数而非 DOM 元素（`generateRangePicker` 同位置是对的）。之前一直被 `resolveToElement` 的 `nextElementSibling` fallback 掩盖；1.0.21 对声明了元素契约的组件不再猜测相邻节点，Tooltip 包裹 DatePicker 时 target 解析不出来导致气泡不显示。已修复，tooltip 51 个用例全过。

> date-picker `demo.test.tsx > renders external-panel correctly` 的快照失败为本地时区问题（不带本 PR 改动也失败），与本 PR 无关。
