### PR TITLE
docs: use local Space link in FAQ

### DIFF
--- a/docs/src/pages/docs/vue/faq.en-US.md
+++ b/docs/src/pages/docs/vue/faq.en-US.md
@@ -4,7 +4,7 @@ title: FAQ
 
 ## Components are not vertically aligned when placed in single row.
 
-Try [Space](https://ant.design/components/space/) component to make them aligned.
+Try [Space](/components/space/) component to make them aligned.
 
 ## Date-related components locale is not working?
 


### PR DESCRIPTION
## What

Update the FAQ Space link to use the local component docs route.

## Why

The FAQ belongs to the antdv-next docs site, so keeping the link internal avoids sending readers to the React Ant Design documentation for this Vue component reference.

## Test

- `git diff --check`
- Static check: confirmed the FAQ no longer contains the external Ant Design Space URL and now points to `/components/space/`

Note: ESLint could not run in this fresh checkout because dependencies were not installed (`@antfu/eslint-config` missing).