### PR TITLE
sync: port ant-design 6.5.0..85a08c107d (4 fixes + 3 docs)

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React 主组件库 -> antdv-next 主包"
         }
       ],
-      "last_synced_commit": "61861c8bc3a443836b20336830f2ae30db518813",
-      "last_synced_commit_short": "61861c8bc3",
-      "last_synced_at": "2026-06-30T00:00:00Z",
+      "last_synced_commit": "85a08c107db7b29d8692e0106dd37550cbecf9aa",
+      "last_synced_commit_short": "85a08c107d",
+      "last_synced_at": "2026-07-03T00:00:00Z",
       "last_synced_tag": "6.5.0",
-      "sync_count": 15
+      "sync_count": 16
     },
     {
       "name": "cssinjs",

--- a/docs/src/pages/components/card/demo/button-alignment-debug.vue
+++ b/docs/src/pages/components/card/demo/button-alignment-debug.vue
@@ -1,0 +1,68 @@
+<docs lang="zh-CN">
+调试 Card extra 中按钮图标的垂直对齐（#57727、#57896、#58428）。
+</docs>
+
+<docs lang="en-US">
+Debug vertical alignment of button icons inside Card extra (#57727, #57896, #58428).
+</docs>
+
+<script setup lang="ts">
+import { SmileOutlined } from '@antdv-next/icons'
+import { Popconfirm } from 'antdv-next'
+import { h } from 'vue'
+
+const InternalPopconfirm = Popconfirm._InternalPanelDoNotUseOrYouWillBeFired
+
+const btnCls = {
+  icon: 'card-btn-debug-icon',
+  content: 'card-btn-debug-content',
+}
+</script>
+
+<template>
+  <a-config-provider :button="{ classes: btnCls }">
+    <a-flex vertical gap="middle">
+      <a-card class="line-card" title="#57727 Card extra">
+        <template #extra>
+          <a-button>
+            <template #icon>
+              <SmileOutlined />
+            </template>
+            Test
+          </a-button>
+        </template>
+        Button in Card extra should be vertically centered with the title.
+      </a-card>
+
+      <a-card title="#57896 regression minimum case">
+        <div class="simulate-57896">
+          <div class="inline-buttons">
+            <a-button>Cancel</a-button>
+            <a-button type="primary" :icon="() => h(SmileOutlined)">
+              Confirm
+            </a-button>
+          </div>
+        </div>
+      </a-card>
+
+      <InternalPopconfirm
+        title="Are you OK?"
+        :ok-button-props="{ icon: () => h(SmileOutlined) }"
+      />
+    </a-flex>
+  </a-config-provider>
+</template>
+
+<style>
+.card-btn-debug-icon {
+  background: rgba(255, 0, 0, 0.1);
+}
+
+.card-btn-debug-icon span {
+  background: rgba(0, 255, 0, 0.5);
+}
+
+.card-btn-debug-content {
+  background: rgba(0, 0, 255, 0.1);
+}
+</style>

--- a/docs/src/pages/components/card/index.en-US.md
+++ b/docs/src/pages/components/card/index.en-US.md
@@ -26,6 +26,7 @@ A card can be used to display content related to a single subject. The content c
   <demo src="./demo/meta.vue">Support more content configuration</demo>
   <demo src="./demo/style-class.vue">Custom semantic dom styling</demo>
   <demo src="./demo/no-body-debug.vue" debug>Cover and actions without body</demo>
+  <demo src="./demo/button-alignment-debug.vue" debug>Debug button icon alignment in Card extra</demo>
 </demo-group>
 
 ## API

--- a/docs/src/pages/components/card/index.zh-CN.md
+++ b/docs/src/pages/components/card/index.zh-CN.md
@@ -27,6 +27,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*5WDvQp_H7LUAAA
   <demo src="./demo/meta.vue">支持更多内容配置</demo>
   <demo src="./demo/style-class.vue">自定义语义结构的样式和类</demo>
   <demo src="./demo/no-body-debug.vue" debug>封面和操作区不渲染 body</demo>
+  <demo src="./demo/button-alignment-debug.vue" debug>调试 Card extra 中按钮图标对齐</demo>
 </demo-group>
 
 ## API

--- a/docs/src/pages/components/notification/index.en-US.md
+++ b/docs/src/pages/components/notification/index.en-US.md
@@ -186,3 +186,27 @@ Then `notification.open`, `notification.success` and other static methods will r
 ### How to set static methods prefixCls? {#faq-set-prefix-cls}
 
 You can config with [`ConfigProvider.config`](/components/config-provider#configproviderconfig-4130).
+
+### Why doesn't `style="width: max-content"` work on Notification? {#faq-notification-width}
+
+Notification uses a fixed-width layout so the stacked card style can stay consistent. Because of this, intrinsic widths such as `max-content`, `min-content`, and `fit-content(...)` are not supported on the outer notification node.
+
+If you need to customize the notification width, use the component token `width`:
+
+```vue
+<template>
+  <a-config-provider
+    :theme="{
+      components: {
+        Notification: {
+          width: 480,
+        },
+      },
+    }"
+  >
+    <a-app />
+  </a-config-provider>
+</template>
+```
+
+If you only need the content to size itself, render your own node in `title` or `description`, and apply `max-content` to the inner node instead of the notification root.

--- a/docs/src/pages/components/notification/index.zh-CN.md
+++ b/docs/src/pages/components/notification/index.zh-CN.md
@@ -187,3 +187,27 @@ ConfigProvider.config({
 ### 静态方法如何设置 prefixCls？ {#faq-set-prefix-cls}
 
 你可以通过 [`ConfigProvider.config`](/components/config-provider-cn#configproviderconfig-4130) 进行设置。
+
+### 为什么 `style="width: max-content"` 在 Notification 上不生效？ {#faq-notification-width}
+
+Notification 使用固定宽度布局，以保证堆叠卡片样式的一致性。因此不支持在通知外层节点上使用 `max-content`、`min-content`、`fit-content(...)` 这类 intrinsic width。
+
+如果你需要调整 Notification 的整体宽度，建议通过组件 token `width` 来配置：
+
+```vue
+<template>
+  <a-config-provider
+    :theme="{
+      components: {
+        Notification: {
+          width: 480,
+        },
+      },
+    }"
+  >
+    <a-app />
+  </a-config-provider>
+</template>
+```
+
+如果只需要内容自适应宽度，请在 `title` 或 `description` 中渲染自定义节点，并将 `max-content` 应用到内部节点，而不是通知的根节点上。

--- a/docs/src/pages/components/table/demo/auto-height.vue
+++ b/docs/src/pages/components/table/demo/auto-height.vue
@@ -1,0 +1,161 @@
+<docs lang="zh-CN">
+通过封装，实现 Table 始终自动填充容器高度。
+</docs>
+
+<docs lang="en-US">
+Wrap Table to make it always fill the container height automatically.
+</docs>
+
+<script setup lang="ts">
+import type { TableProps } from 'antdv-next'
+import { Table } from 'antdv-next'
+import { defineComponent, h, onBeforeUnmount, onMounted, ref, shallowRef } from 'vue'
+
+// ===================== Wrapper =====================
+const measureClasses = {
+  header: 'measure-header',
+  pagination: 'measure-pagination',
+}
+
+const tableClasses = {
+  header: {
+    wrapper: measureClasses.header,
+  },
+  pagination: {
+    root: measureClasses.pagination,
+  },
+}
+
+const AutoHeightTable = defineComponent<TableProps>(
+  (props, { attrs }) => {
+    const rootRef = shallowRef<InstanceType<typeof Table>>()
+    const scrollY = ref(0)
+    const sectionHeight = ref(0)
+
+    const getHeight = (target: string | HTMLElement) => {
+      const ele = typeof target === 'string'
+        ? rootRef.value?.nativeElement?.querySelector<HTMLElement>(`.${target}`)
+        : target
+
+      if (ele) {
+        const styles = getComputedStyle(ele)
+        const marginTop = Number.parseFloat(styles.marginTop) || 0
+        const marginBottom = Number.parseFloat(styles.marginBottom) || 0
+
+        return ele.getBoundingClientRect().height + marginTop + marginBottom
+      }
+
+      return 0
+    }
+
+    let resizeObserver: ResizeObserver | undefined
+
+    onMounted(() => {
+      const element = rootRef.value?.nativeElement
+      if (!element)
+        return
+
+      const measure = () => {
+        const totalHeight = getHeight(element)
+        const headerHeight = getHeight(measureClasses.header)
+        const paginationHeight = getHeight(measureClasses.pagination)
+
+        scrollY.value = Math.max(0, Math.floor(totalHeight - headerHeight - paginationHeight))
+        sectionHeight.value = totalHeight - paginationHeight
+      }
+
+      measure()
+
+      resizeObserver = new ResizeObserver(measure)
+      resizeObserver.observe(element)
+    })
+
+    onBeforeUnmount(() => {
+      resizeObserver?.disconnect()
+    })
+
+    return () => {
+      const { scroll, ...restProps } = props
+      return h(Table, {
+        ...restProps,
+        ...attrs,
+        ref: rootRef,
+        scroll: { ...scroll, y: scrollY.value },
+        style: { height: '100%' },
+        styles: {
+          section: {
+            height: `${sectionHeight.value}px`,
+          },
+        },
+        classes: tableClasses,
+      })
+    }
+  },
+  {
+    name: 'AutoHeightTable',
+    props: ['columns', 'dataSource', 'scroll'] as any,
+  },
+)
+
+// ==================== Usage ====================
+
+interface DataType {
+  key: number
+  name: string
+  age: number
+  address: string
+}
+
+const columns: TableProps<DataType>['columns'] = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    width: '20%',
+  },
+  {
+    title: 'Age',
+    dataIndex: 'age',
+    width: '20%',
+  },
+  {
+    title: 'Address',
+    dataIndex: 'address',
+    width: '60%',
+  },
+]
+
+function genData(length: number): DataType[] {
+  return Array.from({ length }).map((_, index) => ({
+    key: index,
+    name: `Edward King ${index}`,
+    age: 32 + index,
+    address: `London, Park Lane no. ${index}`,
+  }))
+}
+
+const dataMore = genData(30)
+const dataLess = genData(2)
+
+const hasData = ref(true)
+</script>
+
+<template>
+  <a-flex vertical gap="middle" align="start">
+    <a-switch
+      v-model:checked="hasData"
+      checked-children="More Data"
+      un-checked-children="More Data"
+    />
+    <div
+      :style="{
+        height: '400px',
+        boxSizing: 'border-box',
+        background: 'rgba(140, 140, 140, 0.03)',
+        padding: '16px',
+        alignSelf: 'stretch',
+      }"
+    >
+      <AutoHeightTable :columns="columns" :data-source="hasData ? dataMore : dataLess" />
+    </div>
+  </a-flex>
+</template>

--- a/docs/src/pages/components/table/index.en-US.md
+++ b/docs/src/pages/components/table/index.en-US.md
@@ -345,3 +345,9 @@ Properties for row selection.
 <ComponentTokenTable component="Table" />
 
 See [Customize Theme](/docs/vue/customize-theme) to learn how to use Design Token.
+
+## FAQ
+
+### How should I troubleshoot Table performance issues? {#faq-table-performance}
+
+Vue DevTools may add extra overhead when profiling complex tables, especially with many rows or cells. If you notice obvious lag, please try disabling Vue DevTools or testing in a clean browser environment first. If the performance issue can still be reproduced in a normal runtime, feel free to provide a minimal reproduction so we can continue to investigate.

--- a/docs/src/pages/components/table/index.en-US.md
+++ b/docs/src/pages/components/table/index.en-US.md
@@ -67,6 +67,7 @@ const columns = [
   <demo src="./demo/size.vue">Size</demo>
   <demo src="./demo/sticky.vue">Sticky Header</demo>
   <demo src="./demo/fixed-header.vue">Fixed Header</demo>
+  <demo src="./demo/auto-height.vue">Auto Height</demo>
   <demo src="./demo/fixed-columns.vue">Fixed Columns</demo>
   <demo src="./demo/fixed-columns-header.vue">Fixed Columns & Header</demo>
   <demo src="./demo/fixed-gapped-columns.vue">Wide Fixed Columns</demo>

--- a/docs/src/pages/components/table/index.zh-CN.md
+++ b/docs/src/pages/components/table/index.zh-CN.md
@@ -68,6 +68,7 @@ const columns = [
   <demo src="./demo/size.vue">尺寸</demo>
   <demo src="./demo/sticky.vue">粘性表头</demo>
   <demo src="./demo/fixed-header.vue">固定表头</demo>
+  <demo src="./demo/auto-height.vue">自动高度</demo>
   <demo src="./demo/fixed-columns.vue">固定列</demo>
   <demo src="./demo/fixed-columns-header.vue">固定列与表头</demo>
   <demo src="./demo/fixed-gapped-columns.vue">超宽固定列</demo>

--- a/docs/src/pages/components/table/index.zh-CN.md
+++ b/docs/src/pages/components/table/index.zh-CN.md
@@ -348,3 +348,9 @@ const onHeaderRow: TableProps['onHeaderRow'] = (columns, index) => {
 <ComponentTokenTable component="Table" />
 
 查看 [定制主题](/docs/vue/customize-theme) 了解如何使用主题变量。
+
+## FAQ
+
+### 如何排查 Table 性能问题？ {#faq-table-performance}
+
+Vue DevTools 在分析复杂表格时可能带来额外开销，尤其是行列数量较多的场景。若你遇到明显卡顿，建议先关闭 Vue DevTools，或在干净的浏览器环境中重新测试。如果在正常运行环境下仍能稳定复现性能问题，欢迎提供最小复现以便我们继续排查。

--- a/packages/antdv-next/src/button/style/index.ts
+++ b/packages/antdv-next/src/button/style/index.ts
@@ -49,6 +49,27 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
       // https://github.com/ant-design/ant-design/issues/51380
       [`${componentCls}-icon > svg`]: resetIcon(),
 
+      // https://github.com/ant-design/ant-design/issues/57727
+      [`${componentCls}-icon`]: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+
+        [iconCls]: {
+          verticalAlign: 'middle',
+
+          // Baseline will align the first element.
+          // So the Button with SVG will make the baseline to be the bottom of the SVG.
+          // Let's use `:before` to add a space to make the baseline to be the center of the Button.
+          // https://github.com/ant-design/ant-design/issues/58428
+          '&:before': {
+            content: '"\\a0"',
+            display: 'inline-block',
+            width: 0,
+          },
+        },
+      },
+
       '> a': {
         color: 'currentColor',
       },

--- a/packages/antdv-next/src/card/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/card/tests/__snapshots__/demo.test.tsx.snap
@@ -1234,6 +1234,298 @@ exports[`card demo > renders border-less correctly 1`] = `
 </div>
 `;
 
+exports[`card demo > renders button-alignment-debug correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-flex css-var-root ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+  >
+    <div
+      class="ant-card ant-card-bordered line-card css-var-root"
+    >
+      <div
+        class="ant-card-head"
+      >
+        <div
+          class="ant-card-head-wrapper"
+        >
+          <div
+            class="ant-card-head-title"
+          >
+            #57727 Card extra
+          </div>
+          <div
+            class="ant-card-extra"
+          >
+            <button
+              class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+              type="button"
+            >
+              <span
+                class="ant-btn-icon card-btn-debug-icon"
+              >
+                <span
+                  aria-label="smile"
+                  class="anticon anticon-smile"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="smile"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <span
+                class="card-btn-debug-content"
+              >
+                 Test 
+              </span>
+              <!---->
+            </button>
+          </div>
+        </div>
+        <!---->
+      </div>
+      <!---->
+      <div
+        class="ant-card-body"
+      >
+         Button in Card extra should be vertically centered with the title. 
+      </div>
+      <!---->
+    </div>
+    <div
+      class="ant-card ant-card-bordered css-var-root"
+    >
+      <div
+        class="ant-card-head"
+      >
+        <div
+          class="ant-card-head-wrapper"
+        >
+          <div
+            class="ant-card-head-title"
+          >
+            #57896 regression minimum case
+          </div>
+          <!---->
+        </div>
+        <!---->
+      </div>
+      <!---->
+      <div
+        class="ant-card-body"
+      >
+        <div
+          class="simulate-57896"
+        >
+          <div
+            class="inline-buttons"
+          >
+            <button
+              class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+              type="button"
+            >
+              <transition-stub
+                appear="false"
+                class="card-btn-debug-icon"
+                css="true"
+                enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
+                enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
+                entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
+                leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+                leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
+                leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+                name="ant-btn-loading-icon-motion"
+                persisted="false"
+              >
+                <!---->
+              </transition-stub>
+              <span
+                class="card-btn-debug-content"
+              >
+                Cancel
+              </span>
+              <!---->
+            </button>
+            <button
+              class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+              type="button"
+            >
+              <span
+                class="ant-btn-icon card-btn-debug-icon"
+              >
+                <span
+                  aria-label="smile"
+                  class="anticon anticon-smile"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="smile"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <span
+                class="card-btn-debug-content"
+              >
+                 Confirm 
+              </span>
+              <!---->
+            </button>
+          </div>
+        </div>
+      </div>
+      <!---->
+    </div>
+    <div
+      class="ant-popover ant-popover-pure ant-popover-placement-top ant-popconfirm css-var-root css-var-root"
+    >
+      <div
+        class="ant-popover-arrow"
+      />
+      <div
+        class="ant-popover-container"
+        content="[object Object]"
+        hashid=""
+        placement="top"
+        role="tooltip"
+      >
+        <!---->
+        <div
+          class="ant-popover-content"
+        >
+          <div
+            class="ant-popconfirm-inner-content"
+          >
+            <div
+              class="ant-popconfirm-message"
+            >
+              <span
+                class="ant-popconfirm-message-icon"
+              >
+                <span
+                  aria-label="exclamation-circle"
+                  class="anticon anticon-exclamation-circle"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="exclamation-circle"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <div
+                class="ant-popconfirm-message-text"
+              >
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
+                <!---->
+              </div>
+            </div>
+            <div
+              class="ant-popconfirm-buttons"
+            >
+              <button
+                class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm"
+                type="button"
+              >
+                <transition-stub
+                  appear="false"
+                  class="card-btn-debug-icon"
+                  css="true"
+                  enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
+                  enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
+                  entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
+                  leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+                  leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
+                  leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+                  name="ant-btn-loading-icon-motion"
+                  persisted="false"
+                >
+                  <!---->
+                </transition-stub>
+                <span
+                  class="card-btn-debug-content"
+                >
+                  Cancel
+                </span>
+                <!---->
+              </button>
+              <button
+                class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
+                type="button"
+              >
+                <span
+                  class="ant-btn-icon card-btn-debug-icon"
+                >
+                  <span
+                    aria-label="smile"
+                    class="anticon anticon-smile"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="smile"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <span
+                  class="card-btn-debug-content"
+                >
+                  OK
+                </span>
+                <!---->
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`card demo > renders component-token correctly 1`] = `
 <div
   data-v-app=""

--- a/packages/antdv-next/src/config-provider/index.tsx
+++ b/packages/antdv-next/src/config-provider/index.tsx
@@ -251,7 +251,7 @@ const ProviderChildren = defineComponent<
     const layer = computed(() => styleContext.value.layer)
 
     // Icon Support
-    const memoIconContextValue = computed(() => ({ prefixCls: iconPrefixCls.value, csp: csp.value, layer: layer.value ? 'antd' : undefined, zeroRuntime: mergedTheme.value?.zeroRuntime }))
+    const memoIconContextValue = computed(() => ({ prefixCls: iconPrefixCls.value, csp: csp.value, layer: layer.value ? 'antd' : undefined, zeroRuntime: !!layer.value || mergedTheme.value?.zeroRuntime }))
 
     // ================================ Dynamic theme ================================
     const memoTheme = computed(() => {

--- a/packages/antdv-next/src/config-provider/tests/static.test.tsx
+++ b/packages/antdv-next/src/config-provider/tests/static.test.tsx
@@ -89,12 +89,20 @@ describe('config-provider static methods', () => {
 
     await waitFakeTimer(1, 5)
 
-    const iconStyles = Array.from(document.querySelectorAll('style'))
-      .filter(style => style.innerHTML.includes('.anticon'))
+    // https://github.com/ant-design/ant-design/pull/58559
+    // Layer mode forces zeroRuntime: the icon package must not inject (or
+    // rewrite) its global runtime style into `@layer antd` — demoting that
+    // shared style would break icons rendered outside the layered subtree.
+    const runtimeStyle = document.querySelector('style[vc-util-key="@ant-design-icons"]')
+    if (runtimeStyle) {
+      expect(runtimeStyle.innerHTML).not.toContain('@layer antd')
+    }
 
-    expect(iconStyles.length).toBeGreaterThan(0)
-    iconStyles.forEach((style) => {
-      expect(style.innerHTML).toContain('@layer antd')
-    })
+    // The layered icon reset is served by cssinjs instead.
+    expect(
+      Array.from(document.querySelectorAll('style')).some(
+        style => style.innerHTML.includes('@layer antd') && style.innerHTML.includes('.anticon'),
+      ),
+    ).toBeTruthy()
   })
 })

--- a/packages/antdv-next/src/config-provider/tests/zero-runtime.test.tsx
+++ b/packages/antdv-next/src/config-provider/tests/zero-runtime.test.tsx
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
 
+import { createCache, StyleProvider } from '@antdv-next/cssinjs'
 import { SmileOutlined } from '@antdv-next/icons'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h, nextTick } from 'vue'
@@ -44,6 +45,30 @@ describe('configProvider theme.zeroRuntime', () => {
     )
     await flush()
     expect(document.head.querySelector(ICON_STYLE_SELECTOR)).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  // https://github.com/ant-design/ant-design/pull/58559
+  it('does not rewrite icon runtime style when cssinjs layer is enabled', async () => {
+    const wrapper = mount(
+      () => h(
+        StyleProvider,
+        { layer: true, cache: createCache() },
+        { default: () => h(ConfigProvider, null, { default: () => h(SmileOutlined) }) },
+      ),
+      { attachTo: document.body },
+    )
+    await flush()
+    // Layer mode forces zeroRuntime so the icon package must not inject its
+    // own runtime style (which would live outside `@layer antd` and win the
+    // cascade over layered antd styles).
+    expect(document.head.querySelector(ICON_STYLE_SELECTOR)).toBeFalsy()
+    // The icon styles are served by cssinjs inside the antd layer instead.
+    expect(
+      Array.from(document.querySelectorAll('style')).some(
+        style => style.innerHTML.includes('@layer antd') && style.innerHTML.includes('.anticon'),
+      ),
+    ).toBeTruthy()
     wrapper.unmount()
   })
 })

--- a/packages/antdv-next/src/descriptions/style/index.ts
+++ b/packages/antdv-next/src/descriptions/style/index.ts
@@ -154,16 +154,14 @@ const genDescriptionStyles: GenerateStyle<DescriptionsToken, CSSObject> = (token
         fontSize: token.fontSize,
       },
       [`${componentCls}-view`]: {
-        // Use `min-width: 100%` together with `width: 0` instead of
-        // `width: 100%` so the view still fills its container in normal layout,
-        // but won't contribute an extreme intrinsic width when nested inside a
-        // `max-content` sized ancestor (e.g. Table with
-        // `scroll={{ x: 'max-content' }}`). See antd #54268.
-        width: 0,
-        minWidth: '100%',
+        // antd #54268 used `width: 0` with `min-width: 100%` to avoid oversized
+        // intrinsic widths in max-content ancestors. Keep the wrapper at
+        // `width: 100%` so it remains measurable in shrink-to-fit containers
+        // like Popover (antd #58574), while the inner table preserves the minimum.
+        width: '100%',
         borderRadius: token.borderRadiusLG,
         table: {
-          width: '100%',
+          minWidth: '100%',
           tableLayout: 'fixed',
           borderCollapse: 'collapse',
         },

--- a/packages/antdv-next/src/descriptions/tests/style-extract.test.tsx
+++ b/packages/antdv-next/src/descriptions/tests/style-extract.test.tsx
@@ -1,0 +1,42 @@
+import { createCache, extractStyle, StyleProvider } from '@antdv-next/cssinjs'
+import { describe, expect, it } from 'vitest'
+import { createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import Descriptions from '..'
+import ConfigProvider from '../../config-provider'
+
+async function extractDescriptionsStyle() {
+  const cache = createCache()
+  const app = createSSRApp({
+    render: () =>
+      h(ConfigProvider, { theme: { hashed: false } }, {
+        default: () =>
+          h(StyleProvider, { cache, mock: 'server' }, {
+            default: () => h(Descriptions, { items: [{ label: 'a', children: 'b' }] }),
+          }),
+      }),
+  })
+
+  await renderToString(app)
+
+  return extractStyle(cache, { plain: true, types: 'style' })
+}
+
+describe('descriptions style extract', () => {
+  // antd #58583: `-view` keeps `width: 100%` so it stays measurable in
+  // shrink-to-fit containers (Popover, antd #58574), while the inner table
+  // carries `min-width: 100%` to avoid oversized intrinsic widths inside
+  // max-content ancestors (antd #54268).
+  it('keeps view measurable while table preserves the minimum width', async () => {
+    const styleText = await extractDescriptionsStyle()
+
+    const viewRules = styleText.match(/\.ant-descriptions-view\{[^}]*\}/g) ?? []
+    expect(viewRules.length).toBeGreaterThan(0)
+    expect(viewRules.some(rule => rule.includes('width:100%'))).toBeTruthy()
+    expect(viewRules.some(rule => rule.includes('width:0'))).toBeFalsy()
+
+    const tableRules = styleText.match(/\.ant-descriptions-view table\{[^}]*\}/g) ?? []
+    expect(tableRules.length).toBeGreaterThan(0)
+    expect(tableRules.some(rule => rule.includes('min-width:100%'))).toBeTruthy()
+  })
+})

--- a/packages/antdv-next/src/locale/ar_EG.ts
+++ b/packages/antdv-next/src/locale/ar_EG.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'يرجى التحديد',
     close: 'إغلاق',
+    sortable: 'قابل للفرز',
   },
   Table: {
     filterTitle: 'الفلاتر',
@@ -30,6 +31,11 @@ const localeValues: Locale = {
     triggerDesc: 'ترتيب تنازلي',
     triggerAsc: 'ترتيب تصاعدي',
     cancelSort: 'إلغاء الترتيب',
+    filterEmptyText: 'لا مرشحات',
+    filterCheckAll: 'حدد كافة العناصر',
+    filterSearchPlaceholder: 'البحث في المرشحات',
+    emptyText: 'لا توجد بيانات',
+    selectNone: 'مسح كافة البيانات',
   },
   Tour: {
     Next: 'التالي',
@@ -50,6 +56,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'ابحث هنا',
     itemUnit: 'عنصر',
     itemsUnit: 'عناصر',
+    remove: 'إزالة',
+    selectAll: 'حدد كافة البيانات',
+    deselectAll: 'إلغاء تحديد كافة البيانات',
+    selectCurrent: 'حدد الصفحة الحالية',
+    selectInvert: 'عكس الصفحة الحالية',
+    removeAll: 'إزالة كافة البيانات',
+    removeCurrent: 'إزالة الصفحة الحالية',
   },
   Upload: {
     uploading: 'جاري الرفع...',
@@ -69,6 +82,7 @@ const localeValues: Locale = {
     copy: 'نسخ',
     copied: 'نقل',
     expand: 'وسع',
+    collapse: 'طي',
   },
   Form: {
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/az_AZ.ts
+++ b/packages/antdv-next/src/locale/az_AZ.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Zəhmət olmasa seçin',
     close: 'Bağla',
+    sortable: 'çeşidlənən',
   },
   Table: {
     filterTitle: 'Filter menyu',

--- a/packages/antdv-next/src/locale/bg_BG.ts
+++ b/packages/antdv-next/src/locale/bg_BG.ts
@@ -15,6 +15,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Затвори',
+    placeholder: 'Моля изберете',
+    sortable: 'сортируеми',
   },
   Table: {
     filterTitle: 'Филтриране',
@@ -22,6 +24,18 @@ const localeValues: Locale = {
     filterReset: 'Нулриане',
     selectAll: 'Избор на текуща страница',
     selectInvert: 'Обръщане',
+    filterEmptyText: 'Без филтри',
+    filterCheckAll: 'Изберете всички елементи',
+    filterSearchPlaceholder: 'Търсене във филтри',
+    emptyText: 'Няма данни',
+    selectNone: 'Изчистване на всички данни',
+    selectionAll: 'Изберете всички данни',
+    sortTitle: 'Сортиране',
+    expand: 'Разширяване на реда',
+    collapse: 'Свиване на ред',
+    triggerDesc: 'Кликнете, за да сортирате в низходящ ред',
+    triggerAsc: 'Кликнете, за да сортирате във възходящ ред',
+    cancelSort: 'Кликнете, за да отмените сортирането',
   },
   Tour: {
     Next: 'Следващ',
@@ -42,6 +56,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Търсене',
     itemUnit: 'избор',
     itemsUnit: 'избори',
+    remove: 'Премахнете',
+    selectAll: 'Изберете всички данни',
+    deselectAll: 'Демаркирайте всички данни',
+    selectCurrent: 'Изберете текущата страница',
+    selectInvert: 'Обърнете текущата страница',
+    removeAll: 'Премахнете всички данни',
+    removeCurrent: 'Премахване на текущата страница',
   },
   Upload: {
     uploading: 'Качване...',
@@ -102,6 +123,24 @@ const localeValues: Locale = {
         mismatch: '${label} не отговаря на модела ${pattern}',
       },
     },
+  },
+  Text: {
+    edit: 'Редактиране',
+    copy: 'копие',
+    copied: 'Копирано',
+    expand: 'Разширяване',
+    collapse: 'Свиване',
+  },
+  QRCode: {
+    expired: 'QR кодът е изтекъл',
+    refresh: 'Опресняване',
+    scanned: 'Сканирани',
+  },
+  ColorPicker: {
+    presetEmpty: 'празна',
+    transparent: 'Прозрачен',
+    singleColor: 'Едноцветен',
+    gradientColor: 'Преливащ цвят',
   },
 }
 

--- a/packages/antdv-next/src/locale/bn_BD.ts
+++ b/packages/antdv-next/src/locale/bn_BD.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'অনুগ্রহ করে নির্বাচন করুন',
     close: 'বন্ধ',
+    sortable: 'বাছাইযোগ্য',
   },
   Table: {
     filterTitle: 'ফিল্টার মেনু',
@@ -33,6 +34,8 @@ const localeValues: Locale = {
     triggerDesc: 'অবতরণকে সাজানোর জন্য ক্লিক করুন',
     triggerAsc: 'আরোহী বাছাই করতে ক্লিক করুন',
     cancelSort: 'বাছাই বাতিল করতে ক্লিক করুন',
+    filterCheckAll: 'সব আইটেম নির্বাচন করুন',
+    filterSearchPlaceholder: 'ফিল্টারে অনুসন্ধান করুন',
   },
   Tour: {
     Next: 'পরবর্তী',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'সমস্ত ডেটা নির্বাচন করুন',
     removeAll: 'সমস্ত ডেটা সরান',
     selectInvert: 'বর্তমান পৃষ্ঠাটি উল্টে দিন',
+    deselectAll: 'সমস্ত ডেটা অনির্বাচন করুন',
   },
   Upload: {
     uploading: 'আপলোড হচ্ছে ...',
@@ -78,6 +82,7 @@ const localeValues: Locale = {
     copy: 'অনুলিপি',
     copied: 'অনুলিপি হয়েছে',
     expand: 'বিস্তৃত করা',
+    collapse: 'সঙ্কুচিত',
   },
   Form: {
     optional: '(ঐচ্ছিক)',
@@ -128,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} এই ${pattern} প্যাটার্নের সাথে মেলে না',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR কোডের মেয়াদ শেষ',
+    refresh: 'রিফ্রেশ',
+    scanned: 'স্ক্যান করা হয়েছে',
+  },
+  ColorPicker: {
+    presetEmpty: 'খালি',
+    transparent: 'স্বচ্ছ',
+    singleColor: 'একক রঙ',
+    gradientColor: 'গ্রেডিয়েন্ট রঙ',
   },
 }
 

--- a/packages/antdv-next/src/locale/by_BY.ts
+++ b/packages/antdv-next/src/locale/by_BY.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Калі ласка, выберыце',
     close: 'Закрыць',
+    sortable: 'сартавальны',
   },
   Table: {
     filterTitle: 'Фільтр',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Выбраць усе даныя',
     removeAll: 'Выдаліць усе даныя',
     selectInvert: 'Паказаць у адваротным парадку',
+    deselectAll: 'Адмяніце выбар усіх даных',
   },
   Upload: {
     uploading: 'Запампоўка...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Капіяваць',
     copied: 'Капіяванне завершана',
     expand: 'Разгарнуць',
+    collapse: 'Згарнуць',
   },
   Form: {
     optional: '(не абавязкова)',
@@ -130,6 +133,17 @@ const localeValues: Locale = {
         mismatch: 'Значэнне поля «${label}» не адпавядае шаблону ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'Тэрмін дзеяння QR-кода скончыўся',
+    refresh: 'Абнавіць',
+    scanned: 'Адсканаваныя',
+  },
+  ColorPicker: {
+    presetEmpty: 'Пусты',
+    transparent: 'Празрысты',
+    singleColor: 'Аднакаляровы',
+    gradientColor: 'Градыент колеру',
   },
 }
 

--- a/packages/antdv-next/src/locale/ca_ES.ts
+++ b/packages/antdv-next/src/locale/ca_ES.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Seleccionar',
     close: 'Tancar',
+    sortable: 'ordenable',
   },
   Table: {
     filterTitle: 'Filtrar el menú',
@@ -31,6 +32,10 @@ const localeValues: Locale = {
     triggerDesc: 'Ordre descendent',
     triggerAsc: 'Ordre ascendent',
     cancelSort: 'Desactivar l’ordre',
+    filterCheckAll: 'Seleccioneu tots els elements',
+    filterSearchPlaceholder: 'Cerca en filtres',
+    emptyText: 'Sense dades',
+    selectNone: 'Esborra totes les dades',
   },
   Tour: {
     Next: 'Següent',
@@ -57,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Seleccionar-ho tot',
     removeAll: 'Eliminar-ho tot',
     selectInvert: 'Invertir la selecció',
+    deselectAll: 'Desseleccioneu totes les dades',
   },
   Upload: {
     uploading: 'Carregant…',
@@ -76,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Copiar',
     copied: 'Copiat',
     expand: 'Ampliar',
+    collapse: 'Col·lapse',
   },
   Form: {
     optional: '(opcional)',
@@ -126,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} no coincideix amb el patró ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'El codi QR ha caducat',
+    refresh: 'Actualitza',
+    scanned: 'Escanejat',
+  },
+  ColorPicker: {
+    presetEmpty: 'Buit',
+    transparent: 'Transparent',
+    singleColor: 'Un sol',
+    gradientColor: 'Color degradat',
   },
 }
 

