### PR TITLE
[sync] motion reduced-motion fix, AutoComplete filled fix & BorderBeam hover demo (#58685, #58669, #58683)

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React 主组件库 -> antdv-next 主包"
         }
       ],
-      "last_synced_commit": "e02f4c9f65e3cb424550c39d16b97c744a3ed455",
-      "last_synced_commit_short": "e02f4c9f65",
-      "last_synced_at": "2026-07-12T00:00:00Z",
-      "last_synced_tag": "6.5.0",
-      "sync_count": 19
+      "last_synced_commit": "b6e8bdc29f9db4ef4f3909c6129240327601ad9d",
+      "last_synced_commit_short": "b6e8bdc29f",
+      "last_synced_at": "2026-07-13T00:00:00Z",
+      "last_synced_tag": "6.5.1",
+      "sync_count": 20
     },
     {
       "name": "cssinjs",

--- a/docs/src/pages/components/auto-complete/demo/filled-custom-debug.vue
+++ b/docs/src/pages/components/auto-complete/demo/filled-custom-debug.vue
@@ -1,0 +1,26 @@
+<docs lang="zh-CN">
+填充形态自定义输入组件 Debug。
+</docs>
+
+<docs lang="en-US">
+Filled custom input debug.
+</docs>
+
+<script setup lang="ts">
+const options = [{ value: 'Burnaby' }, { value: 'Seattle' }, { value: 'Los Angeles' }]
+</script>
+
+<template>
+  <a-flex :gap="24" wrap>
+    <a-form layout="vertical" variant="filled" :style="{ width: '280px' }">
+      <a-form-item label="AutoComplete TextArea">
+        <a-auto-complete :options="options">
+          <a-textarea placeholder="Custom TextArea" />
+        </a-auto-complete>
+      </a-form-item>
+      <a-form-item label="Input TextArea">
+        <a-textarea placeholder="Compare TextArea" />
+      </a-form-item>
+    </a-form>
+  </a-flex>
+</template>

--- a/docs/src/pages/components/auto-complete/index.en-US.md
+++ b/docs/src/pages/components/auto-complete/index.en-US.md
@@ -35,6 +35,7 @@ The differences with Select are:
   <demo src="./demo/allowClear.vue">Customize clear button</demo>
   <demo src="./demo/style-class.vue">Custom semantic dom styling</demo>
   <demo src="./demo/disabled-custom-debug.vue" debug>Disabled custom input debug</demo>
+  <demo src="./demo/filled-custom-debug.vue" debug>Filled custom input debug</demo>
 </demo-group>
 
 ## API

--- a/docs/src/pages/components/auto-complete/index.zh-CN.md
+++ b/docs/src/pages/components/auto-complete/index.zh-CN.md
@@ -36,6 +36,7 @@ demo:
   <demo src="./demo/allowClear.vue">自定义清除按钮</demo>
   <demo src="./demo/style-class.vue">自定义语义结构的样式和类</demo>
   <demo src="./demo/disabled-custom-debug.vue" debug>禁用自定义输入 Debug</demo>
+  <demo src="./demo/filled-custom-debug.vue" debug>填充形态自定义输入 Debug</demo>
 </demo-group>
 
 ## API

--- a/docs/src/pages/components/border-beam/demo/hover.vue
+++ b/docs/src/pages/components/border-beam/demo/hover.vue
@@ -1,0 +1,44 @@
+<docs lang="zh-CN">
+默认隐藏边框流光，在鼠标 hover 到容器上时显示。
+</docs>
+
+<docs lang="en-US">
+Hide the border beam by default, and reveal it when hovering over the container.
+</docs>
+
+<script setup lang="ts">
+import { theme } from 'antdv-next'
+
+const { token } = theme.useToken()
+</script>
+
+<template>
+  <a-border-beam>
+    <a-card class="hover-card" title="Hover over the card">
+      The border beam appears when the pointer moves over this card.
+    </a-card>
+  </a-border-beam>
+</template>
+
+<style scoped>
+.hover-card {
+  width: 360px;
+}
+
+.hover-card :deep(.ant-border-beam) {
+  opacity: 0;
+  transition: opacity v-bind('token.motionDurationMid');
+}
+
+.hover-card :deep(.ant-border-beam)::before {
+  animation-play-state: paused;
+}
+
+.hover-card:hover :deep(.ant-border-beam) {
+  opacity: 1;
+}
+
+.hover-card:hover :deep(.ant-border-beam)::before {
+  animation-play-state: running;
+}
+</style>

--- a/docs/src/pages/components/border-beam/index.en-US.md
+++ b/docs/src/pages/components/border-beam/index.en-US.md
@@ -22,6 +22,7 @@ tag: 1.3.0
 
 <demo-group>
   <demo src="./demo/basic.vue">Basic</demo>
+  <demo src="./demo/hover.vue">Show on hover</demo>
   <demo src="./demo/customized-color.vue">Gradients</demo>
   <demo src="./demo/non-uniform-radius.vue" debug>Non-uniform radius</demo>
   <demo src="./demo/component-token.vue" debug>Line width</demo>

--- a/docs/src/pages/components/border-beam/index.zh-CN.md
+++ b/docs/src/pages/components/border-beam/index.zh-CN.md
@@ -23,6 +23,7 @@ tag: 1.3.0
 
 <demo-group>
   <demo src="./demo/basic.vue">基础用法</demo>
+  <demo src="./demo/hover.vue">鼠标悬浮时显示</demo>
   <demo src="./demo/customized-color.vue">渐变色</demo>
   <demo src="./demo/non-uniform-radius.vue" debug>不规则圆角</demo>
   <demo src="./demo/component-token.vue" debug>线宽</demo>

--- a/docs/src/pages/components/changelog.en-US.md
+++ b/docs/src/pages/components/changelog.en-US.md
@@ -2,6 +2,49 @@
 title: Component Changelog
 ---
 
+## V1.4.2
+
+Release Date: 2026-07-13
+
+This release advances the ant-design upstream sync to **6.5.1** ([#644](https://github.com/antdv-next/antdv-next/pull/644), [#647](https://github.com/antdv-next/antdv-next/pull/647), [#650](https://github.com/antdv-next/antdv-next/pull/650)) and focuses on **TypeScript type infrastructure** (generic constructor exports, type inference in `h()` usage). It also fixes a batch of component issues — Switch label centering and bare attribute parsing, AutoComplete filled background stacking, Modal lazy rendering — and upgrades `@v-c/table` 1.1.8, `@v-c/util` 1.0.21 and other dependencies.
+
+**✨ Features**
+
+* feat(types): export generic constructor types for Transfer / Cascader / TreeSelect / Segmented, enabling full generic inference in `h()` and TSX
+* feat(ecosystem): add the antdv-next-tiptap rich-text editor to the Awesome page
+
+**🐞 Fixes**
+
+* fix(switch): center label content with flex instead of aligning it to the text baseline, fixing the upward offset of icon content (#58672)
+* fix(switch, checkbox): bare `checked` / `default-checked` template attributes now correctly resolve to `true` (previously parsed as an empty string and rendered unchecked)
+* fix(input): prevent the Search button focus outline from being covered by adjacent elements (#58615)
+* fix(auto-complete): avoid duplicate filled background on custom input components (#58669)
+* fix(motion): `prefers-reduced-motion` now also disables transitions/animations on `::before` / `::after` pseudo elements (#58685)
+* fix(modal): keep default slot rendering lazy while loading; apply `styles.body` of Modal methods to the content
+* fix(pagination): keep the size changer width inside Form.Item
+* fix(button): align icons inside Card extra
+* fix(descriptions): restore view width in shrink-to-fit containers
+* fix(date-picker): expose `nativeElement` as an element instead of a function
+* fix(config-provider): component-level `classes` / `styles` config is no longer silently inferred as `any` ([#642](https://github.com/antdv-next/antdv-next/pull/642)); force `zeroRuntime` when the cssinjs layer is enabled
+* fix(locale): complete missing locale fields
+* fix(types): fix lost contextual callback types in `h()` usage, unresolvable `h(Table, props)`, and clean up remaining type errors in component sources
+* fix(deps): bump `@v-c/util` to 1.0.21, fixing Select dropdown misalignment inside Space.Compact under vue 3.5.39
+* build: externalize `@vueuse/core` to silence rolldown build warnings
+
+**📖 Docs**
+
+* docs(layout): add a "Collapsible overlay" demo (#58566)
+* docs(grid): document the semantic difference between number and string values of Col `flex` (#58624)
+* docs(border-beam): add a "Show on hover" demo (#58683)
+* docs(auto-complete): add a filled custom input debug demo (#58669)
+* docs(table): add an auto-height demo, a performance troubleshooting FAQ (Vue DevTools), `change` event typing examples, and more
+* docs(notification): add a fixed-width usage FAQ
+* docs(site): add an "All" filter to icon search; add Serene / Dashboard preview themes; align component overview card hover with ant-design
+
+**🧰 Dependencies**
+
+* chore(deps): bump `@v-c/table` ^1.1.8, `@v-c/virtual-list` ^1.1.0, `@v-c/mentions` ^1.1.2, `@v-c/util` ^1.0.21, `@antdv-next/happy-work-theme` 1.0.1
+
 ## V1.4.1
 
 Release Date: 2026-07-02

--- a/docs/src/pages/components/changelog.zh-CN.md
+++ b/docs/src/pages/components/changelog.zh-CN.md
@@ -2,6 +2,49 @@
 title: 组件更新日志
 ---
 
+## V1.4.2
+
+发布日期：2026-07-13
+
+本次版本将 ant-design 上游同步推进到 **6.5.1**（[#644](https://github.com/antdv-next/antdv-next/pull/644)、[#647](https://github.com/antdv-next/antdv-next/pull/647)、[#650](https://github.com/antdv-next/antdv-next/pull/650)），重点完善 **TypeScript 类型基建**（泛型组件构造器导出、`h()` 场景类型推断），并修复 Switch 标签居中与裸属性解析、AutoComplete filled 背景叠加、Modal 惰性渲染等一批组件问题；同步升级 `@v-c/table` 1.1.8、`@v-c/util` 1.0.21 等依赖。
+
+**✨ 新功能 Features**
+
+* feat(types)：Transfer / Cascader / TreeSelect / Segmented 导出泛型构造器类型，`h()` 与 TSX 下可获得完整泛型推断
+* feat(ecosystem)：Awesome 页面新增 antdv-next-tiptap 富文本编辑器
+
+**🐞 问题修复 Fixes**
+
+* fix(switch)：标签内容改为 flex 居中，修复图标类内容按文字基线对齐导致的向上偏移（#58672）
+* fix(switch, checkbox)：模板中裸写 `checked` / `default-checked` 现在正确解析为 `true`（原会解析为空字符串导致不选中）
+* fix(input)：修复 Search 按钮获得焦点时 focus 轮廓被相邻元素遮挡（#58615）
+* fix(auto-complete)：修复 filled 形态下自定义输入组件背景色叠加两层（#58669）
+* fix(motion)：`prefers-reduced-motion` 下同时禁用 `::before` / `::after` 伪元素的过渡与动画（#58685）
+* fix(modal)：loading 期间默认插槽保持惰性渲染；Modal 方法调用的 `styles.body` 正确应用到 content
+* fix(pagination)：修复 Form.Item 中页码尺寸切换器宽度异常
+* fix(button)：修复 Card extra 中按钮图标对齐
+* fix(descriptions)：恢复 shrink-to-fit 容器下的视图宽度
+* fix(date-picker)：`nativeElement` 暴露为元素本身而非函数
+* fix(config-provider)：组件级配置的 `classes` / `styles` 不再被静默推断为 `any`（[#642](https://github.com/antdv-next/antdv-next/pull/642)）；开启 cssinjs layer 时强制 `zeroRuntime`
+* fix(locale)：补齐多语言包缺失字段
+* fix(types)：修复 `h()` 用法下回调参数上下文类型丢失、`h(Table, props)` 无法解析等类型问题，清理组件源码遗留类型错误
+* fix(deps)：升级 `@v-c/util` 1.0.21，修复 vue 3.5.39 下 Space.Compact 中 Select 弹层首开错位
+* build：外置 `@vueuse/core`，消除 rolldown 构建告警
+
+**📖 文档 Docs**
+
+* docs(layout)：新增「折叠覆盖布局」demo（#58566）
+* docs(grid)：补充 Col `flex` 数字与字符串取值的语义差异（#58624）
+* docs(border-beam)：新增「鼠标悬浮时显示」demo（#58683）
+* docs(auto-complete)：新增 filled 形态自定义输入 Debug demo（#58669）
+* docs(table)：新增自适应高度 demo、性能排查 FAQ（Vue DevTools）、`change` 事件类型示例等
+* docs(notification)：新增固定宽度用法 FAQ
+* docs(site)：图标搜索新增「全部」筛选；主题预览新增 Serene / Dashboard；组件总览卡片 hover 效果对齐 ant-design
+
+**🧰 依赖更新 Dependencies**
+
+* chore(deps)：升级 `@v-c/table` ^1.1.8、`@v-c/virtual-list` ^1.1.0、`@v-c/mentions` ^1.1.2、`@v-c/util` ^1.0.21、`@antdv-next/happy-work-theme` 1.0.1
+
 ## V1.4.1
 
 发布日期：2026-07-02

--- a/packages/antdv-next/src/auto-complete/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/auto-complete/tests/__snapshots__/demo.test.tsx.snap
@@ -1807,6 +1807,153 @@ exports[`auto-complete demo > renders disabled-custom-debug correctly 1`] = `
 </div>
 `;
 
+exports[`auto-complete demo > renders filled-custom-debug correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-wrap-wrap"
+  style="gap: 24px;"
+>
+  <form
+    class="ant-form ant-form-vertical css-var-root ant-form-css-var"
+    style="width: 280px;"
+  >
+    <div
+      class="ant-form-item css-var-root ant-form-css-var ant-form-item-vertical"
+    >
+      <div
+        class="ant-row css-var-root ant-form-item-row"
+      >
+        <div
+          class="ant-col css-var-root ant-form-item-label"
+        >
+          <label
+            title="AutoComplete TextArea"
+          >
+            AutoComplete TextArea
+          </label>
+        </div>
+        <div
+          class="ant-col css-var-root ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <!---->
+              <div
+                class="ant-select ant-select-filled ant-select-in-form-item ant-select-auto-complete ant-select-customize css-var-root ant-select-css-var ant-select-single ant-select-customize-input ant-select-show-search"
+              >
+                <!---->
+                <div
+                  class="ant-select-content"
+                >
+                  <!---->
+                  <textarea
+                    aria-autocomplete="list"
+                    aria-controls="test-id_list"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="test-id_list"
+                    autocomplete="off"
+                    class="ant-input ant-input-filled css-var-root ant-input-css-var ant-select-input"
+                    id="test-id"
+                    placeholder="Custom TextArea"
+                    role="combobox"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <!---->
+                <!---->
+                <!---->
+              </div>
+              <!---->
+            </div>
+          </div>
+          <div
+            class="ant-form-item-additional"
+          >
+            <transition-stub
+              appear="true"
+              css="true"
+              enteractiveclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare "
+              enterfromclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare ant-form-show-help-enter-start"
+              entertoclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-active ant-form-show-help-enter-active"
+              leaveactiveclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+              leavefromclass="ant-form-show-help ant-form-show-help-leave"
+              leavetoclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+              name="ant-form-show-help"
+              persisted="false"
+            >
+              <!---->
+            </transition-stub>
+            <!---->
+          </div>
+        </div>
+        <!---->
+      </div>
+      <!---->
+    </div>
+    <div
+      class="ant-form-item css-var-root ant-form-css-var ant-form-item-vertical"
+    >
+      <div
+        class="ant-row css-var-root ant-form-item-row"
+      >
+        <div
+          class="ant-col css-var-root ant-form-item-label"
+        >
+          <label
+            title="Input TextArea"
+          >
+            Input TextArea
+          </label>
+        </div>
+        <div
+          class="ant-col css-var-root ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <textarea
+                class="ant-input ant-input-filled css-var-root ant-input-css-var"
+                placeholder="Compare TextArea"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="ant-form-item-additional"
+          >
+            <transition-stub
+              appear="true"
+              css="true"
+              enteractiveclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare "
+              enterfromclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare ant-form-show-help-enter-start"
+              entertoclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-active ant-form-show-help-enter-active"
+              leaveactiveclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+              leavefromclass="ant-form-show-help ant-form-show-help-leave"
+              leavetoclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+              name="ant-form-show-help"
+              persisted="false"
+            >
+              <!---->
+            </transition-stub>
+            <!---->
+          </div>
+        </div>
+        <!---->
+      </div>
+      <!---->
+    </div>
+  </form>
+</div>
+`;
+
 exports[`auto-complete demo > renders non-case-sensitive correctly 1`] = `
 <div
   data-v-app=""

--- a/packages/antdv-next/src/border-beam/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/border-beam/tests/__snapshots__/demo.test.tsx.snap
@@ -333,6 +333,41 @@ exports[`border-beam demo > renders customized-color correctly 1`] = `
 </div>
 `;
 
+exports[`border-beam demo > renders hover correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <div
+    class="ant-card ant-card-bordered hover-card css-var-root"
+    data-v-ed084c0b=""
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          Hover over the card
+        </div>
+        <!---->
+      </div>
+      <!---->
+    </div>
+    <!---->
+    <div
+      class="ant-card-body"
+    >
+       The border beam appears when the pointer moves over this card. 
+    </div>
+    <!---->
+  </div>
+  <!---->
+</div>
+`;
+
 exports[`border-beam demo > renders non-uniform-radius correctly 1`] = `
 <div
   style="width: 360px;"

--- a/packages/antdv-next/src/select/style/select-input-customize.ts
+++ b/packages/antdv-next/src/select/style/select-input-customize.ts
@@ -37,6 +37,10 @@ const genSelectInputCustomizeStyle: GenerateStyle<SelectToken, CSSObject> = (tok
         },
       },
 
+      [`&${componentCls}-filled ${componentCls}-content`]: {
+        [`${antCls}-input-filled`]: transparentBackground,
+      },
+
       [`&${componentCls}-disabled ${componentCls}-content`]: {
         [disabledCustomizedInputSelector]: transparentBackground,
 

--- a/packages/antdv-next/src/style/motion/util.ts
+++ b/packages/antdv-next/src/style/motion/util.ts
@@ -3,8 +3,10 @@ import type { CSSObject } from '@antdv-next/cssinjs'
 export function genNoMotionStyle(): CSSObject {
   return {
     '@media (prefers-reduced-motion: reduce)': {
-      transition: 'none',
-      animation: 'none',
+      '&, &::before, &::after': {
+        transition: 'none',
+        animation: 'none',
+      },
     },
   }
 }


### PR DESCRIPTION
## 同步说明

同步上游 ant-design `e02f4c9f65` → `b6e8bdc29f`（6.5.1），共 13 个新提交，其中 3 个需要同步。

### 同步内容

| 类型 | 内容 | 上游 PR |
| --- | --- | --- |
| fix | `genNoMotionStyle` 的 `prefers-reduced-motion` 规则扩展到 `&::before / &::after` 伪元素 | [ant-design#58685](https://github.com/ant-design/ant-design/pull/58685) |
| fix | AutoComplete 自定义输入在 filled 形态下背景色叠加两层；Select 样式对 `.ant-input-filled` 透明化，并新增 filled-custom-debug demo | [ant-design#58669](https://github.com/ant-design/ant-design/pull/58669) |
| demo | BorderBeam 新增「鼠标悬浮时显示」demo | [ant-design#58683](https://github.com/ant-design/ant-design/pull/58683) |

### 跳过项

- #58689 + #58693、#58673 + #58686：两对 fix/docs 已在上游 revert，净变更为零
- #58681/#58688：antd 自身 6.5.1 changelog
- #58684：Affix 文档大小写修正，改动的句子（React FC 重写说明）下游文档不存在
- 其余为上游 chore/site/发版脚本改动

### 验证

- `pnpm -F antdv-next test auto-complete border-beam select`：14 个测试文件、175 个用例全过，2 个新 demo 快照已提交
- `.sync-upstream.json` 位点推进到 `b6e8bdc29f`（tag 6.5.1）