### PR TITLE
[sync] ant-design 6.5.0 → 96880a4d: Input.Search fix, Grid docs, Layout demo & deps bump

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React 主组件库 -> antdv-next 主包"
         }
       ],
-      "last_synced_commit": "a7a37ce59fbdad431a33dadb2b13c1221cc8145d",
-      "last_synced_commit_short": "a7a37ce59f",
-      "last_synced_at": "2026-07-07T00:00:00Z",
+      "last_synced_commit": "96880a4d40ba1db8a5e16bd9992bc984705e680c",
+      "last_synced_commit_short": "96880a4d40",
+      "last_synced_at": "2026-07-09T00:00:00Z",
       "last_synced_tag": "6.5.0",
-      "sync_count": 17
+      "sync_count": 18
     },
     {
       "name": "cssinjs",

--- a/docs/src/pages/components/grid/index.en-US.md
+++ b/docs/src/pages/components/grid/index.en-US.md
@@ -74,7 +74,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
-| flex | Flex layout style | string \| number | - |  | × |
+| flex | Flex layout style. Number for 'flex: n n auto', string is applied directly (e.g. pure number string 'n' for 'flex: n 1 0') | string \| number | - |  | × |
 | offset | The number of cells to offset Col from the left | number | 0 |  | × |
 | order | Raster order | number | 0 |  | × |
 | pull | The number of cells that raster is moved to the left | number | 0 |  | × |

--- a/docs/src/pages/components/grid/index.zh-CN.md
+++ b/docs/src/pages/components/grid/index.zh-CN.md
@@ -73,7 +73,7 @@ demo:
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
 | --- | --- | --- | --- | --- | --- |
-| flex | flex 布局属性 | string \| number | - |  | × |
+| flex | flex 布局属性。数字类型对应 'flex: n n auto'；字符串类型直接透传（例如纯数字字符串 'n' 对应 'flex: n 1 0'） | string \| number | - |  | × |
 | offset | 栅格左侧的间隔格数，间隔内不可以有栅格 | number | 0 |  | × |
 | order | 栅格顺序 | number | 0 |  | × |
 | pull | 栅格向左移动格数 | number | 0 |  | × |

--- a/docs/src/pages/components/layout/demo/collapsible-overlay.vue
+++ b/docs/src/pages/components/layout/demo/collapsible-overlay.vue
@@ -1,0 +1,113 @@
+<docs lang="zh-CN">
+通过贴附在 Sider 边缘的自定义触发器控制收起展开。展开后的 Sider 可以通过业务样式脱离文档流并覆盖内容，避免挤压内容区域。
+</docs>
+
+<docs lang="en-US">
+Use a custom trigger attached to the Sider edge to collapse or expand it. The expanded Sider can leave the document flow and overlay the content with business styles to avoid squeezing the content area.
+</docs>
+
+<script setup lang="ts">
+import type { MenuItemType } from 'antdv-next'
+import {
+  DesktopOutlined,
+  FileOutlined,
+  MenuFoldOutlined,
+  MenuUnfoldOutlined,
+  PieChartOutlined,
+  TeamOutlined,
+} from '@antdv-next/icons'
+import { theme } from 'antdv-next'
+import { ref } from 'vue'
+
+const { token } = theme.useToken()
+
+const collapsed = ref(false)
+
+const items: MenuItemType[] = [
+  { key: '1', icon: PieChartOutlined, label: 'nav 1' },
+  { key: '2', icon: DesktopOutlined, label: 'nav 2' },
+  { key: '3', icon: TeamOutlined, label: 'nav 3' },
+  { key: '4', icon: FileOutlined, label: 'nav 4' },
+]
+
+const currentYear = new Date().getFullYear()
+</script>
+
+<template>
+  <a-layout class="overlay-layout">
+    <a-layout-sider
+      v-model:collapsed="collapsed"
+      collapsible
+      collapsed-width="0"
+      class="overlay-sider"
+    >
+      <template #trigger>
+        <MenuUnfoldOutlined v-if="collapsed" />
+        <MenuFoldOutlined v-else />
+      </template>
+      <div class="demo-logo-vertical" />
+      <a-menu
+        theme="dark"
+        mode="inline"
+        :default-selected-keys="['1']"
+        :items="items"
+      />
+    </a-layout-sider>
+    <a-layout>
+      <a-layout-header class="overlay-header" :style="{ background: token.colorBgContainer }" />
+      <a-layout-content class="overlay-content">
+        <div
+          class="overlay-content-inner"
+          :style="{
+            background: token.colorBgContainer,
+            borderRadius: `${token.borderRadiusLG}px`,
+          }"
+        >
+          Content keeps its full width when the sider overlays it.
+        </div>
+      </a-layout-content>
+      <a-layout-footer class="overlay-footer">
+        Antdv Next ©{{ currentYear }} Created by Ant UED
+      </a-layout-footer>
+    </a-layout>
+  </a-layout>
+</template>
+
+<style scoped>
+.overlay-layout {
+  position: relative;
+  min-height: 360px;
+}
+
+.overlay-sider {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  inset-inline-start: 0;
+  z-index: 10;
+}
+
+.overlay-header {
+  padding: 0;
+}
+
+.overlay-content {
+  margin: 24px 16px 0;
+}
+
+.overlay-content-inner {
+  padding: 24px;
+  min-height: 240px;
+}
+
+.overlay-footer {
+  text-align: center;
+}
+
+.demo-logo-vertical {
+  height: 32px;
+  margin: 16px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+}
+</style>