--- a/packages/antdv-next/src/locale/cs_CZ.ts
+++ b/packages/antdv-next/src/locale/cs_CZ.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Prosím vyber',
     close: 'Zavřít',
+    sortable: 'seřadit',
   },
   Table: {
     filterTitle: 'Filtr',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Označit vše',
     removeAll: 'Odznačit vše',
     selectInvert: 'Opačný výběr',
+    deselectAll: 'Zrušte výběr všech dat',
   },
   Upload: {
     uploading: 'Nahrávání...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Kopírovat',
     copied: 'Zkopírované',
     expand: 'Zvětšit',
+    collapse: 'kolaps',
   },
   Form: {
     optional: '(nepovinné)',

--- a/packages/antdv-next/src/locale/da_DK.ts
+++ b/packages/antdv-next/src/locale/da_DK.ts
@@ -14,6 +14,8 @@ const localeValues: Locale = {
   Pagination,
   global: {
     close: 'Luk',
+    placeholder: 'Vælg venligst',
+    sortable: 'sorterbar',
   },
   Table: {
     filterTitle: 'Filtermenu',
@@ -31,6 +33,8 @@ const localeValues: Locale = {
     triggerDesc: 'Klik for at sortere faldende',
     triggerAsc: 'Klik for at sortere stigende',
     cancelSort: 'Klik for at annullere sortering',
+    filterCheckAll: 'Vælg alle elementer',
+    filterSearchPlaceholder: 'Søg i filtre',
   },
   Tour: {
     Next: 'Næste',
@@ -51,6 +55,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Søg her',
     itemUnit: 'element',
     itemsUnit: 'elementer',
+    remove: 'Fjern',
+    selectAll: 'Vælg alle data',
+    deselectAll: 'Fravælg alle data',
+    selectCurrent: 'Vælg den aktuelle side',
+    selectInvert: 'Inverter den aktuelle side',
+    removeAll: 'Fjern alle data',
+    removeCurrent: 'Fjern den aktuelle side',
   },
   Upload: {
     uploading: 'Uploader...',
@@ -111,6 +122,24 @@ const localeValues: Locale = {
         mismatch: '${label} stemmer ikke overens med mønsteret ${pattern}',
       },
     },
+  },
+  Text: {
+    edit: 'Rediger',
+    copy: 'Kopiér',
+    copied: 'Kopieret',
+    expand: 'Udvid',
+    collapse: 'Kollaps',
+  },
+  QRCode: {
+    expired: 'QR-koden er udløbet',
+    refresh: 'Opdater',
+    scanned: 'Scannet',
+  },
+  ColorPicker: {
+    presetEmpty: 'Tom',
+    transparent: 'Gennemsigtig',
+    singleColor: 'Enkelt farve',
+    gradientColor: 'Gradient farve',
   },
 }
 

--- a/packages/antdv-next/src/locale/de_DE.ts
+++ b/packages/antdv-next/src/locale/de_DE.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Bitte auswählen',
     close: 'Schließen',
+    sortable: 'sortierbar',
   },
   Table: {
     filterTitle: 'Filter-Menü',
@@ -34,6 +35,7 @@ const localeValues: Locale = {
     triggerDesc: 'Klicken zur absteigenden Sortierung',
     triggerAsc: 'Klicken zur aufsteigenden Sortierung',
     cancelSort: 'Klicken zum Abbrechen der Sortierung',
+    selectNone: 'Alle Daten löschen',
   },
   Tour: {
     Next: 'Weiter',
@@ -77,6 +79,7 @@ const localeValues: Locale = {
     copy: 'Kopieren',
     copied: 'Kopiert',
     expand: 'Erweitern',
+    collapse: 'Zusammenbruch',
   },
   Form: {
     defaultValidateMessages: {
@@ -130,6 +133,13 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'QR-Code abgelaufen',
     refresh: 'Aktualisieren',
+    scanned: 'Gescannt',
+  },
+  ColorPicker: {
+    presetEmpty: 'Leer',
+    transparent: 'Transparent',
+    singleColor: 'Einfarbig',
+    gradientColor: 'Farbverlauf',
   },
 }
 

--- a/packages/antdv-next/src/locale/el_GR.ts
+++ b/packages/antdv-next/src/locale/el_GR.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Παρακαλώ επιλέξτε',
     close: 'Κλείσιμο',
+    sortable: 'διαλογήσιμος',
   },
   Table: {
     filterTitle: 'Μενού φίλτρων',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Επιλογή όλων των δεδομένων',
     removeAll: 'Αφαίρεση όλων των δεδομένων',
     selectInvert: 'Αντιστροφή τρέχουσας σελίδας',
+    deselectAll: 'Καταργήστε την επιλογή όλων των δεδομένων',
   },
   Upload: {
     uploading: 'Μεταφόρτωση...',

--- a/packages/antdv-next/src/locale/en_GB.ts
+++ b/packages/antdv-next/src/locale/en_GB.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Please select',
     close: 'Close',
+    sortable: 'sortable',
   },
   Table: {
     filterTitle: 'Filter menu',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Select all data',
     removeAll: 'Remove all data',
     selectInvert: 'Invert current page',
+    deselectAll: 'Deselect all data',
   },
   Upload: {
     uploading: 'Uploading...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Copy',
     copied: 'Copied',
     expand: 'Expand',
+    collapse: 'Collapse',
   },
   Form: {
     optional: '(optional)',

--- a/packages/antdv-next/src/locale/en_US.ts
+++ b/packages/antdv-next/src/locale/en_US.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Please select',
     close: 'Close',
+    sortable: 'sortable',
   },
   Table: {
     filterTitle: 'Filter menu',

--- a/packages/antdv-next/src/locale/es_ES.ts
+++ b/packages/antdv-next/src/locale/es_ES.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Seleccione',
     close: 'Cerrar',
+    sortable: 'ordenable',
   },
   Table: {
     filterTitle: 'Filtrar menú',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Seleccionar todos los datos',
     removeAll: 'Eliminar todos los datos',
     selectInvert: 'Invertir página actual',
+    deselectAll: 'Deseleccionar todos los datos',
   },
   Upload: {
     uploading: 'Subiendo...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Copiar',
     copied: 'Copiado',
     expand: 'Expandir',
+    collapse: 'Colapso',
   },
   Form: {
     optional: '(opcional)',
@@ -130,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} no coincide con el patrón ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'El código QR expiró',
+    refresh: 'Actualizar',
+    scanned: 'escaneado',
+  },
+  ColorPicker: {
+    presetEmpty: 'vacio',
+    transparent: 'Transparente',
+    singleColor: 'color único',
+    gradientColor: 'Color degradado',
   },
 }
 

