### PR TITLE
fix(component-overview): align site search focus outline with ant-design

### DIFF
--- a/docs/src/components/component-overview/index.vue
+++ b/docs/src/components/component-overview/index.vue
@@ -171,7 +171,7 @@ onMounted(() => {
   padding: 0;
   font-size: 20px;
   border: 0;
-  box-shadow: none;
+  box-shadow: none !important;
 
   input {
     font-size: 20px;
@@ -179,6 +179,13 @@ onMounted(() => {
 
   .anticon {
     color: var(--ant-color-text-placeholder);
+  }
+
+  // 对齐 ant-design 组件总览搜索框的可访问性覆盖：
+  // borderless 变体在 :focus-visible 时会绘制 outline，这里强制移除
+  &:focus-visible,
+  &:has(input:focus-visible) {
+    outline: none !important;
   }
 }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠️ Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> Aligns the component-overview search a11y CSS override with the upstream ant-design site (`.dumi/theme/builtins/ComponentOverview/index.tsx` -> `componentsOverviewSearch`).

### 💡 Background and Solution

> - The borderless Input variant (`packages/antdv-next/src/input/style/variants.ts`, `genBorderlessFocusVisibleStyle`) draws an `activeBorderColor` outline on `:focus-visible` via `:has(input:focus-visible)` on the affix-wrapper.
> - The component-overview search box uses `variant="borderless"` with a `#suffix` (affix-wrapper structure), so it showed an unwanted focus outline when focused via keyboard.
> - ant-design's site overrides this in its `componentsOverviewSearch` style with `box-shadow: none !important` and `outline: none !important` on `:focus-visible` / `:has(input:focus-visible)`. This PR applies the same override to `docs/src/components/component-overview/index.vue`.
> - Verified that Vue 3.5 scoped CSS handles `:has()` correctly: the scope id is only added to the outer subject (`.components-overview-search`, which lands on the affix-wrapper root where the outline is painted), not to the `input` inside `:has()`, so the override matches the right element.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove the unwanted keyboard-focus outline on the component-overview search box to align with ant-design's site a11y behavior. |
| 🇨🇳 Chinese | 移除组件总览搜索框键盘聚焦时多余的外轮廓（outline），对齐 ant-design 站点的可访问性表现。 |