--- a/docs/src/pages/components/layout/index.en-US.md
+++ b/docs/src/pages/components/layout/index.en-US.md
@@ -64,6 +64,7 @@ Style of a navigation should conform to its level.
   <demo src="./demo/top-side-2.vue" compact background="grey">Header Sider 2</demo>
   <demo src="./demo/side.vue" iframe="360">Sider</demo>
   <demo src="./demo/custom-trigger.vue" compact background="grey">Custom trigger</demo>
+  <demo src="./demo/collapsible-overlay.vue" compact background="grey">Collapsible overlay</demo>
   <demo src="./demo/responsive.vue" compact background="grey">Responsive</demo>
   <demo src="./demo/fixed.vue" iframe="360">Fixed Header</demo>
   <demo src="./demo/fixed-sider.vue" iframe="360">Fixed Sider</demo>

--- a/docs/src/pages/components/layout/index.zh-CN.md
+++ b/docs/src/pages/components/layout/index.zh-CN.md
@@ -65,6 +65,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
   <demo src="./demo/top-side-2.vue" compact background="grey">顶部-侧边布局-通栏</demo>
   <demo src="./demo/side.vue" iframe="360">侧边布局</demo>
   <demo src="./demo/custom-trigger.vue" compact background="grey">自定义触发器</demo>
+  <demo src="./demo/collapsible-overlay.vue" compact background="grey">折叠覆盖布局</demo>
   <demo src="./demo/responsive.vue" compact background="grey">响应式布局</demo>
   <demo src="./demo/fixed.vue" iframe="360">固定头部</demo>
   <demo src="./demo/fixed-sider.vue" iframe="360">固定侧边栏</demo>