--- a/packages/antdv-next/src/locale/et_EE.ts
+++ b/packages/antdv-next/src/locale/et_EE.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Palun vali',
     close: 'Sulge',
+    sortable: 'sorteeritav',
   },
   Table: {
     filterTitle: 'Filtri menüü',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Vali kõik',
     removeAll: 'Eemalda kõik andmed',
     selectInvert: 'Inverteeri valik',
+    deselectAll: 'Tühista kõik andmed',
   },
   Upload: {
     uploading: 'Üleslaadimine...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Kopeeri',
     copied: 'Kopeeritud',
     expand: 'Laienda',
+    collapse: 'Ahenda',
   },
   Form: {
     optional: '(valikuline)',
@@ -130,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} ei vasta mustrile ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR-kood aegus',
+    refresh: 'Värskenda',
+    scanned: 'Skaneeritud',
+  },
+  ColorPicker: {
+    presetEmpty: 'Tühi',
+    transparent: 'Läbipaistev',
+    singleColor: 'Ühevärviline',
+    gradientColor: 'Gradiendi värv',
   },
 }
 

--- a/packages/antdv-next/src/locale/eu_ES.ts
+++ b/packages/antdv-next/src/locale/eu_ES.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Aukeratu',
     close: 'Itxi',
+    sortable: 'ordenagarria',
   },
   Table: {
     filterTitle: 'Iragazi menua',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Datu guztiak hautatu',
     removeAll: 'Ezabatu datu guztiak',
     selectInvert: 'Uneko orrialdea alderantzikatu',
+    deselectAll: 'Deshautatu datu guztiak',
   },
   Upload: {
     uploading: 'Igotzen...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Kopiatu',
     copied: 'Kopiatuta',
     expand: 'Zabaldu',
+    collapse: 'Tolestu',
   },
   Form: {
     optional: '(aukerakoa)',
@@ -134,6 +137,7 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'QR kodea kadukatuta',
     refresh: 'Freskatu',
+    scanned: 'Eskaneatua',
   },
   ColorPicker: {
     presetEmpty: 'Hustu',

--- a/packages/antdv-next/src/locale/fa_IR.ts
+++ b/packages/antdv-next/src/locale/fa_IR.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'لطفاً انتخاب کنید',
     close: 'بستن',
+    sortable: 'قابل مرتب سازی',
   },
   Table: {
     filterTitle: 'منوی فیلتر',

--- a/packages/antdv-next/src/locale/fi_FI.ts
+++ b/packages/antdv-next/src/locale/fi_FI.ts
@@ -13,6 +13,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Sulje',
+    placeholder: 'Ole hyvä ja valitse',
+    sortable: 'lajiteltava',
   },
   Table: {
     filterTitle: 'Suodatus valikko',
@@ -24,6 +26,14 @@ const localeValues: Locale = {
     triggerDesc: 'Lajittele laskevasti',
     triggerAsc: 'Lajittele nousevasti',
     cancelSort: 'Peruuta lajittelu',
+    filterEmptyText: 'Ei suodattimia',
+    filterCheckAll: 'Valitse kaikki kohteet',
+    filterSearchPlaceholder: 'Hae suodattimista',
+    emptyText: 'Ei dataa',
+    selectNone: 'Tyhjennä kaikki tiedot',
+    selectionAll: 'Valitse kaikki tiedot',
+    expand: 'Laajenna riviä',
+    collapse: 'Tiivistä rivi',
   },
   Tour: {
     Next: 'Seuraava',
@@ -44,6 +54,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Etsi täältä',
     itemUnit: 'kohde',
     itemsUnit: 'kohdetta',
+    remove: 'Poista',
+    selectAll: 'Valitse kaikki tiedot',
+    deselectAll: 'Poista kaikkien tietojen valinnat',
+    selectCurrent: 'Valitse nykyinen sivu',
+    selectInvert: 'Kääntää nykyinen sivu',
+    removeAll: 'Poista kaikki tiedot',
+    removeCurrent: 'Poista nykyinen sivu',
   },
   Upload: {
     uploading: 'Lähetetään...',
@@ -60,6 +77,18 @@ const localeValues: Locale = {
     copy: 'Kopioi',
     copied: 'Kopioitu',
     expand: 'Näytä lisää',
+    collapse: 'Kutista',
+  },
+  QRCode: {
+    expired: 'QR-koodi vanhentunut',
+    refresh: 'Päivitä',
+    scanned: 'Skannattu',
+  },
+  ColorPicker: {
+    presetEmpty: 'Tyhjä',
+    transparent: 'Läpinäkyvä',
+    singleColor: 'Yksivärinen',
+    gradientColor: 'Gradienttiväri',
   },
 }
 

--- a/packages/antdv-next/src/locale/fr_BE.ts
+++ b/packages/antdv-next/src/locale/fr_BE.ts
@@ -15,6 +15,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Fermer',
+    placeholder: 'Veuillez sélectionner',
+    sortable: 'triable',
   },
   Table: {
     filterTitle: 'Filtrer',
@@ -60,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Sélectionner toutes les données',
     removeAll: 'Désélectionner toutes les données',
     selectInvert: 'Inverser la sélection de la page actuelle',
+    deselectAll: 'Désélectionner toutes les données',
   },
   Upload: {
     uploading: 'Téléchargement...',
@@ -79,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Copier',
     copied: 'Copie effectuée',
     expand: 'Développer',
+    collapse: 'Réduire',
   },
   Form: {
     optional: '(optionnel)',
@@ -129,6 +133,17 @@ const localeValues: Locale = {
         mismatch: 'La valeur du champ ${label} ne correspond pas au modèle ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'Code QR expiré',
+    refresh: 'Actualiser',
+    scanned: 'Numérisé',
+  },
+  ColorPicker: {
+    presetEmpty: 'Vide',
+    transparent: 'Transparente',
+    singleColor: 'Couleur unique',
+    gradientColor: 'Couleur dégradée',
   },
 }
 

--- a/packages/antdv-next/src/locale/fr_CA.ts
+++ b/packages/antdv-next/src/locale/fr_CA.ts
@@ -15,6 +15,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Fermer',
+    placeholder: 'Veuillez sélectionner',
+    sortable: 'triable',
   },
   Table: {
     filterTitle: 'Filtrer',
@@ -60,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Sélectionner toutes les données',
     removeAll: 'Désélectionner toutes les données',
     selectInvert: 'Inverser la sélection de la page actuelle',
+    deselectAll: 'Désélectionner toutes les données',
   },
   Upload: {
     uploading: 'Téléchargement...',
@@ -79,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Copier',
     copied: 'Copie effectuée',
     expand: 'Développer',
+    collapse: 'Réduire',
   },
   Form: {
     optional: '(optionnel)',
@@ -129,6 +133,17 @@ const localeValues: Locale = {
         mismatch: 'La valeur du champ ${label} ne correspond pas au modèle ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'Code QR expiré',
+    refresh: 'Actualiser',
+    scanned: 'Numérisé',
+  },
+  ColorPicker: {
+    presetEmpty: 'Vide',
+    transparent: 'Transparente',
+    singleColor: 'Couleur unique',
+    gradientColor: 'Couleur dégradée',
   },
 }
 

--- a/packages/antdv-next/src/locale/fr_FR.ts
+++ b/packages/antdv-next/src/locale/fr_FR.ts
@@ -15,6 +15,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Fermer',
+    placeholder: 'Veuillez sélectionner',
+    sortable: 'triable',
   },
   Table: {
     filterTitle: 'Filtrer',
@@ -60,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Sélectionner toutes les données',
     removeAll: 'Désélectionner toutes les données',
     selectInvert: 'Inverser la sélection de la page actuelle',
+    deselectAll: 'Désélectionner toutes les données',
   },
   Upload: {
     uploading: 'Téléchargement...',
@@ -79,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Copier',
     copied: 'Copie effectuée',
     expand: 'Développer',
+    collapse: 'Réduire',
   },
   Form: {
     optional: '(optionnel)',
@@ -129,6 +133,17 @@ const localeValues: Locale = {
         mismatch: 'La valeur du champ ${label} ne correspond pas au modèle ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'Code QR expiré',
+    refresh: 'Actualiser',
+    scanned: 'Numérisé',
+  },
+  ColorPicker: {
+    presetEmpty: 'Vide',
+    transparent: 'Transparente',
+    singleColor: 'Couleur unique',
+    gradientColor: 'Couleur dégradée',
   },
 }
 

--- a/packages/antdv-next/src/locale/ga_IE.ts
+++ b/packages/antdv-next/src/locale/ga_IE.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Please select',
     close: 'Dún',
