### PR TITLE
fix(component-overview): align card hover box-shadow with ant-design

### DIFF
--- a/docs/src/components/component-overview/index.vue
+++ b/docs/src/components/component-overview/index.vue
@@ -145,10 +145,13 @@ onMounted(() => {
 
   &-card {
     cursor: pointer;
-    transition: all 0.5s ease 0s;
+    transition: all 0.5s;
 
     &:hover {
-      box-shadow: var(--shadow-2);
+      box-shadow:
+        0 6px 16px -8px #00000014,
+        0 9px 28px #0000000d,
+        0 12px 48px 16px #00000008;
     }
   }
 


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

无对应 Issue，需求来源于站点视觉对齐：首页「组件总览」卡片 hover 时的 box-shadow 与 ant-design 官网不一致。

### 💡 背景与方案

首页「组件总览」卡片 hover 时的阴影原先写为 `box-shadow: var(--shadow-2)`，但 `--shadow-2` 在整个 docs 中并未定义（仅有 `--vp-shadow-2`，值也不同），导致该声明无效，hover 时没有正确阴影。

对照 ant-design 官网源码 `.dumi/theme/builtins/ComponentOverview/index.tsx` 中的 `componentsOverviewCard`，官网使用的是一段自定义的更大、更柔和的阴影，并配合 `transition: all 0.5s`：

```css
cursor: pointer;
transition: all 0.5s;
&:hover {
  box-shadow:
    0 6px 16px -8px #00000014,
    0 9px 28px #0000000d,
    0 12px 48px 16px #00000008;
}
```

本次将 `docs/src/components/component-overview/index.vue` 的 `&-card` 样式逐字对齐官网：用上述阴影值替换未定义的 `var(--shadow-2)`，并将 `transition: all 0.5s ease 0s` 简化为 `transition: all 0.5s`，使 hover 效果与 ant-design 官网完全一致。

> 注：先前一度尝试改用 Card 组件内置的 `hoverable`，但其对应的是 `boxShadowCard` token（更小更锐的阴影），且会把 `border-color` 置为透明、过渡变为 `motionDurationMid`，均与官网不一致，故改回自定义样式方案。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Fix the homepage component-overview card hover `box-shadow`: the previous `var(--shadow-2)` was undefined so hover had no shadow. Now aligned byte-for-byte with ant-design's official site hover shadow (`0 6px 16px -8px #00000014, 0 9px 28px #0000000d, 0 12px 48px 16px #00000008`) and `transition: all 0.5s`. |
| 🇨🇳 中文 | 修复首页「组件总览」卡片 hover 阴影：原 `var(--shadow-2)` 未定义导致 hover 无阴影。现逐字对齐 ant-design 官网 hover 阴影（`0 6px 16px -8px #00000014, 0 9px 28px #0000000d, 0 12px 48px 16px #00000008`）与 `transition: all 0.5s`。 |