--- a/packages/antdv-next/src/input/style/search.ts
+++ b/packages/antdv-next/src/input/style/search.ts
@@ -30,6 +30,10 @@ const genSearchStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
       [btnCls]: {
         height: varRef('btn-height'),
 
+        '&:focus-visible': {
+          zIndex: 5,
+        },
+
         [`&${antCls}-btn-icon-only`]: {
           width: varRef('btn-height'),
         },

--- a/packages/antdv-next/src/layout/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/layout/tests/__snapshots__/demo.test.tsx.snap
@@ -151,6 +151,240 @@ exports[`layout demo > renders basic correctly 1`] = `
 </div>
 `;
 
+exports[`layout demo > renders collapsible-overlay correctly 1`] = `
+<div
+  class="ant-layout ant-layout-has-sider overlay-layout css-var-root"
+  data-v-bc6c39d9=""
+>
+  <aside
+    class="ant-layout-sider ant-layout-sider-dark overlay-sider css-var-root"
+    data-v-bc6c39d9=""
+    style="flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;"
+  >
+    <div
+      class="ant-layout-sider-children"
+    >
+      <div
+        class="demo-logo-vertical"
+        data-v-bc6c39d9=""
+      />
+      <ul
+        class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark css-var-root ant-menu-css-var"
+        data-menu-list="true"
+        role="menu"
+        tabindex="0"
+      >
+        <!---->
+        <li
+          class="ant-menu-item ant-menu-item-selected"
+          data-menu-id="vc-menu-uuid-1"
+          label="nav 1"
+          role="menuitem"
+          style="padding-left: 24px;"
+          tabindex="-1"
+        >
+          <span
+            aria-label="pie-chart"
+            class="anticon anticon-pie-chart ant-menu-item-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="pie-chart"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M864 518H506V160c0-4.4-3.6-8-8-8h-26a398.46 398.46 0 00-282.8 117.1 398.19 398.19 0 00-85.7 127.1A397.61 397.61 0 0072 552a398.46 398.46 0 00117.1 282.8c36.7 36.7 79.5 65.6 127.1 85.7A397.61 397.61 0 00472 952a398.46 398.46 0 00282.8-117.1c36.7-36.7 65.6-79.5 85.7-127.1A397.61 397.61 0 00872 552v-26c0-4.4-3.6-8-8-8zM705.7 787.8A331.59 331.59 0 01470.4 884c-88.1-.4-170.9-34.9-233.2-97.2C174.5 724.1 140 640.7 140 552c0-88.7 34.5-172.1 97.2-234.8 54.6-54.6 124.9-87.9 200.8-95.5V586h364.3c-7.7 76.3-41.3 147-96.6 201.8zM952 462.4l-2.6-28.2c-8.5-92.1-49.4-179-115.2-244.6A399.4 399.4 0 00589 74.6L560.7 72c-4.7-.4-8.7 3.2-8.7 7.9V464c0 4.4 3.6 8 8 8l384-1c4.7 0 8.4-4 8-8.6zm-332.2-58.2V147.6a332.24 332.24 0 01166.4 89.8c45.7 45.6 77 103.6 90 166.1l-256.4.7z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-menu-title-content"
+          >
+            nav 1
+          </span>
+          <!---->
+        </li>
+        <!---->
+        <li
+          class="ant-menu-item"
+          data-menu-id="vc-menu-uuid-2"
+          label="nav 2"
+          role="menuitem"
+          style="padding-left: 24px;"
+          tabindex="-1"
+        >
+          <span
+            aria-label="desktop"
+            class="anticon anticon-desktop ant-menu-item-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="desktop"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M928 140H96c-17.7 0-32 14.3-32 32v496c0 17.7 14.3 32 32 32h380v112H304c-8.8 0-16 7.2-16 16v48c0 4.4 3.6 8 8 8h432c4.4 0 8-3.6 8-8v-48c0-8.8-7.2-16-16-16H548V700h380c17.7 0 32-14.3 32-32V172c0-17.7-14.3-32-32-32zm-40 488H136V212h752v416z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-menu-title-content"
+          >
+            nav 2
+          </span>
+          <!---->
+        </li>
+        <!---->
+        <li
+          class="ant-menu-item"
+          data-menu-id="vc-menu-uuid-3"
+          label="nav 3"
+          role="menuitem"
+          style="padding-left: 24px;"
+          tabindex="-1"
+        >
+          <span
+            aria-label="team"
+            class="anticon anticon-team ant-menu-item-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="team"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M824.2 699.9a301.55 301.55 0 00-86.4-60.4C783.1 602.8 812 546.8 812 484c0-110.8-92.4-201.7-203.2-200-109.1 1.7-197 90.6-197 200 0 62.8 29 118.8 74.2 155.5a300.95 300.95 0 00-86.4 60.4C345 754.6 314 826.8 312 903.8a8 8 0 008 8.2h56c4.3 0 7.9-3.4 8-7.7 1.9-58 25.4-112.3 66.7-153.5A226.62 226.62 0 01612 684c60.9 0 118.2 23.7 161.3 66.8C814.5 792 838 846.3 840 904.3c.1 4.3 3.7 7.7 8 7.7h56a8 8 0 008-8.2c-2-77-33-149.2-87.8-203.9zM612 612c-34.2 0-66.4-13.3-90.5-37.5a126.86 126.86 0 01-37.5-91.8c.3-32.8 13.4-64.5 36.3-88 24-24.6 56.1-38.3 90.4-38.7 33.9-.3 66.8 12.9 91 36.6 24.8 24.3 38.4 56.8 38.4 91.4 0 34.2-13.3 66.3-37.5 90.5A127.3 127.3 0 01612 612zM361.5 510.4c-.9-8.7-1.4-17.5-1.4-26.4 0-15.9 1.5-31.4 4.3-46.5.7-3.6-1.2-7.3-4.5-8.8-13.6-6.1-26.1-14.5-36.9-25.1a127.54 127.54 0 01-38.7-95.4c.9-32.1 13.8-62.6 36.3-85.6 24.7-25.3 57.9-39.1 93.2-38.7 31.9.3 62.7 12.6 86 34.4 7.9 7.4 14.7 15.6 20.4 24.4 2 3.1 5.9 4.4 9.3 3.2 17.6-6.1 36.2-10.4 55.3-12.4 5.6-.6 8.8-6.6 6.3-11.6-32.5-64.3-98.9-108.7-175.7-109.9-110.9-1.7-203.3 89.2-203.3 199.9 0 62.8 28.9 118.8 74.2 155.5-31.8 14.7-61.1 35-86.5 60.4-54.8 54.7-85.8 126.9-87.8 204a8 8 0 008 8.2h56.1c4.3 0 7.9-3.4 8-7.7 1.9-58 25.4-112.3 66.7-153.5 29.4-29.4 65.4-49.8 104.7-59.7 3.9-1 6.5-4.7 6-8.7z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-menu-title-content"
+          >
+            nav 3
+          </span>
+          <!---->
+        </li>
+        <!---->
+        <li
+          class="ant-menu-item"
+          data-menu-id="vc-menu-uuid-4"
+          label="nav 4"
+          role="menuitem"
+          style="padding-left: 24px;"
+          tabindex="-1"
+        >
+          <span
+            aria-label="file"
+            class="anticon anticon-file ant-menu-item-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="file"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-menu-title-content"
+          >
+            nav 4
+          </span>
+          <!---->
+        </li>
+        <!---->
+        <!---->
+        <!---->
+        <!---->
+      </ul>
+      <div
+        aria-hidden="true"
+        style="display: none;"
+      >
+        <!---->
+        <!---->
+        <!---->
+        <!---->
+      </div>
+    </div>
+    <span
+      class="ant-layout-sider-zero-width-trigger ant-layout-sider-zero-width-trigger-left"
+    >
+      <span
+        aria-label="menu-fold"
+        class="anticon anticon-menu-fold"
+        data-v-bc6c39d9=""
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="menu-fold"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M408 442h480c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8H408c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8zm-8 204c0 4.4 3.6 8 8 8h480c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8H408c-4.4 0-8 3.6-8 8v56zm504-486H120c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zm0 632H120c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zM115.4 518.9L271.7 642c5.8 4.6 14.4.5 14.4-6.9V388.9c0-7.4-8.5-11.5-14.4-6.9L115.4 505.1a8.74 8.74 0 000 13.8z"
+          />
+        </svg>
+      </span>
+    </span>
+  </aside>
+  <div
+    class="ant-layout css-var-root"
+    data-v-bc6c39d9=""
+  >
+    <header
+      class="ant-layout-header overlay-header css-var-root"
+      data-v-bc6c39d9=""
+      style="background: rgb(255, 255, 255);"
+    />
+    <main
+      class="ant-layout-content overlay-content css-var-root"
+      data-v-bc6c39d9=""
+    >
+      <div
+        class="overlay-content-inner"
+        data-v-bc6c39d9=""
+        style="background: rgb(255, 255, 255); border-radius: 8px;"
+      >
+         Content keeps its full width when the sider overlays it. 
+      </div>
+    </main>
+    <footer
+      class="ant-layout-footer overlay-footer css-var-root"
+      data-v-bc6c39d9=""
+    >
+       Antdv Next ©2026 Created by Ant UED 
+    </footer>
+  </div>
+</div>
+`;
+
 exports[`layout demo > renders custom-trigger correctly 1`] = `
 <div
   class="ant-layout ant-layout-has-sider css-var-root"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,8 +405,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@v-c/table':
-      specifier: ^1.1.6
-      version: 1.1.6
+      specifier: ^1.1.7
+      version: 1.1.7
     '@v-c/tabs':
       specifier: ^1.2.1
       version: 1.2.1
@@ -429,8 +429,8 @@ catalogs:
       specifier: ^1.0.0
       version: 1.0.0
     '@v-c/virtual-list':
-      specifier: ^1.0.9
-      version: 1.0.9
+      specifier: ^1.1.0
+      version: 1.1.0
 
 overrides:
   '@v-c/notification': ^2.0.2
@@ -880,7 +880,7 @@ importers:
         version: 1.0.1(vue@3.5.39(typescript@5.9.3))
       '@v-c/table':
         specifier: catalog:vc
-        version: 1.1.6(vue@3.5.39(typescript@5.9.3))
+        version: 1.1.7(vue@3.5.39(typescript@5.9.3))
       '@v-c/tabs':
         specifier: catalog:vc
         version: 1.2.1(vue@3.5.39(typescript@5.9.3))
@@ -910,7 +910,7 @@ importers:
         version: 1.0.21(vue@3.5.39(typescript@5.9.3))
       '@v-c/virtual-list':
         specifier: catalog:vc
-        version: 1.0.9(vue@3.5.39(typescript@5.9.3))
+        version: 1.1.0(vue@3.5.39(typescript@5.9.3))
       '@vueuse/core':
         specifier: catalog:prod
         version: 14.3.0(vue@3.5.39(typescript@5.9.3))
@@ -2866,11 +2866,6 @@ packages:
   '@v-c/async-validator@1.0.1':
     resolution: {integrity: sha512-2WXdbTso13119ZLiwUv1JkmdL0K4ll69id4oE3ft3LQX+YAHOoJtfx080u26lLtypgZS32PguoohgB0BVo39rg==}
 
-  '@v-c/cascader@1.1.1':
-    resolution: {integrity: sha512-KeQdt/9dV7NN+zqvTNLl5eDJNTEL+p1o0mimMbkHH4sCkgzHYY0nxKtBRpDh1uzeSjqiN8YKxx9VvuzVeDkaOg==}
-    peerDependencies:
-      vue: ^3.0.0
-
   '@v-c/cascader@1.1.2':
     resolution: {integrity: sha512-Aa0cXTo4J3d71NjSogjB1fG+yTBGIK5xt/oxqjy/jBcYo0mweOOLrtxSXl+86ZK7LIoWjEE+/MBxRwAR0R4l3w==}
     peerDependencies:
@@ -2878,11 +2873,6 @@ packages:
 
   '@v-c/checkbox@1.0.1':
     resolution: {integrity: sha512-+QsE/0VfU6oeglwuHWYxRNTn3+eV08iG0uN/upDmqSGznezInzfUClh+t4acd/OxyJVtuob0WKsg/vPlT6WRWw==}
-    peerDependencies:
-      vue: ^3.0.0
-
-  '@v-c/collapse@1.0.0':
-    resolution: {integrity: sha512-y4NAl3j4mka193ZMDLHdISA8to61qoROG6/kTQ0myM2ZuEsonnEK1QWlqoEw3gveMsa6a4RdyoXLxdGdcJyp0Q==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -2906,11 +2896,6 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/dropdown@1.0.3':
-    resolution: {integrity: sha512-SnagI71+ffYUa2P5GO6ThXHeHIRcDGGnR2Yk3Y0HUIvMpMQZ8LqXeB9u1um5fIyyRRi/Lz6zyLflbGhX5FWURA==}
-    peerDependencies:
-      vue: ^3.0.0
-
   '@v-c/dropdown@1.0.4':
     resolution: {integrity: sha512-HHIREYqHp5HR6R0Wwgw5jujxTnlhFWrVZS0/H8EQomeLAAJXWAnRxFvT6fWqaIo9S5JFPN7fbjE9vGjNjWzGng==}
     peerDependencies:
@@ -2918,11 +2903,6 @@ packages:
 
   '@v-c/image@1.0.12':
     resolution: {integrity: sha512-SwGOHRSHPiAWlazy+vfwE3dIniIWQLXfl6R0SdlMFbUZ6mbklkym2KqJxj+ZL7psl4tpO+WsgU9IZDMBzXmFPw==}
-    peerDependencies:
-      vue: ^3.0.0
-
-  '@v-c/input-number@1.0.5':
-    resolution: {integrity: sha512-YQBpV1KnuYf0o2XrbC+OEyP6lkyqv1XhzDVh3QhHO2bs/Jr3uSD8b3cxdEGU+gjoNJUcoZx7XiIzcYhLlvMctw==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -2938,11 +2918,6 @@ packages:
 
   '@v-c/input@1.1.1':
     resolution: {integrity: sha512-rEqhP6ULovlFCMaLYlMC3axjSU2hlyBJs/+Bw2N+403H2nreJKjS82n6vgvl/9vMAwTHrkm/jdFxk78WwWDRxw==}
-    peerDependencies:
-      vue: ^3.0.0
-
-  '@v-c/mentions@1.1.2':
-    resolution: {integrity: sha512-KNwrUKLNH/rJU2EV1jzwwGxt8q5J/ovMgWtzGw4+nEO33u1cZ22XFBUfBT0elA79Gz63xVXWFDH7zEQRCjFdIw==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -2983,24 +2958,6 @@ packages:
     resolution: {integrity: sha512-lx8B/kjAA+ABGXSKpm92z5OjKb25UqNcDOUAc0PlYurKZYfn2JG+jTCDS2mGVHV/8PEjiIBT22Xv0XLh3blvIg==}
     peerDependencies:
       vue: ^3.0.0
-
-  '@v-c/picker@1.2.1':
-    resolution: {integrity: sha512-mYqyT1PkfyFbKjbKoTUEMqtnaAY5X8N9A4EX/oWun3fJvQGzkzgTiLA2CjI9EqCrjvL3Nf+l3hhvGZf0O8NPUg==}
-    peerDependencies:
-      date-fns: '>= 2.x'
-      dayjs: '>= 1.x'
-      luxon: '>= 3.x'
-      moment: '>= 2.x'
-      vue: ^3.0.0
-    peerDependenciesMeta:
-      date-fns:
-        optional: true
-      dayjs:
-        optional: true
-      luxon:
-        optional: true
-      moment:
-        optional: true
 
   '@v-c/picker@1.2.2':
     resolution: {integrity: sha512-HaM6cG9MjTfo/g2qFiRRTGfQ4Fb9MhoPrj4k486dJSEE0EFwVEdRDdHURbY10m491OAEFdg/ZwNrIl63SBQBcw==}
@@ -3083,6 +3040,11 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
+  '@v-c/table@1.1.7':
+    resolution: {integrity: sha512-9b/2oMilG78uXkMMiw9Tc2NplpqamxasXdD6Utf0FqCsYW6cDFx2+o5nfUYLYfSQxP2xPq9jhMC701R6tyoDeA==}
+    peerDependencies:
+      vue: ^3.0.0
+
   '@v-c/tabs@1.2.1':
     resolution: {integrity: sha512-rN8F+yFv6Wh7ZPDDY/vmVNh1QScpTErmY3HgdOFH96PrsunSvACCtE8R0Y0ZlbNPP3sIwVCykiyvtxVOstDHCg==}
     peerDependencies:
@@ -3130,6 +3092,11 @@ packages:
 
   '@v-c/virtual-list@1.0.9':
     resolution: {integrity: sha512-Yjbjux9HYDWNPAAJkZuc49DSbkJ2KR5Hft2IzMR9v70FSqzYMbMZVKMVu+k1z86xdlcutT8WObpKMLlRXjdHFg==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@v-c/virtual-list@1.1.0':
+    resolution: {integrity: sha512-EwOdJVe/lx5O8oKtHXZ7SR19GozuI4o70MN58uZfWrPkzOCiYs0flJslcveyVCxPrdqNE2t8XF3lPN+px1Fbqw==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -8433,13 +8400,6 @@ snapshots:
 
   '@v-c/async-validator@1.0.1': {}
 
-  '@v-c/cascader@1.1.1(vue@3.5.39(typescript@5.9.3))':
-    dependencies:
-      '@v-c/select': 1.1.4(vue@3.5.39(typescript@5.9.3))
-      '@v-c/tree': 1.1.1(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
-      vue: 3.5.39(typescript@5.9.3)
-
   '@v-c/cascader@1.1.2(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/select': 1.1.4(vue@3.5.39(typescript@5.9.3))
@@ -8448,11 +8408,6 @@ snapshots:
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/checkbox@1.0.1(vue@3.5.39(typescript@5.9.3))':
-    dependencies:
-      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
-      vue: 3.5.39(typescript@5.9.3)
-
-  '@v-c/collapse@1.0.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
@@ -8480,12 +8435,6 @@ snapshots:
       '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
-  '@v-c/dropdown@1.0.3(vue@3.5.39(typescript@5.9.3))':
-    dependencies:
-      '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
-      vue: 3.5.39(typescript@5.9.3)
-
   '@v-c/dropdown@1.0.4(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
@@ -8495,13 +8444,6 @@ snapshots:
   '@v-c/image@1.0.12(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
-      vue: 3.5.39(typescript@5.9.3)
-
-  '@v-c/input-number@1.0.5(vue@3.5.39(typescript@5.9.3))':
-    dependencies:
-      '@v-c/input': 1.1.1(vue@3.5.39(typescript@5.9.3))
-      '@v-c/mini-decimal': 1.0.1
       '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
@@ -8519,15 +8461,6 @@ snapshots:
 
   '@v-c/input@1.1.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
-      vue: 3.5.39(typescript@5.9.3)
-
-  '@v-c/mentions@1.1.2(vue@3.5.39(typescript@5.9.3))':
-    dependencies:
-      '@v-c/input': 1.1.1(vue@3.5.39(typescript@5.9.3))
-      '@v-c/menu': 1.2.2(vue@3.5.39(typescript@5.9.3))
-      '@v-c/textarea': 1.1.0(vue@3.5.39(typescript@5.9.3))
-      '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
       '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
@@ -8576,16 +8509,6 @@ snapshots:
     dependencies:
       '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
-
-  '@v-c/picker@1.2.1(dayjs@1.11.21)(vue@3.5.39(typescript@5.9.3))':
-    dependencies:
-      '@v-c/overflow': 1.1.0(vue@3.5.39(typescript@5.9.3))
-      '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
-      '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
-      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
-      vue: 3.5.39(typescript@5.9.3)
-    optionalDependencies:
-      dayjs: 1.11.21
 
   '@v-c/picker@1.2.2(dayjs@1.11.21)(vue@3.5.39(typescript@5.9.3))':
     dependencies:
@@ -8649,7 +8572,7 @@ snapshots:
       '@v-c/overflow': 1.1.0(vue@3.5.39(typescript@5.9.3))
       '@v-c/trigger': 1.0.18(vue@3.5.39(typescript@5.9.3))
       '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
-      '@v-c/virtual-list': 1.0.9(vue@3.5.39(typescript@5.9.3))
+      '@v-c/virtual-list': 1.1.0(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/slick@1.0.2(vue@3.5.39(typescript@5.9.3))':
@@ -8678,6 +8601,13 @@ snapshots:
       '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
       '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.9(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
+
+  '@v-c/table@1.1.7(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
+      '@v-c/virtual-list': 1.1.0(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/tabs@1.2.1(vue@3.5.39(typescript@5.9.3))':
@@ -8719,7 +8649,7 @@ snapshots:
   '@v-c/tree@1.1.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
-      '@v-c/virtual-list': 1.0.9(vue@3.5.39(typescript@5.9.3))
+      '@v-c/virtual-list': 1.1.0(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/trigger@1.0.18(vue@3.5.39(typescript@5.9.3))':
@@ -8739,6 +8669,12 @@ snapshots:
       vue: 3.5.39(typescript@5.9.3)
 
   '@v-c/virtual-list@1.0.9(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
+
+  '@v-c/virtual-list@1.1.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.3(vue@3.5.39(typescript@5.9.3))
       '@v-c/util': 1.0.21(vue@3.5.39(typescript@5.9.3))
@@ -9082,22 +9018,22 @@ snapshots:
       '@antdv-next/cssinjs': 1.0.6(vue@3.5.39(typescript@5.9.3))
       '@antdv-next/icons': 1.1.1(vue@3.5.39(typescript@5.9.3))
       '@v-c/async-validator': 1.0.1
-      '@v-c/cascader': 1.1.1(vue@3.5.39(typescript@5.9.3))
+      '@v-c/cascader': 1.1.2(vue@3.5.39(typescript@5.9.3))
       '@v-c/checkbox': 1.0.1(vue@3.5.39(typescript@5.9.3))
-      '@v-c/collapse': 1.0.0(vue@3.5.39(typescript@5.9.3))
+      '@v-c/collapse': 1.0.1(vue@3.5.39(typescript@5.9.3))
       '@v-c/color-picker': 1.0.6(vue@3.5.39(typescript@5.9.3))
       '@v-c/dialog': 1.2.0(vue@3.5.39(typescript@5.9.3))
       '@v-c/drawer': 1.0.6(vue@3.5.39(typescript@5.9.3))
-      '@v-c/dropdown': 1.0.3(vue@3.5.39(typescript@5.9.3))
+      '@v-c/dropdown': 1.0.4(vue@3.5.39(typescript@5.9.3))
       '@v-c/image': 1.0.12(vue@3.5.39(typescript@5.9.3))
       '@v-c/input': 1.1.1(vue@3.5.39(typescript@5.9.3))
-      '@v-c/input-number': 1.0.5(vue@3.5.39(typescript@5.9.3))
-      '@v-c/mentions': 1.1.2(vue@3.5.39(typescript@5.9.3))
+      '@v-c/input-number': 1.0.6(vue@3.5.39(typescript@5.9.3))
+      '@v-c/mentions': 1.1.3(vue@3.5.39(typescript@5.9.3))
       '@v-c/menu': 1.2.2(vue@3.5.39(typescript@5.9.3))
       '@v-c/mutate-observer': 1.0.2(vue@3.5.39(typescript@5.9.3))
       '@v-c/notification': 2.0.2(vue@3.5.39(typescript@5.9.3))
       '@v-c/pagination': 1.0.1(vue@3.5.39(typescript@5.9.3))
-      '@v-c/picker': 1.2.1(dayjs@1.11.21)(vue@3.5.39(typescript@5.9.3))
+      '@v-c/picker': 1.2.2(dayjs@1.11.21)(vue@3.5.39(typescript@5.9.3))
       '@v-c/progress': 1.0.1(vue@3.5.39(typescript@5.9.3))
       '@v-c/qrcode': 1.0.1(vue@3.5.39(typescript@5.9.3))
       '@v-c/rate': 1.0.1(vue@3.5.39(typescript@5.9.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -157,7 +157,7 @@ catalogs:
     '@v-c/slider': ^1.1.0
     '@v-c/steps': ^1.0.0
     '@v-c/switch': ^1.0.1
-    '@v-c/table': ^1.1.6
+    '@v-c/table': ^1.1.7
     '@v-c/tabs': ^1.2.1
     '@v-c/textarea': ^1.1.0
     '@v-c/tooltip': ^1.0.4
@@ -167,8 +167,7 @@ catalogs:
     '@v-c/trigger': ^1.0.18
     '@v-c/upload': ^1.0.0
     '@v-c/util': ^1.0.21
-    '@v-c/virtual-list': ^1.0.9
-
+    '@v-c/virtual-list': ^1.1.0
 onlyBuiltDependencies:
   - esbuild
   - less


### PR DESCRIPTION
## 同步说明

同步上游 ant-design `a7a37ce59f` (6.5.0) → `96880a4d40`，共 4 个提交。

### 同步内容

| 类型 | 内容 | 上游 PR |
| --- | --- | --- |
| fix | Input.Search 按钮 `:focus-visible` 时 `zIndex: 5`，防止 focus 轮廓被相邻元素遮挡 | [ant-design#58615](https://github.com/ant-design/ant-design/pull/58615) |
| docs | Grid 文档：Col `flex` 参数补充数字与字符串的语义区别（中英文） | [ant-design#58624](https://github.com/ant-design/ant-design/pull/58624) |
| docs | Layout 新增「折叠覆盖布局」demo（React tsx → Vue SFC，`#trigger` 插槽 + `collapsed-width="0"`） | [ant-design#58566](https://github.com/ant-design/ant-design/pull/58566) |
| chore | 依赖升级：`@v-c/table` ^1.1.7、`@v-c/virtual-list` ^1.1.0 | - |

### 跳过项

- ant-design#58623（Table 滚动排查博客，React rc-table 内部实现记录；对应 Vue 侧修复已包含在 @v-c/table 1.1.7）
- ant-design#58614（上游仓库 dependabot 配置）
- ant-design#58610（React 侧代码风格调整，不适用）
- 其余为上游 chore/站点改动

### 验证

- `pnpm -F antdv-next test input`：18 个测试文件、193 个用例全部通过
- 新增 demo 及文档 eslint 通过
- `.sync-upstream.json` 同步位点已推进到 `96880a4d40`