+    sortable: 'insocraithe',
   },
   Table: {
     filterTitle: 'Filter menu',
@@ -30,6 +31,11 @@ const localeValues: Locale = {
     triggerDesc: 'Click to sort descending',
     triggerAsc: 'Click to sort ascending',
     cancelSort: 'Click to cancel sorting',
+    filterEmptyText: 'Gan scagairí',
+    filterCheckAll: 'Roghnaigh gach mír',
+    filterSearchPlaceholder: 'Cuardaigh i scagairí',
+    emptyText: 'Gan sonraí',
+    selectNone: 'Glan na sonraí go léir',
   },
   Tour: {
     Next: 'Aghaidh',
@@ -56,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Select all data',
     removeAll: 'Remove all data',
     selectInvert: 'Invert current page',
+    deselectAll: 'Díroghnaigh na sonraí go léir',
   },
   Upload: {
     uploading: 'Uploading...',
@@ -75,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Copy',
     copied: 'Copied',
     expand: 'Expand',
+    collapse: 'Laghdaigh',
   },
   Form: {
     defaultValidateMessages: {
@@ -124,6 +132,17 @@ const localeValues: Locale = {
         mismatch: '${label} does not match the pattern ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'Chuaigh an cód QR in éag',
+    refresh: 'Athnuaigh',
+    scanned: 'Scanta',
+  },
+  ColorPicker: {
+    presetEmpty: 'Folamh',
+    transparent: 'Trédhearcach',
+    singleColor: 'Dath aonair',
+    gradientColor: 'Dath grádán',
   },
 }
 

--- a/packages/antdv-next/src/locale/gl_ES.ts
+++ b/packages/antdv-next/src/locale/gl_ES.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Escolla',
     close: 'Cerrar',
+    sortable: 'clasificable',
   },
   Table: {
     filterTitle: 'Filtrar menú',
@@ -24,6 +25,17 @@ const localeValues: Locale = {
     selectAll: 'Seleccionar todo',
     selectInvert: 'Invertir selección',
     sortTitle: 'Ordenar',
+    filterEmptyText: 'Sen filtros',
+    filterCheckAll: 'Selecciona todos os elementos',
+    filterSearchPlaceholder: 'Busca en filtros',
+    emptyText: 'Sen datos',
+    selectNone: 'Borrar todos os datos',
+    selectionAll: 'Seleccione todos os datos',
+    expand: 'Expandir fila',
+    collapse: 'Contraer fila',
+    triggerDesc: 'Fai clic para ordenar descendente',
+    triggerAsc: 'Fai clic para ordenar ascendente',
+    cancelSort: 'Fai clic para cancelar a clasificación',
   },
   Tour: {
     Next: 'Avanzar',
@@ -44,6 +56,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Buscar aquí',
     itemUnit: 'elemento',
     itemsUnit: 'elementos',
+    remove: 'Eliminar',
+    selectAll: 'Seleccione todos os datos',
+    deselectAll: 'Deseleccione todos os datos',
+    selectCurrent: 'Seleccione a páxina actual',
+    selectInvert: 'Inverte a páxina actual',
+    removeAll: 'Elimina todos os datos',
+    removeCurrent: 'Eliminar a páxina actual',
   },
   Upload: {
     uploading: 'Subindo...',
@@ -63,6 +82,7 @@ const localeValues: Locale = {
     copy: 'copiar',
     copied: 'copiado',
     expand: 'expandir',
+    collapse: 'Colapsar',
   },
   Form: {
     defaultValidateMessages: {
@@ -112,6 +132,17 @@ const localeValues: Locale = {
         mismatch: '${label} non coincide co patrón ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'O código QR caducou',
+    refresh: 'Actualizar',
+    scanned: 'Escaneado',
+  },
+  ColorPicker: {
+    presetEmpty: 'Baleiro',
+    transparent: 'Transparente',
+    singleColor: 'Cor única',
+    gradientColor: 'Cor degradado',
   },
 }
 

--- a/packages/antdv-next/src/locale/he_IL.ts
+++ b/packages/antdv-next/src/locale/he_IL.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'אנא בחר',
     close: 'סגור',
+    sortable: 'ניתן למיין',
   },
   Table: {
     filterTitle: 'תפריט סינון',
@@ -30,6 +31,11 @@ const localeValues: Locale = {
     triggerDesc: 'לחץ למיון לפי סדר יורד',
     triggerAsc: 'לחץ למיון לפי סדר עולה',
     cancelSort: 'לחץ כדי לבטל את המיון',
+    filterEmptyText: 'אין מסננים',
+    filterCheckAll: 'בחר את כל הפריטים',
+    filterSearchPlaceholder: 'חפש במסננים',
+    emptyText: 'אין נתונים',
+    selectNone: 'נקה את כל הנתונים',
   },
   Tour: {
     Next: 'הבא',
@@ -50,6 +56,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'חפש כאן',
     itemUnit: 'פריט',
     itemsUnit: 'פריטים',
+    remove: 'הסר',
+    selectAll: 'בחר את כל הנתונים',
+    deselectAll: 'בטל את הבחירה בכל הנתונים',
+    selectCurrent: 'בחר את הדף הנוכחי',
+    selectInvert: 'הפוך את הדף הנוכחי',
+    removeAll: 'הסר את כל הנתונים',
+    removeCurrent: 'הסר את הדף הנוכחי',
   },
   Upload: {
     uploading: 'מעלה...',
@@ -69,6 +82,7 @@ const localeValues: Locale = {
     copy: 'העתק',
     copied: 'הועתק',
     expand: 'הרחב',
+    collapse: 'התמוטט',
   },
   Form: {
     defaultValidateMessages: {
@@ -118,6 +132,17 @@ const localeValues: Locale = {
         mismatch: '${label} לא תואם לתבנית ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'פג תוקפו של קוד QR',
+    refresh: 'רענן',
+    scanned: 'נסרק',
+  },
+  ColorPicker: {
+    presetEmpty: 'ריק',
+    transparent: 'שקוף',
+    singleColor: 'צבע יחיד',
+    gradientColor: 'צבע שיפוע',
   },
 }
 

--- a/packages/antdv-next/src/locale/hi_IN.ts
+++ b/packages/antdv-next/src/locale/hi_IN.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'कृपया चुनें',
     close: 'बंद',
+    sortable: 'क्रमबद्ध',
   },
   Table: {
     filterTitle: 'सूची बंद करें',
@@ -33,6 +34,8 @@ const localeValues: Locale = {
     triggerDesc: 'अवरोही क्रमित करने के लिए क्लिक करें',
     triggerAsc: 'आरोही क्रमित करने के लिए क्लिक करें',
     cancelSort: 'छँटाई रद्द करने के लिए क्लिक करें',
+    filterCheckAll: 'सभी आइटम चुनें',
+    filterSearchPlaceholder: 'फ़िल्टर में खोजें',
   },
   Tour: {
     Next: 'अगाड़ा',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'सभी डेटा का चयन करें',
     removeAll: 'सभी डेटा हटाएं',
     selectInvert: 'वर्तमान पृष्ठ को उल्टा करें',
+    deselectAll: 'सभी डेटा का चयन रद्द करें',
   },
   Upload: {
     uploading: 'अपलोड हो रहा...',
@@ -78,6 +82,7 @@ const localeValues: Locale = {
     copy: 'प्रतिलिपि',
     copied: 'कॉपी किया गया',
     expand: 'विस्तार',
+    collapse: 'पतन',
   },
   Form: {
     optional: '(ऐच्छिक)',
@@ -128,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} ${pattern} पैटर्न से मेल नहीं खाता',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR कोड समाप्त हो गया',
+    refresh: 'ताज़ा करें',
+    scanned: 'स्कैन किया गया',
+  },
+  ColorPicker: {
+    presetEmpty: 'ख़ाली',
+    transparent: 'पारदर्शी',
+    singleColor: 'एकल रंग',
+    gradientColor: 'ढाल का रंग',
   },
 }
 

--- a/packages/antdv-next/src/locale/hr_HR.ts
+++ b/packages/antdv-next/src/locale/hr_HR.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Molimo označite',
     close: 'Zatvori',
+    sortable: 'sortibilan',
   },
   Table: {
     filterTitle: 'Filter meni',
@@ -32,6 +33,9 @@ const localeValues: Locale = {
     triggerDesc: 'Kliknite za sortiranje silazno',
     triggerAsc: 'Kliknite za sortiranje uzlazno',
     cancelSort: 'Kliknite da biste otkazali sortiranje',
+    filterCheckAll: 'Odaberite sve stavke',
+    filterSearchPlaceholder: 'Traži u filterima',
+    selectNone: 'Izbriši sve podatke',
   },
   Tour: {
     Next: 'Slijedeći',
@@ -58,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Odaberite sve podatke',
     removeAll: 'Uklonite sve podatke',
     selectInvert: 'Obrni trenutnu stranicu',
+    deselectAll: 'Poništi odabir svih podataka',
   },
   Upload: {
     uploading: 'Upload u tijeku...',
@@ -77,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Kopiraj',
     copied: 'Kopiranje uspješno',
     expand: 'Proširi',
+    collapse: 'Sažimanje',
   },
   Form: {
     optional: '(neobavezno)',
@@ -127,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} ne odgovara obrascu ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR kod je istekao',
+    refresh: 'Osvježi',
+    scanned: 'Skenirano',
+  },
+  ColorPicker: {
+    presetEmpty: 'Prazna',
+    transparent: 'Prozirno',
+    singleColor: 'Jedna boja',
+    gradientColor: 'Gradijent boje',
   },
 }
 

--- a/packages/antdv-next/src/locale/hu_HU.ts
+++ b/packages/antdv-next/src/locale/hu_HU.ts
@@ -13,6 +13,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Bezárás',
+    placeholder: 'Kérem válasszon',
+    sortable: 'válogatható',
   },
   Table: {
     filterTitle: 'Szűrők',
@@ -21,6 +23,17 @@ const localeValues: Locale = {
     selectAll: 'Jelenlegi oldal kiválasztása',
     selectInvert: 'Jelenlegi oldal inverze',
     sortTitle: 'Rendezés',
+    filterEmptyText: 'Nincsenek szűrők',
+    filterCheckAll: 'Válassza ki az összes elemet',
+    filterSearchPlaceholder: 'Keresés a szűrőkben',
+    emptyText: 'Nincs adat',
+    selectNone: 'Minden adat törlése',
+    selectionAll: 'Válassza ki az összes adatot',
+    expand: 'Sor kibontása',
+    collapse: 'Sor összecsukása',
+    triggerDesc: 'Kattintson ide a csökkenő sorrendbe rendezéshez',
+    triggerAsc: 'Kattintson a növekvő sorrendbe rendezéshez',
+    cancelSort: 'Kattintson a rendezés megszakításához',
   },
   Modal: {
     okText: 'Alkalmazás',
@@ -36,6 +49,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Keresés',
     itemUnit: 'elem',
     itemsUnit: 'elemek',
+    remove: 'Távolítsa el',
+    selectAll: 'Válassza ki az összes adatot',
+    deselectAll: 'Törölje az összes adat kijelölését',
+    selectCurrent: 'Válassza ki az aktuális oldalt',
+    selectInvert: 'Az aktuális oldal megfordítása',
+    removeAll: 'Távolítsa el az összes adatot',
+    removeCurrent: 'Az aktuális oldal eltávolítása',
   },
   Upload: {
     uploading: 'Feltöltés...',
@@ -51,6 +71,24 @@ const localeValues: Locale = {
     Next: 'Következő',
     Previous: 'Előző',
     Finish: 'Befejezés',
+  },
+  Text: {
+    edit: 'Szerkesztés',
+    copy: 'Másolás',
+    copied: 'Másolva',
+    expand: 'Bontsa ki',
+    collapse: 'Összeomlás',
+  },
+  QRCode: {
+    expired: 'A QR kód lejárt',
+    refresh: 'Frissítés',
+    scanned: 'Beolvasva',
+  },
+  ColorPicker: {
+    presetEmpty: 'Üres',
+    transparent: 'Átlátszó',
+    singleColor: 'Egyszínű',
+    gradientColor: 'Gradiens szín',
   },
 }
 

--- a/packages/antdv-next/src/locale/hy_AM.ts
+++ b/packages/antdv-next/src/locale/hy_AM.ts
@@ -62,6 +62,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Ընտրեք',
     close: 'Դադարեցնել',
+    sortable: 'տեսակավորելի',
   },
   Table: {
     filterTitle: 'ֆիլտրի ընտրացանկ',
@@ -72,6 +73,15 @@ const localeValues: Locale = {
     sortTitle: 'Տեսակավորել',
     expand: 'Ընդլայնեք տողը',
     collapse: 'Կրճատել տողը',
+    filterEmptyText: 'Զտիչներ չկան',
+    filterCheckAll: 'Ընտրեք բոլոր տարրերը',
+    filterSearchPlaceholder: 'Որոնել ֆիլտրերում',
+    emptyText: 'Տվյալներ չկան',
+    selectNone: 'Մաքրել բոլոր տվյալները',
+    selectionAll: 'Ընտրեք բոլոր տվյալները',
+    triggerDesc: 'Սեղմեք՝ նվազման կարգով',
+    triggerAsc: 'Սեղմեք՝ աճող տեսակավորելու համար',
+    cancelSort: 'Սեղմեք՝ տեսակավորումը չեղարկելու համար',
   },
   Tour: {
     Next: 'Հաջորդ',
@@ -92,6 +102,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Որոնեք այստեղ',
     itemUnit: 'պարագան',
     itemsUnit: 'պարագաները',
+    remove: 'Հեռացնել',
+    selectAll: 'Ընտրեք բոլոր տվյալները',
+    deselectAll: 'Ապաընտրել բոլոր տվյալները',
+    selectCurrent: 'Ընտրեք ընթացիկ էջը',
+    selectInvert: 'Շրջել ընթացիկ էջը',
+    removeAll: 'Հեռացրեք բոլոր տվյալները',
+    removeCurrent: 'Հեռացնել ընթացիկ էջը',
   },
   Upload: {
     uploading: 'Ներբեռնում...',
@@ -111,6 +128,18 @@ const localeValues: Locale = {
     copy: 'Պատճենել',
     copied: 'Պատճենվել է',
     expand: 'Տեսնել ավելին',
+    collapse: 'Փլուզում',
+  },
+  QRCode: {
+    expired: 'QR կոդը ժամկետանց է',
+    refresh: 'Թարմացնել',
+    scanned: 'Սկանավորվել է',
+  },
+  ColorPicker: {
+    presetEmpty: 'Դատարկ',
+    transparent: 'Թափանցիկ',
+    singleColor: 'Մեկ գույն',
+    gradientColor: 'Գրադիենտ գույն',
   },
 }
 

--- a/packages/antdv-next/src/locale/id_ID.ts
+++ b/packages/antdv-next/src/locale/id_ID.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Silahkan pilih',
     close: 'Tutup',
+    sortable: 'dapat diurutkan',
   },
   Table: {
     filterTitle: 'Menu filter',

--- a/packages/antdv-next/src/locale/is_IS.ts
+++ b/packages/antdv-next/src/locale/is_IS.ts
@@ -15,6 +15,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Loka',
+    placeholder: 'Vinsamlegast veldu',
+    sortable: 'flokkanlegt',
   },
   Table: {
     filterTitle: 'Afmarkanir',
@@ -22,6 +24,18 @@ const localeValues: Locale = {
     filterReset: 'Núllstilla',
     selectAll: 'Velja allt',
     selectInvert: 'Viðsnúa vali',
+    filterEmptyText: 'Engar síur',
+    filterCheckAll: 'Veldu alla hluti',
+    filterSearchPlaceholder: 'Leitaðu í síum',
+    emptyText: 'Engin gögn',
+    selectNone: 'Hreinsaðu öll gögn',
+    selectionAll: 'Veldu öll gögn',
+    sortTitle: 'Raða',
+    expand: 'Stækkaðu röð',
+    collapse: 'Draga saman röð',
+    triggerDesc: 'Smelltu til að raða lækkandi',
+    triggerAsc: 'Smelltu til að flokka hækkandi',
+    cancelSort: 'Smelltu til að hætta við flokkun',
   },
   Tour: {
     Next: 'Áfram',
@@ -42,6 +56,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Leita hér',
     itemUnit: 'færsla',
     itemsUnit: 'færslur',
+    remove: 'Fjarlægja',
+    selectAll: 'Veldu öll gögn',
+    deselectAll: 'Afvelja öll gögn',
+    selectCurrent: 'Veldu núverandi síðu',
+    selectInvert: 'Snúa núverandi síðu við',
+    removeAll: 'Fjarlægðu öll gögn',
+    removeCurrent: 'Fjarlægðu núverandi síðu',
   },
   Upload: {
     uploading: 'Hleð upp...',
@@ -102,6 +123,24 @@ const localeValues: Locale = {
         mismatch: '${label} passar ekki við mynstur ${pattern}',
       },
     },
+  },
+  Text: {
+    edit: 'Breyta',
+    copy: 'Afrita',
+    copied: 'Afritað',
+    expand: 'Stækkaðu',
+    collapse: 'Hrun',
+  },
+  QRCode: {
+    expired: 'QR kóða útrunninn',
+    refresh: 'Endurnýja',
+    scanned: 'Skannaður',
+  },
+  ColorPicker: {
+    presetEmpty: 'Tómt',
+    transparent: 'Gegnsætt',
+    singleColor: 'Einlitur',
+    gradientColor: 'Gradient litur',
   },
 }
 

--- a/packages/antdv-next/src/locale/it_IT.ts
+++ b/packages/antdv-next/src/locale/it_IT.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Selezionare',
     close: 'Chiudi',
+    sortable: 'ordinabile',
   },
   Table: {
     filterTitle: 'Menù Filtro',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Seleziona tutti i dati',
     removeAll: 'Rimuovi tutti i dati',
     selectInvert: 'Inverti la pagina corrente',
+    deselectAll: 'Deseleziona tutti i dati',
   },
   Upload: {
     uploading: 'Caricamento...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'copia',
     copied: 'copia effettuata',
     expand: 'espandi',
+    collapse: 'Crollo',
   },
   Form: {
     optional: '(opzionale)',

--- a/packages/antdv-next/src/locale/ja_JP.ts
+++ b/packages/antdv-next/src/locale/ja_JP.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: '選んでください',
     close: '閉じる',
+    sortable: '並べ替え可能',
   },
   Table: {
     filterTitle: 'フィルター',

--- a/packages/antdv-next/src/locale/ka_GE.ts
+++ b/packages/antdv-next/src/locale/ka_GE.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'გთხოვთ აირჩიოთ',
     close: 'დახურვა',
+    sortable: 'დასალაგებელი',
   },
   Table: {
     filterTitle: 'ფილტრის მენიუ',
@@ -33,6 +34,8 @@ const localeValues: Locale = {
     triggerDesc: 'დაღმავალი დალაგება',
     triggerAsc: 'აღმავალი დალაგება',
     cancelSort: 'დალაგების გაუქმება',
+    filterCheckAll: 'აირჩიეთ ყველა ელემენტი',
+    filterSearchPlaceholder: 'მოძებნეთ ფილტრებში',
   },
   Tour: {
     Next: 'მომდევნო',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'ყველას მონიშვნა',
     removeAll: 'ყველას წაშლა',
     selectInvert: 'მიმდინარე გვერდის შებრუნება',
+    deselectAll: 'გააუქმეთ ყველა მონაცემი',
   },
   Upload: {
     uploading: 'იტვირთება...',
@@ -78,6 +82,7 @@ const localeValues: Locale = {
     copy: 'ასლი',
     copied: 'ასლი აღებულია',
     expand: 'გაშლა',
+    collapse: 'კოლაფსი',
   },
   Form: {
     optional: '(არასავალდებულო)',
@@ -128,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} არ ერგება შაბლონს ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR კოდს ვადა გაუვიდა',
+    refresh: 'განაახლეთ',
+    scanned: 'დასკანირებულია',
+  },
+  ColorPicker: {
+    presetEmpty: 'ცარიელი',
+    transparent: 'გამჭვირვალე',
+    singleColor: 'ერთი ფერი',
+    gradientColor: 'გრადიენტური ფერი',
   },
 }
 

--- a/packages/antdv-next/src/locale/kk_KZ.ts
+++ b/packages/antdv-next/src/locale/kk_KZ.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Таңдаңыз',
     close: 'Жабу',
+    sortable: 'сұрыпталатын',
   },
   Table: {
     filterTitle: 'Фильтр',
@@ -32,6 +33,9 @@ const localeValues: Locale = {
     triggerDesc: 'Төмендеуді сұрыптау үшін басыңыз',
     triggerAsc: 'Өсу ретімен сұрыптау үшін басыңыз',
     cancelSort: 'Сұрыптаудан бас тарту үшін басыңыз',
+    filterCheckAll: 'Барлық элементтерді таңдаңыз',
+    filterSearchPlaceholder: 'Сүзгілерде іздеу',
+    selectNone: 'Барлық деректерді өшіріңіз',
   },
   Tour: {
     Next: 'Келесі',
@@ -58,6 +62,7 @@ const localeValues: Locale = {
     selectInvert: 'Кері тәртіпте көрсету',
     removeAll: 'Барлық деректерді жою',
     removeCurrent: 'Ағымдағы парақты өшіру',
+    deselectAll: 'Барлық деректердің таңдауын алып тастаңыз',
   },
   Upload: {
     uploading: 'Жүктеу...',
@@ -77,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Көшіру',
     copied: 'Көшірілді',
     expand: 'Жазу',
+    collapse: 'Жыйрату',
   },
   Form: {
     defaultValidateMessages: {
@@ -125,6 +131,17 @@ const localeValues: Locale = {
         mismatch: '${label} ${pattern} мен сәйкес келмейді',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR кодының мерзімі аяқталды',
+    refresh: 'Жаңарту',
+    scanned: 'Сканерленген',
+  },
+  ColorPicker: {
+    presetEmpty: 'Бос',
+    transparent: 'Мөлдір',
+    singleColor: 'Бір түсті',
+    gradientColor: 'Градиент түсі',
   },
 }
 

--- a/packages/antdv-next/src/locale/km_KH.ts
+++ b/packages/antdv-next/src/locale/km_KH.ts
@@ -15,6 +15,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'បិទ',
+    placeholder: 'សូមជ្រើសរើស',
+    sortable: 'អាចតម្រៀបបាន។',
   },
   Table: {
     filterTitle: 'បញ្ចីតម្រៀប',
@@ -32,6 +34,8 @@ const localeValues: Locale = {
     triggerDesc: 'ចុចដើម្បីរៀបតាមលំដាប់ធំ',
     triggerAsc: 'ចុចដើម្បីរៀបតាមលំដាប់តូច​',
     cancelSort: 'ចុចដើម្បីបោះបង់',
+    filterCheckAll: 'ជ្រើសរើសធាតុទាំងអស់។',
+    filterSearchPlaceholder: 'ស្វែងរកក្នុងតម្រង',
   },
   Tour: {
     Next: 'បន្ទាប់',
@@ -52,6 +56,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'ស្វែងរកនៅទីនេះ',
     itemUnit: '',
     itemsUnit: 'items',
+    remove: 'ដកចេញ',
+    selectAll: 'ជ្រើសរើសទិន្នន័យទាំងអស់។',
+    deselectAll: 'ដកការជ្រើសរើសទិន្នន័យទាំងអស់។',
+    selectCurrent: 'ជ្រើសរើសទំព័របច្ចុប្បន្ន',
+    selectInvert: 'បញ្ច្រាសទំព័របច្ចុប្បន្ន',
+    removeAll: 'លុបទិន្នន័យទាំងអស់។',
+    removeCurrent: 'លុបទំព័របច្ចុប្បន្ន',
   },
   Upload: {
     uploading: 'កំពុងបញ្ចូលឡើង...',
@@ -111,6 +122,24 @@ const localeValues: Locale = {
         mismatch: '${label} does not match the pattern ${pattern}',
       },
     },
+  },
+  Text: {
+    edit: 'កែសម្រួល',
+    copy: 'ចម្លង',
+    copied: 'ចម្លង',
+    expand: 'ពង្រីក',
+    collapse: 'ដួលរលំ',
+  },
+  QRCode: {
+    expired: 'កូដ QR ផុតកំណត់',
+    refresh: 'ធ្វើឱ្យស្រស់',
+    scanned: 'ស្កេន',
+  },
+  ColorPicker: {
+    presetEmpty: 'ទទេ',
+    transparent: 'តម្លាភាព',
+    singleColor: 'ពណ៌តែមួយ',
+    gradientColor: 'ពណ៌ជម្រាល',
   },
 }
 

--- a/packages/antdv-next/src/locale/kmr_IQ.ts
+++ b/packages/antdv-next/src/locale/kmr_IQ.ts
@@ -13,6 +13,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Betal ke',
+    placeholder: 'Ji kerema xwe hilbijêre',
+    sortable: 'sorkirin',
   },
   Table: {
     filterTitle: 'Menuê peldanka',
@@ -20,6 +22,18 @@ const localeValues: Locale = {
     filterReset: 'Jê bibe',
     selectAll: 'Hemî hilbijêre',
     selectInvert: 'Hilbijartinan veguhere',
+    filterEmptyText: 'Parzûn tune',
+    filterCheckAll: 'Hemî tiştan hilbijêrin',
+    filterSearchPlaceholder: 'Di parzûnan de bigerin',
+    emptyText: 'Daneyên tune',
+    selectNone: 'Hemî daneyan paqij bike',
+    selectionAll: 'Hemî daneyan hilbijêrin',
+    sortTitle: 'Sort',
+    expand: 'Rêzê berfireh bike',
+    collapse: 'Rêzê hilweşîne',
+    triggerDesc: 'Bikirtînin ji bo rêzkirina daketî',
+    triggerAsc: 'Ji bo rêzkirina hilkişînê bikirtînin',
+    cancelSort: 'Ji bo betalkirina dabeşkirinê bikirtînin',
   },
   Tour: {
     Next: 'Temam',
@@ -40,6 +54,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Lêgerîn',
     itemUnit: 'tişt',
     itemsUnit: 'tişt',
+    remove: 'Rakirin',
+    selectAll: 'Hemî daneyan hilbijêrin',
+    deselectAll: 'Hemî daneyan jêbirin',
+    selectCurrent: 'Rûpelê heyî hilbijêrin',
+    selectInvert: 'Rûpelê heyî berovajî bikin',
+    removeAll: 'Hemî daneyan jêbirin',
+    removeCurrent: 'Rûpelê heyî jêbirin',
   },
   Upload: {
     uploading: 'Bardike...',
@@ -50,6 +71,24 @@ const localeValues: Locale = {
   },
   Empty: {
     description: 'Agahî tune',
+  },
+  Text: {
+    edit: 'Sererast bike',
+    copy: 'Kopî bike',
+    copied: 'Kopî kirin',
+    expand: 'Zêdetir nîşan bide',
+    collapse: 'Hilweşîn',
+  },
+  QRCode: {
+    expired: 'Koda QR qediya',
+    refresh: 'Refresh',
+    scanned: 'Scanned',
+  },
+  ColorPicker: {
+    presetEmpty: 'Empty',
+    transparent: 'Transparent',
+    singleColor: 'Yek reng',
+    gradientColor: 'Rengê gradient',
   },
 }
 

--- a/packages/antdv-next/src/locale/kn_IN.ts
+++ b/packages/antdv-next/src/locale/kn_IN.ts
@@ -17,6 +17,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'ದಯವಿಟ್ಟು ಆರಿಸಿ',
     close: 'ಮುಚ್ಚಿ',
+    sortable: 'ವಿಂಗಡಿಸಬಹುದಾದ',
   },
   Table: {
     filterTitle: 'ಪಟ್ಟಿ ಸೋಸಿ',
@@ -57,6 +58,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'ಇಲ್ಲಿ ಹುಡುಕಿ',
     itemUnit: 'ವಿಷಯ',
     itemsUnit: 'ವಿಷಯಗಳು',
+    remove: 'ತೆಗೆದುಹಾಕಿ',
+    selectAll: 'ಎಲ್ಲಾ ಡೇಟಾವನ್ನು ಆಯ್ಕೆಮಾಡಿ',
+    deselectAll: 'ಎಲ್ಲಾ ಡೇಟಾವನ್ನು ಆಯ್ಕೆ ರದ್ದುಮಾಡಿ',
+    selectCurrent: 'ಪ್ರಸ್ತುತ ಪುಟವನ್ನು ಆಯ್ಕೆಮಾಡಿ',
+    selectInvert: 'ಪ್ರಸ್ತುತ ಪುಟವನ್ನು ತಿರುಗಿಸಿ',
+    removeAll: 'ಎಲ್ಲಾ ಡೇಟಾವನ್ನು ತೆಗೆದುಹಾಕಿ',
+    removeCurrent: 'ಪ್ರಸ್ತುತ ಪುಟವನ್ನು ತೆಗೆದುಹಾಕಿ',
   },
   Upload: {
     uploading: 'ಏರಿಸಿ...',
@@ -131,6 +139,13 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'QR ಕೋಡ್ ಅವಧಿ ಮೀರಿದೆ',
     refresh: 'ನವೀಕರಿಸಿ',
+    scanned: 'ಸ್ಕ್ಯಾನ್ ಮಾಡಲಾಗಿದೆ',
+  },
+  ColorPicker: {
+    presetEmpty: 'ಖಾಲಿ',
+    transparent: 'ಪಾರದರ್ಶಕ',
+    singleColor: 'ಏಕ ಬಣ್ಣ',
+    gradientColor: 'ಗ್ರೇಡಿಯಂಟ್ ಬಣ್ಣ',
   },
 }
 

--- a/packages/antdv-next/src/locale/ko_KR.ts
+++ b/packages/antdv-next/src/locale/ko_KR.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: '선택하세요',
     close: '닫기',
+    sortable: '정렬 가능',
   },
   Table: {
     filterTitle: '필터 메뉴',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: '전체 선택',
     removeAll: '전체 삭제',
     selectInvert: '선택 반전',
+    deselectAll: '모든 데이터 선택 해제',
   },
   Upload: {
     uploading: '업로드 중...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: '복사',
     copied: '복사됨',
     expand: '확장',
+    collapse: '접기',
   },
   Form: {
     optional: '(선택사항)',
@@ -134,6 +137,7 @@ const localeValues: Locale = {
   QRCode: {
     expired: '만료된 QR 코드',
     refresh: '새로고침',
+    scanned: '스캔됨',
   },
   ColorPicker: {
     presetEmpty: '미정',

--- a/packages/antdv-next/src/locale/ku_IQ.ts
+++ b/packages/antdv-next/src/locale/ku_IQ.ts
@@ -17,6 +17,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Betal ke',
+    placeholder: 'Ji kerema xwe hilbijêre',
+    sortable: 'sorkirin',
   },
   Table: {
     filterTitle: 'Menuê peldanka',
@@ -24,6 +26,18 @@ const localeValues: Locale = {
     filterReset: 'Jê bibe',
     selectAll: 'Hemî hilbijêre',
     selectInvert: 'Hilbijartinan veguhere',
+    filterEmptyText: 'Parzûn tune',
+    filterCheckAll: 'Hemî tiştan hilbijêrin',
+    filterSearchPlaceholder: 'Di parzûnan de bigerin',
+    emptyText: 'Daneyên tune',
+    selectNone: 'Hemî daneyan paqij bike',
+    selectionAll: 'Hemî daneyan hilbijêrin',
+    sortTitle: 'Sort',
+    expand: 'Rêzê berfireh bike',
+    collapse: 'Rêzê hilweşîne',
+    triggerDesc: 'Bikirtînin ji bo rêzkirina daketî',
+    triggerAsc: 'Ji bo rêzkirina hilkişînê bikirtînin',
+    cancelSort: 'Ji bo betalkirina dabeşkirinê bikirtînin',
   },
   Tour: {
     Next: 'Temam',
@@ -44,6 +58,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Lêgerîn',
     itemUnit: 'tişt',
     itemsUnit: 'tişt',
+    remove: 'Rakirin',
+    selectAll: 'Hemî daneyan hilbijêrin',
+    deselectAll: 'Hemî daneyan jêbirin',
+    selectCurrent: 'Rûpelê heyî hilbijêrin',
+    selectInvert: 'Rûpelê heyî berovajî bikin',
+    removeAll: 'Hemî daneyan jêbirin',
+    removeCurrent: 'Rûpelê heyî jêbirin',
   },
   Upload: {
     uploading: 'Bardike...',
@@ -54,6 +75,24 @@ const localeValues: Locale = {
   },
   Empty: {
     description: 'Agahî tune',
+  },
+  Text: {
+    edit: 'Sererast bike',
+    copy: 'Kopî bike',
+    copied: 'Kopî kirin',
+    expand: 'Zêdetir nîşan bide',
+    collapse: 'Hilweşîn',
+  },
+  QRCode: {
+    expired: 'Koda QR qediya',
+    refresh: 'Refresh',
+    scanned: 'Scanned',
+  },
+  ColorPicker: {
+    presetEmpty: 'Empty',
+    transparent: 'Transparent',
+    singleColor: 'Yek reng',
+    gradientColor: 'Rengê gradient',
   },
 }
 

--- a/packages/antdv-next/src/locale/lt_LT.ts
+++ b/packages/antdv-next/src/locale/lt_LT.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Pasirinkite',
     close: 'Uždaryti',
+    sortable: 'rūšiuojami',
   },
   Table: {
     filterTitle: 'Filtras',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Pasirinkti viską',
     removeAll: 'Ištrinti viską',
     selectInvert: 'Apversti pasirinkimą',
+    deselectAll: 'Panaikinkite visų duomenų pasirinkimą',
   },
   Upload: {
     uploading: 'Įkeliami duomenys...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Kopijuoti',
     copied: 'Nukopijuota',
     expand: 'Plačiau',
+    collapse: 'Sutraukti',
   },
   Form: {
     optional: '(neprivaloma)',
@@ -134,6 +137,7 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'QR kodo galiojimas baigėsi',
     refresh: 'Atnaujinti',
+    scanned: 'Nuskaityta',
   },
   ColorPicker: {
     presetEmpty: 'Tuščia',

--- a/packages/antdv-next/src/locale/lv_LV.ts
+++ b/packages/antdv-next/src/locale/lv_LV.ts
@@ -13,6 +13,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Aizvērt',
+    placeholder: 'Lūdzu, atlasiet',
+    sortable: 'šķirojams',
   },
   Table: {
     filterTitle: 'Filtrēšanas izvēlne',
@@ -20,6 +22,18 @@ const localeValues: Locale = {
     filterReset: 'Atiestatīt',
     selectAll: 'Atlasiet pašreizējo lapu',
     selectInvert: 'Pārvērst pašreizējo lapu',
+    filterEmptyText: 'Nav filtru',
+    filterCheckAll: 'Atlasiet visus vienumus',
+    filterSearchPlaceholder: 'Meklēt filtros',
+    emptyText: 'Nav datu',
+    selectNone: 'Notīrīt visus datus',
+    selectionAll: 'Atlasiet visus datus',
+    sortTitle: 'Kārtot',
+    expand: 'Izvērst rindu',
+    collapse: 'Sakļaut rindu',
+    triggerDesc: 'Noklikšķiniet, lai kārtotu dilstošā secībā',
+    triggerAsc: 'Noklikšķiniet, lai kārtotu augošā secībā',
+    cancelSort: 'Noklikšķiniet, lai atceltu kārtošanu',
   },
   Tour: {
     Next: 'Nākamais',
@@ -40,6 +54,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Meklēt šeit',
     itemUnit: 'vienumu',
     itemsUnit: 'vienumus',
+    remove: 'Noņemt',
+    selectAll: 'Atlasiet visus datus',
+    deselectAll: 'Noņemiet visu datu atlasi',
+    selectCurrent: 'Atlasiet pašreizējo lapu',
+    selectInvert: 'Apgriezt pašreizējo lapu',
+    removeAll: 'Noņemiet visus datus',
+    removeCurrent: 'Noņemt pašreizējo lapu',
   },
   Upload: {
     uploading: 'Augšupielāde...',
@@ -50,6 +71,24 @@ const localeValues: Locale = {
   },
   Empty: {
     description: 'Nav datu',
+  },
+  Text: {
+    edit: 'Rediģēt',
+    copy: 'Kopēt',
+    copied: 'Kopēts',
+    expand: 'Izvērst',
+    collapse: 'Sakļaut',
+  },
+  QRCode: {
+    expired: 'QR kods ir beidzies',
+    refresh: 'Atsvaidzināt',
+    scanned: 'Skenēts',
+  },
+  ColorPicker: {
+    presetEmpty: 'Tukšs',
+    transparent: 'Caurspīdīgs',
+    singleColor: 'Vienkrāsains',
+    gradientColor: 'Gradienta krāsa',
   },
 }
 

--- a/packages/antdv-next/src/locale/mk_MK.ts
+++ b/packages/antdv-next/src/locale/mk_MK.ts
@@ -14,6 +14,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Ве молиме означете',
     close: 'Затвори',
+    sortable: 'подредливи',
   },
   Table: {
     filterTitle: 'Мени за филтрирање',
@@ -21,6 +22,18 @@ const localeValues: Locale = {
     filterReset: 'Избриши',
     selectAll: 'Одбери страница',
     selectInvert: 'Инвертирај страница',
+    filterEmptyText: 'Нема филтри',
+    filterCheckAll: 'Изберете ги сите ставки',
+    filterSearchPlaceholder: 'Барај во филтри',
+    emptyText: 'Нема податоци',
+    selectNone: 'Исчистете ги сите податоци',
+    selectionAll: 'Изберете ги сите податоци',
+    sortTitle: 'Подреди',
+    expand: 'Проширете го редот',
+    collapse: 'Собери ред',
+    triggerDesc: 'Кликнете за да сортирате опаѓачки',
+    triggerAsc: 'Кликнете за да сортирате растечки',
+    cancelSort: 'Кликнете за да го откажете сортирањето',
   },
   Tour: {
     Next: 'Следно',
@@ -41,6 +54,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Пребарај тука',
     itemUnit: 'предмет',
     itemsUnit: 'предмети',
+    remove: 'Отстрани',
+    selectAll: 'Изберете ги сите податоци',
+    deselectAll: 'Деселектирај ги сите податоци',
+    selectCurrent: 'Изберете тековна страница',
+    selectInvert: 'Превртете ја тековната страница',
+    removeAll: 'Отстранете ги сите податоци',
+    removeCurrent: 'Отстранете ја моменталната страница',
   },
   Upload: {
     uploading: 'Се прикачува...',
@@ -60,6 +80,18 @@ const localeValues: Locale = {
     copy: 'Копирај',
     copied: 'Копирано',
     expand: 'Зголеми',
+    collapse: 'Колапс',
+  },
+  QRCode: {
+    expired: 'QR-кодот е истечен',
+    refresh: 'Освежи',
+    scanned: 'Скенирано',
+  },
+  ColorPicker: {
+    presetEmpty: 'Празен',
+    transparent: 'Транспарентен',
+    singleColor: 'Еднобојна',
+    gradientColor: 'Боја на градиент',
   },
 }
 

--- a/packages/antdv-next/src/locale/ml_IN.ts
+++ b/packages/antdv-next/src/locale/ml_IN.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'ദയവായി തിരഞ്ഞെടുക്കുക',
     close: 'മുടക്കുക',
+    sortable: 'അടുക്കാവുന്ന',
   },
   Table: {
     filterTitle: 'ഫിൽറ്റർ',
@@ -33,6 +34,8 @@ const localeValues: Locale = {
     triggerDesc: 'അവരോഹണ ക്രമത്തിനായി ക്ലിക്ക് ചെയ്യുക',
     triggerAsc: 'ആരോഹണ ക്രമത്തിനായി ക്ലിക്ക് ചെയ്യുക',
     cancelSort: 'ക്രമീകരണം ഒഴിവാക്കുന്നതിനായി ക്ലിക്ക് ചെയ്യുക',
+    filterCheckAll: 'എല്ലാ ഇനങ്ങളും തിരഞ്ഞെടുക്കുക',
+    filterSearchPlaceholder: 'ഫിൽട്ടറുകളിൽ തിരയുക',
   },
   Tour: {
     Next: 'അടുത്തത്',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'എല്ലാ ഡാറ്റയും തിരഞ്ഞെടുക്കുക',
     removeAll: 'എല്ലാ ഡാറ്റയും നീക്കം ചെയ്യുക',
     selectInvert: 'നിലവിലെ പേജിൽ ഇല്ലാത്തത് തിരഞ്ഞെടുക്കുക',
+    deselectAll: 'എല്ലാ ഡാറ്റയും തിരഞ്ഞെടുത്തത് മാറ്റുക',
   },
   Upload: {
     uploading: 'അപ്‌ലോഡ് ചെയ്തു കൊണ്ടിരിക്കുന്നു...',
@@ -78,6 +82,7 @@ const localeValues: Locale = {
     copy: 'കോപ്പി ചെയ്യുക',
     copied: 'കോപ്പി ചെയ്തു',
     expand: 'വികസിപ്പിക്കുക',
+    collapse: 'ചുരുക്കുക',
   },
   Form: {
     optional: '(optional)',
@@ -128,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} ${pattern} മാതൃകയുമായി യോജിക്കുന്നില്ല',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR കോഡ് കാലഹരണപ്പെട്ടു',
+    refresh: 'പുതുക്കുക',
+    scanned: 'സ്കാൻ ചെയ്തു',
+  },
+  ColorPicker: {
+    presetEmpty: 'ശൂന്യം',
+    transparent: 'സുതാര്യം',
+    singleColor: 'ഏക നിറം',
+    gradientColor: 'ഗ്രേഡിയൻ്റ് നിറം',
   },
 }
 

--- a/packages/antdv-next/src/locale/mn_MN.ts
+++ b/packages/antdv-next/src/locale/mn_MN.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Сонгоно уу',
     close: 'Хаах',
+    sortable: 'ангилах боломжтой',
   },
   Table: {
     filterTitle: 'Хайх цэс',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Бүх өгөгдлийг сонгоно уу',
     removeAll: 'Бүх өгөгдлийг устгана уу',
     selectInvert: 'Одоогийн хуудсыг эргүүлэх',
+    deselectAll: 'Бүх өгөгдлийн сонголтыг цуцлах',
   },
   Upload: {
     uploading: 'Хуулж байна...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Хуулбарлах',
     copied: 'Хуулсан',
     expand: 'Өргөтгөх',
+    collapse: 'Нурах',
   },
   Form: {
     optional: '(сонголттой)',
@@ -130,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} нь ${pattern} загвартай тохирохгүй байна',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR кодын хугацаа дууссан',
+    refresh: 'Сэргээх',
+    scanned: 'Сканнердсан',
+  },
+  ColorPicker: {
+    presetEmpty: 'Хоосон',
+    transparent: 'Ил тод',
+    singleColor: 'Ганц өнгө',
+    gradientColor: 'Градиент өнгө',
   },
 }
 

--- a/packages/antdv-next/src/locale/mr_IN.ts
+++ b/packages/antdv-next/src/locale/mr_IN.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'कृपया निवडा',
     close: 'बंद करा',
+    sortable: 'वर्गीकरण करण्यायोग्य',
   },
   Table: {
     filterTitle: 'फिल्टर मेनू',
@@ -132,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} हे ${pattern} पॅटर्नशी जुळत नाही',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR कोड कालबाह्य झाला',
+    refresh: 'रिफ्रेश करा',
+    scanned: 'स्कॅन केले',
+  },
+  ColorPicker: {
+    presetEmpty: 'रिकामे',
+    transparent: 'पारदर्शक',
+    singleColor: 'एकच रंग',
+    gradientColor: 'ग्रेडियंट रंग',
   },
 }
 

--- a/packages/antdv-next/src/locale/ms_MY.ts
+++ b/packages/antdv-next/src/locale/ms_MY.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Sila pilih',
     close: 'Tutup',
+    sortable: 'boleh disusun',
   },
   Table: {
     filterTitle: 'Cari dengan tajuk',
@@ -62,6 +63,7 @@ const localeValues: Locale = {
     selectAll: 'Pilih Semua',
     removeAll: 'Buang Semua',
     selectInvert: 'Balik Pilihan',
+    deselectAll: 'Nyahpilih semua data',
   },
   Upload: {
     uploading: 'Sedang memuat naik...',
@@ -81,6 +83,7 @@ const localeValues: Locale = {
     copy: 'Salin',
     copied: 'Berjaya menyalin',
     expand: 'Kembang',
+    collapse: 'Runtuh',
   },
   Form: {
     optional: '(Opsional)',
@@ -135,6 +138,7 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'Kod QR luput',
     refresh: 'Segar Semula',
+    scanned: 'Diimbas',
   },
   ColorPicker: {
     presetEmpty: 'Tiada',

--- a/packages/antdv-next/src/locale/my_MM.ts
+++ b/packages/antdv-next/src/locale/my_MM.ts
@@ -17,6 +17,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'ကျေးဇူးပြု၍ ရွေးချယ်ပါ။',
     close: 'ပိတ်ပါ',
+    sortable: 'အမျိုးအစားခွဲနိုင်သည်။',
   },
   Table: {
     filterTitle: 'စစ်ထုတ်ခြင်း မီနူ',
@@ -33,6 +34,9 @@ const localeValues: Locale = {
     expand: 'အတန်းချဲ့ပါ။',
     collapse: 'အတန်းကို ခေါက်သိမ်းပါ။',
     cancelSort: 'အမျိုးအစားခွဲခြင်းကို ပယ်ဖျက်ရန် နှိပ်ပါ။',
+    emptyText: 'ဒေတာမရှိပါ။',
+    triggerDesc: 'ကြီးစဉ်ငယ်လိုက် စီရန် နှိပ်ပါ။',
+    triggerAsc: 'ကြီးကြီးလိုက် စီရန် နှိပ်ပါ။',
   },
   Tour: {
     Next: 'နောက်တစ်ခု',
@@ -59,6 +63,7 @@ const localeValues: Locale = {
     selectAll: 'ဒေတာအားလုံးကို ရွေးပါ။',
     removeAll: 'ဒေတာအားလုံးကို ဖယ်ရှားပါ။',
     selectInvert: 'လက်ရှိစာမျက်နှာကို ပြောင်းလိုက်ပါ။',
+    deselectAll: 'ဒေတာအားလုံးကို မရွေးပါ။',
   },
   Upload: {
     uploading: 'တင်ခြင်း။...',
@@ -78,6 +83,7 @@ const localeValues: Locale = {
     copy: 'ကော်ပီ',
     copied: 'ကူးယူသည်။',
     expand: 'ချဲ့ထွင်ပါ။',
+    collapse: 'ပြိုကျသည်။',
   },
   Form: {
     optional: '(ချန်လှပ်ထားနိုင်သည်)',
@@ -132,6 +138,13 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'QR ကုဒ် သက်တမ်းကုန်သွားပါပြီ။',
     refresh: 'ပြန်လည်စတင်ပါ။',
+    scanned: 'စကင်န်ဖတ်သည်။',
+  },
+  ColorPicker: {
+    presetEmpty: 'ဗလာ',
+    transparent: 'ပွင့်လင်းသည်။',
+    singleColor: 'တစ်ရောင်တည်း',
+    gradientColor: 'Gradient အရောင်',
   },
 }
 

--- a/packages/antdv-next/src/locale/ne_NP.ts
+++ b/packages/antdv-next/src/locale/ne_NP.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'कृपया छान्नुहोस्',
     close: 'बन्द',
+    sortable: 'क्रमबद्ध',
   },
   Table: {
     filterTitle: 'फिल्टर मेनु',

--- a/packages/antdv-next/src/locale/nl_BE.ts
+++ b/packages/antdv-next/src/locale/nl_BE.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Maak een selectie',
     close: 'Sluiten',
+    sortable: 'sorteerbaar',
   },
   Table: {
     cancelSort: 'Klik om sortering te annuleren',
@@ -33,6 +34,8 @@ const localeValues: Locale = {
     sortTitle: 'Sorteren',
     triggerAsc: 'Klik om oplopend te sorteren',
     triggerDesc: 'Klik om aflopend te sorteren',
+    filterCheckAll: 'Selecteer alle artikelen',
+    filterSearchPlaceholder: 'Zoek in filters',
   },
   Tour: {
     Next: 'Volgende',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
     selectCurrent: 'Selecteer huidige pagina',
     selectInvert: 'Huidige pagina omkeren',
     titles: ['', ''],
+    deselectAll: 'Deselecteer alle gegevens',
   },
   Upload: {
     downloadFile: 'Bestand downloaden',
@@ -78,6 +82,7 @@ const localeValues: Locale = {
     copy: 'kopiëren',
     copied: 'Gekopieerd',
     expand: 'Uitklappen',
+    collapse: 'Samenvouwen',
   },
   Form: {
     optional: '(optioneel)',
@@ -128,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} komt niet overeen met het patroon ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR-code verlopen',
+    refresh: 'Vernieuwen',
+    scanned: 'Gescand',
+  },
+  ColorPicker: {
+    presetEmpty: 'Leeg',
+    transparent: 'Transparant',
+    singleColor: 'Enkele kleur',
+    gradientColor: 'Kleurverloop',
   },
 }
 

--- a/packages/antdv-next/src/locale/nl_NL.ts
+++ b/packages/antdv-next/src/locale/nl_NL.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Maak een selectie',
     close: 'Sluiten',
+    sortable: 'sorteerbaar',
   },
   Table: {
     cancelSort: 'Klik om sortering te annuleren',
@@ -33,6 +34,8 @@ const localeValues: Locale = {
     sortTitle: 'Sorteren',
     triggerAsc: 'Klik om oplopend te sorteren',
     triggerDesc: 'Klik om aflopend te sorteren',
+    filterCheckAll: 'Selecteer alle artikelen',
+    filterSearchPlaceholder: 'Zoek in filters',
   },
   Tour: {
     Next: 'Volgende',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
     selectCurrent: 'Selecteer huidige pagina',
     selectInvert: 'Huidige pagina omkeren',
     titles: ['', ''],
+    deselectAll: 'Deselecteer alle gegevens',
   },
   Upload: {
     downloadFile: 'Bestand downloaden',
@@ -78,6 +82,7 @@ const localeValues: Locale = {
     copy: 'kopiëren',
     copied: 'Gekopieerd',
     expand: 'Uitklappen',
+    collapse: 'Samenvouwen',
   },
   Form: {
     optional: '(optioneel)',
@@ -128,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} komt niet overeen met het patroon ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR-code verlopen',
+    refresh: 'Vernieuwen',
+    scanned: 'Gescand',
+  },
+  ColorPicker: {
+    presetEmpty: 'Leeg',
+    transparent: 'Transparant',
+    singleColor: 'Enkele kleur',
+    gradientColor: 'Kleurverloop',
   },
 }
 

--- a/packages/antdv-next/src/locale/pl_PL.ts
+++ b/packages/antdv-next/src/locale/pl_PL.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Wybierz',
     close: 'Zamknij',
+    sortable: 'sortowalne',
   },
   Table: {
     filterTitle: 'Menu filtra',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Wybierz wszystkie',
     removeAll: 'Usuń wszystkie',
     selectInvert: 'Odwróć wybór',
+    deselectAll: 'Odznacz wszystkie dane',
   },
   Upload: {
     uploading: 'Wysyłanie...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Kopiuj',
     copied: 'Skopiowany',
     expand: 'Rozwiń',
+    collapse: 'Zwiń',
   },
   Form: {
     optional: '(opcjonalne)',
@@ -130,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} nie posiada wartości zgodnej ze wzorem ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'Kod QR wygasł',
+    refresh: 'Odśwież',
+    scanned: 'Zeskanowano',
+  },
+  ColorPicker: {
+    presetEmpty: 'Pusty',
+    transparent: 'Przezroczysty',
+    singleColor: 'Pojedynczy kolor',
+    gradientColor: 'Kolor gradientowy',
   },
 }
 

--- a/packages/antdv-next/src/locale/pt_BR.ts
+++ b/packages/antdv-next/src/locale/pt_BR.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Por favor escolha',
     close: 'Fechar',
+    sortable: 'classificável',
   },
   Table: {
     filterTitle: 'Menu de Filtro',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Selecionar todos',
     removeAll: 'Remover todos',
     selectInvert: 'Inverter seleção atual',
+    deselectAll: 'Desmarcar todos os dados',
   },
   Upload: {
     uploading: 'Enviando...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'copiar',
     copied: 'copiado',
     expand: 'expandir',
+    collapse: 'Recolher',
   },
   Form: {
     optional: '(opcional)',

--- a/packages/antdv-next/src/locale/pt_PT.ts
+++ b/packages/antdv-next/src/locale/pt_PT.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Por favor, selecione',
     close: 'Fechar',
+    sortable: 'classificável',
   },
   Table: {
     filterTitle: 'Filtro',

--- a/packages/antdv-next/src/locale/ro_RO.ts
+++ b/packages/antdv-next/src/locale/ro_RO.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Selectează',
     close: 'Închide',
+    sortable: 'sortabil',
   },
   Table: {
     filterTitle: 'Filtrează',
@@ -33,6 +34,8 @@ const localeValues: Locale = {
     triggerDesc: 'Apasă pentru ordonare descrescătoare',
     triggerAsc: 'Apasă pentru ordonare crescătoare',
     cancelSort: 'Apasă pentru a anula ordonarea',
+    filterCheckAll: 'Selectați toate elementele',
+    filterSearchPlaceholder: 'Caută în filtre',
   },
   Tour: {
     Next: 'Următorul',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Selectează toate datele',
     removeAll: 'Șterge toate datele',
     selectInvert: 'Inversează pagina curentă',
+    deselectAll: 'Deselectați toate datele',
   },
   Upload: {
     uploading: 'Se transferă...',
@@ -78,6 +82,7 @@ const localeValues: Locale = {
     copy: 'copiază',
     copied: 'copiat',
     expand: 'extinde',
+    collapse: 'Colaps',
   },
   Form: {
     optional: '(opțional)',
@@ -128,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} nu respectă șablonul ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'Codul QR a expirat',
+    refresh: 'Reîmprospătați',
+    scanned: 'Scanat',
+  },
+  ColorPicker: {
+    presetEmpty: 'Gol',
+    transparent: 'Transparent',
+    singleColor: 'O singură culoare',
+    gradientColor: 'Culoare gradient',
   },
 }
 

--- a/packages/antdv-next/src/locale/ru_RU.ts
+++ b/packages/antdv-next/src/locale/ru_RU.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Пожалуйста выберите',
     close: 'Закрыть',
+    sortable: 'сортируемый',
   },
   Table: {
     filterTitle: 'Фильтр',
@@ -136,6 +137,7 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'QR-код устарел',
     refresh: 'Обновить',
+    scanned: 'Отсканировано',
   },
   ColorPicker: {
     presetEmpty: 'Пустой',

--- a/packages/antdv-next/src/locale/si_LK.ts
+++ b/packages/antdv-next/src/locale/si_LK.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'කරුණාකර තෝරන්න',
     close: 'වසන්න',
+    sortable: 'වර්ග කළ හැකි',
   },
   Table: {
     filterTitle: 'පෙරහන්',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'සියළු දත්ත තෝරන්න',
     removeAll: 'සියළු දත්ත ඉවතලන්න',
     selectInvert: 'වත්මන් පිටුව යටියනය',
+    deselectAll: 'සියලු දත්ත තේරීම ඉවත් කරන්න',
   },
   Upload: {
     uploading: 'උඩුගත වෙමින්...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'පිටපත්',
     copied: 'පිටපත් විය',
     expand: 'විහිදුවන්න',
+    collapse: 'හකුළන්න',
   },
   Form: {
     optional: '(විකල්පයකි)',
@@ -130,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${pattern} රටාවට ${label} නොගැළපේ',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR කේතය කල් ඉකුත් විය',
+    refresh: 'නැවුම් කරන්න',
+    scanned: 'ස්කෑන් කළා',
+  },
+  ColorPicker: {
+    presetEmpty: 'හිස්',
+    transparent: 'විනිවිද පෙනෙන',
+    singleColor: 'තනි වර්ණය',
+    gradientColor: 'Gradient වර්ණය',
   },
 }
 

--- a/packages/antdv-next/src/locale/sk_SK.ts
+++ b/packages/antdv-next/src/locale/sk_SK.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Prosím vyber',
     close: 'Zavrieť',
+    sortable: 'zoradiť',
   },
   Table: {
     filterTitle: 'Filter',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Označ všetko',
     removeAll: 'Odznač všetko',
     selectInvert: 'Opačný výber',
+    deselectAll: 'Zrušte výber všetkých údajov',
   },
   Upload: {
     uploading: 'Nahrávanie...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Kopírovať',
     copied: 'Skopírované',
     expand: 'Zväčšiť',
+    collapse: 'kolaps',
   },
   Form: {
     optional: '(nepovinné)',
@@ -130,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} nezodpovedá vzoru ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'Platnosť QR kódu vypršala',
+    refresh: 'Obnoviť',
+    scanned: 'Naskenované',
+  },
+  ColorPicker: {
+    presetEmpty: 'Prázdny',
+    transparent: 'Transparentné',
+    singleColor: 'Jednofarebné',
+    gradientColor: 'Farba prechodu',
   },
 }
 

--- a/packages/antdv-next/src/locale/sl_SI.ts
+++ b/packages/antdv-next/src/locale/sl_SI.ts
@@ -13,6 +13,8 @@ const localeValues: Locale = {
   Calendar,
   global: {
     close: 'Zapri',
+    placeholder: 'Prosim izberite',
+    sortable: 'razvrstljiv',
   },
   Table: {
     filterTitle: 'Filter',
@@ -20,6 +22,18 @@ const localeValues: Locale = {
     filterReset: 'Pobriši filter',
     selectAll: 'Izberi vse na trenutni strani',
     selectInvert: 'Obrni izbor na trenutni strani',
+    filterEmptyText: 'Brez filtrov',
+    filterCheckAll: 'Izberite vse elemente',
+    filterSearchPlaceholder: 'Išči v filtrih',
+    emptyText: 'Ni podatkov',
+    selectNone: 'Počisti vse podatke',
+    selectionAll: 'Izberite vse podatke',
+    sortTitle: 'Razvrsti',
+    expand: 'Razširi vrstico',
+    collapse: 'Strni vrstico',
+    triggerDesc: 'Kliknite za razvrščanje padajoče',
+    triggerAsc: 'Kliknite za razvrščanje naraščajoče',
+    cancelSort: 'Kliknite za preklic razvrščanja',
   },
   Tour: {
     Next: 'Naprej',
@@ -40,6 +54,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'Išči tukaj',
     itemUnit: 'Objekt',
     itemsUnit: 'Objektov',
+    remove: 'Odstrani',
+    selectAll: 'Izberite vse podatke',
+    deselectAll: 'Počisti vse podatke',
+    selectCurrent: 'Izberite trenutno stran',
+    selectInvert: 'Obrni trenutno stran',
+    removeAll: 'Odstrani vse podatke',
+    removeCurrent: 'Odstrani trenutno stran',
   },
   Upload: {
     uploading: 'Nalaganje...',
@@ -50,6 +71,24 @@ const localeValues: Locale = {
   },
   Empty: {
     description: 'Ni podatkov',
+  },
+  Text: {
+    edit: 'Uredi',
+    copy: 'Kopiraj',
+    copied: 'Kopirano',
+    expand: 'Razširi',
+    collapse: 'Strni',
+  },
+  QRCode: {
+    expired: 'Koda QR je potekla',
+    refresh: 'Osveži',
+    scanned: 'skenirano',
+  },
+  ColorPicker: {
+    presetEmpty: 'prazno',
+    transparent: 'Transparentna',
+    singleColor: 'Enobarvna',
+    gradientColor: 'Prelivna barva',
   },
 }
 

--- a/packages/antdv-next/src/locale/sr_RS.ts
+++ b/packages/antdv-next/src/locale/sr_RS.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Izaberi',
     close: 'Zatvori',
+    sortable: 'sortabilno',
   },
   Table: {
     filterTitle: 'Meni filtera',
@@ -33,6 +34,8 @@ const localeValues: Locale = {
     triggerDesc: 'Klikni da sortiraš po padajućem redosledu',
     triggerAsc: 'Klikni da sortiraš po rastućem redosledu',
     cancelSort: 'Klikni da otkažeš sortiranje',
+    filterCheckAll: 'Изаберите све ставке',
+    filterSearchPlaceholder: 'Тражи у филтерима',
   },
   Tour: {
     Next: 'Sledeće',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Izaberi sve podatke',
     removeAll: 'Ukloni sve podatke',
     selectInvert: 'Obrni izbor trenutne stranice',
+    deselectAll: 'Опозовите избор свих података',
   },
   Upload: {
     uploading: 'Otpremanje...',
@@ -78,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Kopiraj',
     copied: 'Kopirano',
     expand: 'Proširi',
+    collapse: 'Колапс',
   },
   Form: {
     optional: '(opcionalno)',
@@ -128,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} ne odgovara obrascu ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'КР код је истекао',
+    refresh: 'Освежи',
+    scanned: 'Скенирано',
+  },
+  ColorPicker: {
+    presetEmpty: 'Празан',
+    transparent: 'Транспарент',
+    singleColor: 'Једнобојна',
+    gradientColor: 'Градијентна боја',
   },
 }
 

--- a/packages/antdv-next/src/locale/sv_SE.ts
+++ b/packages/antdv-next/src/locale/sv_SE.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Vänligen välj',
     close: 'Stäng',
+    sortable: 'sorterbar',
   },
   Table: {
     filterTitle: 'Filtermeny',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'Markera all data',
     removeAll: 'Ta bort all data',
     selectInvert: 'Invertera nuvarande sida',
+    deselectAll: 'Avmarkera all data',
   },
   Upload: {
     uploading: 'Laddar upp...',
@@ -80,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Kopiera',
     copied: 'Kopierad',
     expand: 'Expandera',
+    collapse: 'Kollapsa',
   },
   Form: {
     optional: '(valfritt)',
@@ -134,6 +137,13 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'QR-koden har upphört att gälla',
     refresh: 'Uppdatera',
+    scanned: 'Skannat',
+  },
+  ColorPicker: {
+    presetEmpty: 'Tom',
+    transparent: 'Transparent',
+    singleColor: 'Enfärgad',
+    gradientColor: 'Gradient färg',
   },
 }
 

--- a/packages/antdv-next/src/locale/ta_IN.ts
+++ b/packages/antdv-next/src/locale/ta_IN.ts
@@ -17,6 +17,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'தேதியைத் தேர்ந்தெடுக்கவும்',
     close: 'மூடு',
+    sortable: 'வரிசைப்படுத்தக்கூடிய',
   },
   Table: {
     filterTitle: 'பட்டியலை மூடு',
@@ -34,6 +35,8 @@ const localeValues: Locale = {
     triggerDesc: 'இறங்குவரிசையை வரிசைப்படுத்த கிளிக் செய்யவும்',
     triggerAsc: 'ஏறுவரிசையில் வரிசைப்படுத்த கிளிக் செய்யவும்',
     cancelSort: 'வரிசையாக்கத்தை ரத்து செய்ய கிளிக் செய்யவும்',
+    selectNone: 'எல்லா தரவையும் அழிக்கவும்',
+    selectionAll: 'எல்லா தரவையும் தேர்ந்தெடுக்கவும்',
   },
   Tour: {
     Next: 'அடுத்தது',
@@ -55,6 +58,13 @@ const localeValues: Locale = {
     searchPlaceholder: 'இங்கு தேடவும்',
     itemUnit: 'தகவல்',
     itemsUnit: 'தகவல்கள்',
+    remove: 'அகற்று',
+    selectAll: 'எல்லா தரவையும் தேர்ந்தெடுக்கவும்',
+    deselectAll: 'எல்லா தரவையும் தேர்வுநீக்கவும்',
+    selectCurrent: 'தற்போதைய பக்கத்தைத் தேர்ந்தெடுக்கவும்',
+    selectInvert: 'தற்போதைய பக்கத்தை மாற்றவும்',
+    removeAll: 'எல்லா தரவையும் அகற்று',
+    removeCurrent: 'தற்போதைய பக்கத்தை அகற்று',
   },
   Upload: {
     uploading: 'பதிவேற்றுகிறது...',
@@ -74,6 +84,7 @@ const localeValues: Locale = {
     copy: 'நகல் எடு',
     copied: 'நகல் எடுக்கப்பட்டது',
     expand: 'விரிவாக்கவும்',
+    collapse: 'சுருக்கு',
   },
   Form: {
     optional: '(optional)',
@@ -128,6 +139,13 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'QR குறியீடு காலாவதியானது',
     refresh: 'புதுப்பிப்பு',
+    scanned: 'ஸ்கேன் செய்யப்பட்டது',
+  },
+  ColorPicker: {
+    presetEmpty: 'காலி',
+    transparent: 'வெளிப்படையானது',
+    singleColor: 'ஒற்றை நிறம்',
+    gradientColor: 'சாய்வு நிறம்',
   },
 }
 

--- a/packages/antdv-next/src/locale/tests/completeness.test.ts
+++ b/packages/antdv-next/src/locale/tests/completeness.test.ts
@@ -1,0 +1,33 @@
+import type { Locale } from '..'
+import { describe, expect, it } from 'vitest'
+import enUS from '../en_US'
+import zhCN from '../zh_CN'
+
+// https://github.com/ant-design/ant-design/pull/58575
+describe('locale completeness', () => {
+  const modules = import.meta.glob<Locale>('../*.ts', { eager: true, import: 'default' })
+  const locales = Object.entries(modules).filter(
+    ([, locale]) => locale && typeof locale.locale === 'string',
+  )
+
+  it('collects all locale files', () => {
+    expect(locales.length).toBeGreaterThan(70)
+  })
+
+  it('every locale provides global.sortable', () => {
+    const missing = locales
+      .filter(([, locale]) => typeof locale.global?.sortable !== 'string')
+      .map(([file]) => file)
+    expect(missing).toEqual([])
+  })
+
+  it('base locales provide the newly added fields', () => {
+    for (const locale of [zhCN, enUS]) {
+      expect(typeof locale.Transfer?.deselectAll).toBe('string')
+      expect(typeof locale.QRCode?.scanned).toBe('string')
+      expect(typeof locale.ColorPicker?.presetEmpty).toBe('string')
+      expect(typeof locale.Table?.filterCheckAll).toBe('string')
+      expect(typeof (locale as any).Text?.collapse).toBe('string')
+    }
+  })
+})

--- a/packages/antdv-next/src/locale/th_TH.ts
+++ b/packages/antdv-next/src/locale/th_TH.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'กรุณาเลือก',
     close: 'ปิด',
+    sortable: 'จัดเรียงได้',
   },
   Table: {
     filterTitle: 'ตัวกรอง',

--- a/packages/antdv-next/src/locale/tk_TK.ts
+++ b/packages/antdv-next/src/locale/tk_TK.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Saýlaň',
     close: 'Ýagty',
+    sortable: 'tertipli',
   },
   Table: {
     filterTitle: 'Filter',
@@ -33,6 +34,8 @@ const localeValues: Locale = {
     triggerDesc: 'Kemelýän tertipde tertiple',
     triggerAsc: 'Artýan tertipde tertiple',
     cancelSort: 'Tertipleri arassala',
+    filterCheckAll: 'Itemshli elementleri saýlaň',
+    filterSearchPlaceholder: 'Süzgüçlerde gözläň',
   },
   Tour: {
     Next: 'Indiki',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
     selectInvert: 'Ters tertipde görkez',
     removeAll: 'Ähli maglumatlary poz',
     removeCurrent: 'Şu sahypany poz',
+    deselectAll: 'Datahli maglumatlary aýyryň',
   },
   Upload: {
     uploading: 'Ugradylýar...',
@@ -78,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Göçürmek',
     copied: 'Göçürildi',
     expand: 'Ýygnamak',
+    collapse: 'Apseykylmak',
   },
   Form: {
     defaultValidateMessages: {
@@ -126,6 +131,17 @@ const localeValues: Locale = {
         mismatch: '${label} meýdany ${pattern} şablony bilen gabat gelmeýär',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR kody gutardy',
+    refresh: 'Täzele',
+    scanned: 'Skanirlendi',
+  },
+  ColorPicker: {
+    presetEmpty: 'Boş',
+    transparent: 'Aç-açan',
+    singleColor: 'Coloreke reňk',
+    gradientColor: 'Gradient reňki',
   },
 }
 

--- a/packages/antdv-next/src/locale/tr_TR.ts
+++ b/packages/antdv-next/src/locale/tr_TR.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Lütfen seçiniz',
     close: 'Kapat',
+    sortable: 'sıralanabilir',
   },
   Table: {
     filterTitle: 'Filtre menüsü',
@@ -32,6 +33,9 @@ const localeValues: Locale = {
     triggerDesc: 'Azalan düzende sırala',
     triggerAsc: 'Artan düzende sırala',
     cancelSort: 'Sıralamayı kaldır',
+    filterSearchPlaceholder: 'Filtrelerde ara',
+    emptyText: 'Veri yok',
+    selectNone: 'Tüm verileri temizle',
   },
   Tour: {
     Next: 'Sonraki',
@@ -129,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} şu kalıpla eşleşmeli: ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR kodunun süresi doldu',
+    refresh: 'Yenile',
+    scanned: 'Tarandı',
+  },
+  ColorPicker: {
+    presetEmpty: 'Boş',
+    transparent: 'Şeffaf',
+    singleColor: 'Tek renk',
+    gradientColor: 'Gradyan rengi',
   },
 }
 

--- a/packages/antdv-next/src/locale/uk_UA.ts
+++ b/packages/antdv-next/src/locale/uk_UA.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Будь ласка, оберіть',
     close: 'Закрити',
+    sortable: 'сортувальний',
   },
   Table: {
     filterTitle: 'Фільтрувати',
@@ -81,6 +82,7 @@ const localeValues: Locale = {
     copy: 'Скопіювати',
     copied: 'Скопійовано',
     expand: 'Розширити',
+    collapse: 'Згорнути',
   },
   Form: {
     optional: '(опціонально)',
@@ -135,6 +137,13 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'QR-код закінчився',
     refresh: 'Оновити',
+    scanned: 'Відскановані',
+  },
+  ColorPicker: {
+    presetEmpty: 'Порожній',
+    transparent: 'Прозорий',
+    singleColor: 'Одноколірний',
+    gradientColor: 'Градієнтний колір',
   },
 }
 

--- a/packages/antdv-next/src/locale/ur_PK.ts
+++ b/packages/antdv-next/src/locale/ur_PK.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'منتخب کریں',
     close: 'بند کریں',
+    sortable: 'قابل ترتیب',
   },
   Table: {
     filterTitle: 'فلٹر مینو',
@@ -33,6 +34,8 @@ const localeValues: Locale = {
     triggerDesc: 'نزولی کو ترتیب دینے کیلئے کلک کریں',
     triggerAsc: 'چڑھنے کو ترتیب دینے کیلئے کلک کریں',
     cancelSort: 'ترتیب کو منسوخ کرنے کیلئے دبائیں',
+    filterCheckAll: 'تمام اشیاء کو منتخب کریں۔',
+    filterSearchPlaceholder: 'فلٹرز میں تلاش کریں۔',
   },
   Tour: {
     Next: 'اگلا',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
     selectAll: 'تمام ڈیٹا کو منتخب کریں',
     removeAll: 'تمام ڈیٹا کو ہٹا دیں',
     selectInvert: 'موجودہ صفحے کو الٹ دیں',
+    deselectAll: 'تمام ڈیٹا کو غیر منتخب کریں۔',
   },
   Upload: {
     uploading: 'اپ لوڈ ہو رہا ہے…',
@@ -78,6 +82,7 @@ const localeValues: Locale = {
     copy: 'کاپی',
     copied: 'کاپی ہوگیا',
     expand: 'پھیلائیں',
+    collapse: 'سمٹنا',
   },
   Form: {
     optional: '(اختیاری)',
@@ -128,6 +133,17 @@ const localeValues: Locale = {
         mismatch: '${label} پیٹرن سے ملتا نہیں ہے ${pattern}',
       },
     },
+  },
+  QRCode: {
+    expired: 'QR کوڈ کی میعاد ختم ہو گئی۔',
+    refresh: 'ریفریش کریں۔',
+    scanned: 'سکین کیا گیا۔',
+  },
+  ColorPicker: {
+    presetEmpty: 'خالی',
+    transparent: 'شفاف',
+    singleColor: 'سنگل رنگ',
+    gradientColor: 'تدریجی رنگ',
   },
 }
 

--- a/packages/antdv-next/src/locale/uz_UZ.ts
+++ b/packages/antdv-next/src/locale/uz_UZ.ts
@@ -21,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Iltimos tanlang',
     close: 'Yopish',
+    sortable: 'saralanadigan',
   },
   Table: {
     filterTitle: 'Filtr',
@@ -66,6 +67,7 @@ const localeValues: Locale = {
     selectInvert: 'Tanlovni aylantirish',
     removeAll: 'Barcha ma\'lumotlarni o\'chirish',
     removeCurrent: 'Joriy sahifani o\'chirish',
+    deselectAll: 'Barcha ma\'lumotlarni bekor qiling',
   },
   Upload: {
     uploading: 'Yuklanmoqda...',
@@ -85,6 +87,7 @@ const localeValues: Locale = {
     copy: 'Nusxalash',
     copied: 'Nusxalandi',
     expand: 'Ochib qoyish',
+    collapse: 'Yiqilish',
   },
   Form: {
     optional: '(shart emas)',
@@ -139,6 +142,13 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'QR-kod eskirgan',
     refresh: 'Yangilash',
+    scanned: 'Skanerlangan',
+  },
+  ColorPicker: {
+    presetEmpty: 'Bo\'sh',
+    transparent: 'Shaffof',
+    singleColor: 'Yagona rang',
+    gradientColor: 'Gradient rangi',
   },
 }
 

--- a/packages/antdv-next/src/locale/vi_VN.ts
+++ b/packages/antdv-next/src/locale/vi_VN.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Vui lòng chọn',
     close: 'Đóng',
+    sortable: 'có thể sắp xếp được',
   },
   Table: {
     filterTitle: 'Bộ lọc',

--- a/packages/antdv-next/src/locale/zh_CN.ts
+++ b/packages/antdv-next/src/locale/zh_CN.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: '请选择',
     close: '关闭',
+    sortable: '可排序',
   },
   Table: {
     filterTitle: '筛选',

--- a/packages/antdv-next/src/locale/zh_HK.ts
+++ b/packages/antdv-next/src/locale/zh_HK.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: '請選擇',
     close: '關閉',
+    sortable: '可排序',
   },
   Table: {
     filterTitle: '篩選器',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: '全選所有',
     removeAll: '刪除全部',
     selectInvert: '反選當頁',
+    deselectAll: '取消全選',
   },
   Upload: {
     uploading: '正在上傳...',

--- a/packages/antdv-next/src/locale/zh_TW.ts
+++ b/packages/antdv-next/src/locale/zh_TW.ts
@@ -16,6 +16,7 @@ const localeValues: Locale = {
   global: {
     placeholder: '請選擇',
     close: '關閉',
+    sortable: '可排序',
   },
   Table: {
     filterTitle: '篩選器',
@@ -61,6 +62,7 @@ const localeValues: Locale = {
     selectAll: '全選所有',
     removeAll: '删除全部',
     selectInvert: '反選當頁',
+    deselectAll: '取消全選',
   },
   Upload: {
     uploading: '正在上傳...',

--- a/packages/antdv-next/src/table/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/table/tests/__snapshots__/demo.test.tsx.snap
@@ -2051,6 +2051,554 @@ exports[`table demo > renders ajax correctly 1`] = `
 </div>
 `;
 
+exports[`table demo > renders auto-height correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-start ant-flex-gap-middle ant-flex-vertical"
+>
+  <button
+    aria-checked="true"
+    checked="true"
+    class="ant-switch css-var-root ant-switch-checked"
+    role="switch"
+    type="button"
+  >
+    <div
+      class="ant-switch-handle"
+    >
+      <!---->
+    </div>
+    <span
+      class="ant-switch-inner"
+    >
+      <span
+        class="ant-switch-inner-checked"
+      >
+        More Data
+      </span>
+      <span
+        class="ant-switch-inner-unchecked"
+      >
+        More Data
+      </span>
+    </span>
+  </button>
+  <div
+    style="height: 400px; box-sizing: border-box; background: rgba(140, 140, 140, 0.03); padding: 16px; align-self: stretch;"
+  >
+    <div
+      class="css-var-root ant-table-css-var ant-table-wrapper"
+      data-allow-mismatch="true"
+      style="height: 100%;"
+    >
+      <div
+        aria-busy="false"
+        aria-live="polite"
+        class="ant-spin css-var-root"
+      >
+        <!---->
+        <div
+          class="ant-spin-container"
+        >
+          <div
+            class="ant-table css-var-root ant-table-css-var ant-table-fixed-header"
+          >
+            <!---->
+            <div
+              class="ant-table-container"
+              style="height: 0px;"
+            >
+              <div
+                class="ant-table-header"
+                scroll="[object Object]"
+                style="overflow: hidden;"
+              >
+                <table
+                  style="table-layout: fixed; min-width: 100%;"
+                >
+                  <colgroup>
+                    <col
+                      style="width: 20%;"
+                    />
+                    <col
+                      style="width: 20%;"
+                    />
+                    <col
+                      style="width: 60%;"
+                    />
+                  </colgroup>
+                  <thead
+                    class="ant-table-thead measure-header"
+                  >
+                    <tr
+                      class=""
+                    >
+                      <th
+                        class="ant-table-cell"
+                        colend="0"
+                        colstart="0"
+                        scope="col"
+                      >
+                        <!---->
+                        Name
+                      </th>
+                      <th
+                        class="ant-table-cell"
+                        colend="1"
+                        colstart="1"
+                        scope="col"
+                      >
+                        <!---->
+                        Age
+                      </th>
+                      <th
+                        class="ant-table-cell"
+                        colend="2"
+                        colstart="2"
+                        scope="col"
+                      >
+                        <!---->
+                        Address
+                      </th>
+                    </tr>
+                  </thead>
+                  <!---->
+                </table>
+              </div>
+              <div
+                class="ant-table-body"
+                style="overflow-y: scroll; max-height: 0px;"
+              >
+                <table
+                  style="table-layout: fixed;"
+                >
+                  <!---->
+                  <colgroup>
+                    <col
+                      style="width: 20%;"
+                    />
+                    <col
+                      style="width: 20%;"
+                    />
+                    <col
+                      style="width: 60%;"
+                    />
+                  </colgroup>
+                  <tbody
+                    class="ant-table-tbody"
+                  >
+                    <tr
+                      aria-hidden="true"
+                      class="ant-table-measure-row"
+                      style="height: 0px;"
+                    >
+                      <td
+                        style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                      >
+                        <div
+                          style="height: 0px; overflow: hidden; font-weight: bold;"
+                        >
+                          Name
+                        </div>
+                      </td>
+                      <td
+                        style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                      >
+                        <div
+                          style="height: 0px; overflow: hidden; font-weight: bold;"
+                        >
+                          Age
+                        </div>
+                      </td>
+                      <td
+                        style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                      >
+                        <div
+                          style="height: 0px; overflow: hidden; font-weight: bold;"
+                        >
+                          Address
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="0"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Edward King 0
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        32
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        London, Park Lane no. 0
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="1"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Edward King 1
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        33
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        London, Park Lane no. 1
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="2"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Edward King 2
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        34
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        London, Park Lane no. 2
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="3"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Edward King 3
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        35
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        London, Park Lane no. 3
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="4"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Edward King 4
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        36
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        London, Park Lane no. 4
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="5"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Edward King 5
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        37
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        London, Park Lane no. 5
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="6"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Edward King 6
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        38
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        London, Park Lane no. 6
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="7"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Edward King 7
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        39
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        London, Park Lane no. 7
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="8"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Edward King 8
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        40
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        London, Park Lane no. 8
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="9"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Edward King 9
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        41
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        London, Park Lane no. 9
+                      </td>
+                    </tr>
+                  </tbody>
+                  <!---->
+                </table>
+              </div>
+              <!---->
+              <!---->
+            </div>
+            <!---->
+          </div>
+          <!---->
+          <ul
+            class="ant-pagination ant-table-pagination ant-table-pagination-end measure-pagination css-var-root"
+          >
+            <!---->
+            <li
+              aria-disabled="true"
+              class="ant-pagination-prev ant-pagination-disabled"
+              title="上一页"
+            >
+              <button
+                class="ant-pagination-item-link"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  aria-label="left"
+                  class="anticon anticon-left"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="left"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+              tabindex="0"
+              title="1"
+            >
+              <a
+                rel="nofollow"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-2"
+              tabindex="0"
+              title="2"
+            >
+              <a
+                rel="nofollow"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ant-pagination-item ant-pagination-item-3"
+              tabindex="0"
+              title="3"
+            >
+              <a
+                rel="nofollow"
+              >
+                3
+              </a>
+            </li>
+            <li
+              aria-disabled="false"
+              class="ant-pagination-next"
+              tabindex="0"
+              title="下一页"
+            >
+              <button
+                class="ant-pagination-item-link"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  aria-label="right"
+                  class="anticon anticon-right"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="right"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </li>
+            <!---->
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`table demo > renders basic correctly 1`] = `
 <div
   class="css-var-root ant-table-css-var ant-table-wrapper"
@@ -3904,6 +4452,7 @@ exports[`table demo > renders custom-filter-panel correctly 1`] = `
                     </div>
                   </th>
                   <th
+                    aria-description="sortable"
                     aria-label="Address"
                     class="ant-table-cell ant-table-column-has-sorters"
                     colend="2"
@@ -6167,6 +6716,7 @@ exports[`table demo > renders dynamic-settings correctly 1`] = `
                       Name
                     </th>
                     <th
+                      aria-description="sortable"
                       aria-label="Age"
                       class="ant-table-cell ant-table-column-has-sorters"
                       colend="3"
@@ -6277,6 +6827,7 @@ exports[`table demo > renders dynamic-settings correctly 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-description="sortable"
                       aria-label="Action"
                       class="ant-table-cell ant-table-column-has-sorters"
                       colend="5"
@@ -10331,6 +10882,7 @@ exports[`table demo > renders filter-in-tree correctly 1`] = `
                     </div>
                   </th>
                   <th
+                    aria-description="sortable"
                     aria-label="Age"
                     class="ant-table-cell ant-table-column-has-sorters"
                     colend="1"
@@ -10731,6 +11283,7 @@ exports[`table demo > renders filter-search correctly 1`] = `
                     </div>
                   </th>
                   <th
+                    aria-description="sortable"
                     aria-label="Age"
                     class="ant-table-cell ant-table-column-has-sorters"
                     colend="1"
@@ -11121,6 +11674,7 @@ exports[`table demo > renders fixed-columns correctly 1`] = `
                     Full Name
                   </th>
                   <th
+                    aria-description="sortable"
                     aria-label="Age"
                     class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start ant-table-cell-fix-start-shadow ant-table-column-has-sorters"
                     colend="1"
@@ -17207,6 +17761,7 @@ exports[`table demo > renders grouping-columns correctly 1`] = `
                   class=""
                 >
                   <th
+                    aria-description="sortable"
                     aria-label="Age"
                     class="ant-table-cell ant-table-column-has-sorters"
                     colend="1"
@@ -18490,6 +19045,7 @@ exports[`table demo > renders head correctly 1`] = `
                   class=""
                 >
                   <th
+                    aria-description="sortable"
                     aria-label="Name"
                     class="ant-table-cell ant-table-column-has-sorters"
                     colend="0"
@@ -18573,6 +19129,7 @@ exports[`table demo > renders head correctly 1`] = `
                     </div>
                   </th>
                   <th
+                    aria-description="sortable"
                     aria-label="Age"
                     aria-sort="descending"
                     class="ant-table-cell ant-table-column-sort ant-table-column-has-sorters"
@@ -19517,6 +20074,7 @@ exports[`table demo > renders measure-row-render correctly 1`] = `
                     </div>
                   </th>
                   <th
+                    aria-description="sortable"
                     aria-label="Address"
                     class="ant-table-cell ant-table-column-has-sorters"
                     colend="2"
@@ -20078,6 +20636,7 @@ exports[`table demo > renders multiple-sorter correctly 1`] = `
                     Name
                   </th>
                   <th
+                    aria-description="sortable"
                     aria-label="Chinese Score"
                     class="ant-table-cell ant-table-column-has-sorters"
                     colend="1"
@@ -20145,6 +20704,7 @@ exports[`table demo > renders multiple-sorter correctly 1`] = `
                     <!---->
                   </th>
                   <th
+                    aria-description="sortable"
                     aria-label="Math Score"
                     class="ant-table-cell ant-table-column-has-sorters"
                     colend="2"
@@ -20212,6 +20772,7 @@ exports[`table demo > renders multiple-sorter correctly 1`] = `
                     <!---->
                   </th>
                   <th
+                    aria-description="sortable"
                     aria-label="English Score"
                     class="ant-table-cell ant-table-column-has-sorters"
                     colend="3"
@@ -24840,6 +25401,7 @@ exports[`table demo > renders reset-filter correctly 1`] = `
                     class=""
                   >
                     <th
+                      aria-description="sortable"
                       aria-label="Name"
                       class="ant-table-cell ant-table-cell-ellipsis ant-table-column-has-sorters"
                       colend="0"
@@ -24942,6 +25504,7 @@ exports[`table demo > renders reset-filter correctly 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-description="sortable"
                       aria-label="Age"
                       class="ant-table-cell ant-table-cell-ellipsis ant-table-column-has-sorters"
                       colend="1"
@@ -25010,6 +25573,7 @@ exports[`table demo > renders reset-filter correctly 1`] = `
                       <!---->
                     </th>
                     <th
+                      aria-description="sortable"
                       aria-label="Address"
                       class="ant-table-cell ant-table-cell-ellipsis ant-table-column-has-sorters"
                       colend="2"
@@ -25390,6 +25954,7 @@ exports[`table demo > renders resizable-column correctly 1`] = `
                     />
                   </th>
                   <th
+                    aria-description="sortable"
                     aria-label="Amount"
                     class="resizable-title ant-table-cell ant-table-column-has-sorters"
                     colend="1"


### PR DESCRIPTION
## 同步范围

ant-design `61861c8bc3`(6.5.0) → `85a08c107d`（2026-07-03，master），共 9 个上游提交：4 fix + 3 docs 全部移植，2 个 chore（devcontainer/react-doctor 依赖）跳过。cssinjs 上游无新提交。

| 上游 | 类型 | 内容 | 本 PR 提交 |
|------|------|------|-----------|
| [#58559](https://github.com/ant-design/ant-design/pull/58559) | fix | ConfigProvider：开启 cssinjs `layer` 时强制 `zeroRuntime`，修复 StyleProvider layer 模式下样式丢失 | `fix(config-provider)` |
| [#58584](https://github.com/ant-design/ant-design/pull/58584) | fix | Button：icon 容器 `inline-flex` + `:before` 插入 `\a0` 修正 SVG baseline，解决 Card extra 中图标不对齐（antd #57727/#58428） | `fix(button)` |
| [#58583](https://github.com/ant-design/ant-design/pull/58583) | fix | Descriptions：`-view` 恢复 `width:100%`、内层 table 改 `min-width:100%`，兼顾 Popover 收缩容器（antd #58574）与 max-content 祖先（antd #54268） | `fix(descriptions)` |
| [#58575](https://github.com/ant-design/ant-design/pull/58575) | fix | Locale：70 个语言包补齐缺失字段（`global.sortable`、`Text.collapse`、`Table.filterCheckAll/filterSearchPlaceholder/…`、`Transfer.deselectAll/…`、`QRCode`、`ColorPicker` 区块） | `fix(locale)` |
| [#58545](https://github.com/ant-design/ant-design/pull/58545) | docs | Notification 固定宽度 FAQ | `docs(notification)` |
| [`6467fb7159`](https://github.com/ant-design/ant-design/commit/6467fb7159) | docs | Table 自动填充容器高度 demo（AutoHeightTable 封装，已改写为 Vue） | `docs(table)` |
| [`48aafca06d`](https://github.com/ant-design/ant-design/commit/48aafca06d) | docs | Table 性能排查 FAQ（React DevTools 表述已改写为 Vue DevTools） | `docs(table)` |

## 新增单元测试

- `config-provider/tests/zero-runtime.test.tsx`：layer 模式下 icon 运行时样式不注入/不被重写进 `@layer antd`，layer 内 `.anticon` reset 由 cssinjs 提供（已验证去掉修复后该用例失败）。
- `descriptions/tests/style-extract.test.tsx`：SSR 提取样式断言 `-view` 为 `width:100%`（且无 `width:0`）、内层 table 为 `min-width:100%`。
- `locale/tests/completeness.test.ts`：全部语言包必须提供 `global.sortable`；zh_CN/en_US 断言本次新增各字段齐全。

## 适配说明

- Locale 合并按下游 Locale 类型白名单执行（对象级 diff、只增不改，脚本幂等）；上游 `global.show/hide` 因下游类型尚未支持而未移植。
- `config-provider/tests/static.test.tsx` 原断言编码的是 #58559 修复前的旧行为（运行时样式被重写进 layer），已按上游新语义更新。
- locale 补上 `global.sortable` 后，可排序表头开始输出 `aria-description="sortable"`，相关 demo 快照已刷新。
- 上游 #58545 提交信息里的代码改动在合并前已被裁剪，最终 diff 仅文档，本 PR 同样仅同步文档。

## 同步状态

`.sync-upstream.json` 已推进至 `85a08c107d`（sync_count 16）。
