### PR TITLE
fix(timeline): wire up dotRender/labelRender/contentRender props and slots

### DIFF
--- a/docs/src/pages/components/timeline/demo/dot-render.vue
+++ b/docs/src/pages/components/timeline/demo/dot-render.vue
@@ -1,0 +1,44 @@
+<docs lang="zh-CN">
+通过 `dotRender` 插槽（或同名函数 prop）按 item 统一自定义时间轴点；插槽未渲染内容时，回退到 item 自身的 `icon` 或默认圆点。`labelRender` / `contentRender` 用法相同。
+</docs>
+
+<docs lang="en-US">
+Customize timeline dots per item with the `dotRender` slot (or the prop of the same name). When the slot renders nothing for an item, it falls back to the item `icon` or the default dot. `labelRender` / `contentRender` work the same way.
+</docs>
+
+<script setup lang="ts">
+import { CheckCircleOutlined, CloseCircleOutlined } from '@antdv-next/icons'
+import { theme } from 'antdv-next'
+
+const { token } = theme.useToken()
+
+const items = [
+  { content: 'Create a services site 2015-09-01', state: 'done' },
+  { content: 'Solve initial network problems 2015-09-01', state: 'done' },
+  { content: 'Technical testing 2015-09-01', color: 'red', state: 'failed' },
+  { content: 'Network problems being solved 2015-09-01' },
+]
+</script>
+
+<template>
+  <a-timeline :items="items">
+    <template #dotRender="{ item }">
+      <CheckCircleOutlined
+        v-if="item.state === 'done'"
+        class="dot-icon"
+        :style="{ background: token.colorBgContainer }"
+      />
+      <CloseCircleOutlined
+        v-else-if="item.state === 'failed'"
+        class="dot-icon"
+        :style="{ background: token.colorBgContainer }"
+      />
+    </template>
+  </a-timeline>
+</template>
+
+<style scoped>
+.dot-icon {
+  font-size: 16px;
+}
+</style>

--- a/docs/src/pages/components/timeline/index.en-US.md
+++ b/docs/src/pages/components/timeline/index.en-US.md
@@ -20,6 +20,7 @@ demo:
 <demo src="./demo/basic.vue">Basic</demo>
 <demo src="./demo/alternate.vue">Alternate</demo>
 <demo src="./demo/custom.vue">Custom</demo>
+<demo src="./demo/dot-render.vue">Dot render</demo>
 <demo src="./demo/sfc.vue">SFC Mode</demo>
 <demo src="./demo/pending.vue">Pending</demo>
 <demo src="./demo/title.vue">Label</demo>

--- a/docs/src/pages/components/timeline/index.zh-CN.md
+++ b/docs/src/pages/components/timeline/index.zh-CN.md
@@ -24,6 +24,7 @@ demo:
 <demo src="./demo/alternate.vue">交替展现</demo>
 <demo src="./demo/horizontal.vue">水平布局</demo>
 <demo src="./demo/custom.vue">自定义时间轴点</demo>
+<demo src="./demo/dot-render.vue">自定义渲染函数</demo>
 <demo src="./demo/sfc.vue">SFC 模式</demo>
 <demo src="./demo/end.vue">另一侧时间轴点</demo>
 <demo src="./demo/title.vue">标题</demo>

--- a/packages/antdv-next/src/timeline/Timeline.tsx
+++ b/packages/antdv-next/src/timeline/Timeline.tsx
@@ -76,9 +76,9 @@ export interface TimelineProps extends ComponentBaseProps {
   reverse?: boolean
   mode?: 'left' | 'alternate' | 'right' | 'start' | 'end'
   items?: TimelineItemType[]
-  dotRender?: (params: { item: TimelineItemType, index: number }) => void
-  labelRender?: (params: { item: TimelineItemType, index: number }) => void
-  contentRender?: (params: { item: TimelineItemType, index: number }) => void
+  dotRender?: (params: { item: TimelineItemType, index: number }) => VueNode
+  labelRender?: (params: { item: TimelineItemType, index: number }) => VueNode
+  contentRender?: (params: { item: TimelineItemType, index: number }) => VueNode
   orientation?: 'horizontal' | 'vertical'
   variant?: StepsProps['variant']
   classes?: TimelineClassNamesType
@@ -91,9 +91,9 @@ export type TimelineStylesType = SemanticStylesType<TimelineProps, TimelineSeman
 export interface TimelineSlots {
   pending?: () => void
   pendingDot?: () => void
-  dotRender?: (params: { item: TimelineItemType, index: number }) => void
-  labelRender?: (params: { item: TimelineItemType, index: number }) => void
-  contentRender?: (params: { item: TimelineItemType, index: number }) => void
+  dotRender?: (params: { item: TimelineItemType, index: number }) => any
+  labelRender?: (params: { item: TimelineItemType, index: number }) => any
+  contentRender?: (params: { item: TimelineItemType, index: number }) => any
 }
 
 const defaults = {
@@ -165,7 +165,13 @@ const Timeline = defineComponent<
     }))
 
     // ===================== Data =======================
-    const rawItems = useItems(rootPrefixCls, prefixCls, mergedMode, items, pending, pendingDot)
+    // 插槽优先，其次 props(与 getSlotPropFnRun 的约定一致)
+    const itemRenders = computed(() => ({
+      dotRender: (slots.dotRender ?? props.dotRender) as TimelineProps['dotRender'],
+      labelRender: (slots.labelRender ?? props.labelRender) as TimelineProps['labelRender'],
+      contentRender: (slots.contentRender ?? props.contentRender) as TimelineProps['contentRender'],
+    }))
+    const rawItems = useItems(rootPrefixCls, prefixCls, mergedMode, items, pending, pendingDot, itemRenders)
 
     const mergedItems = computed(() => {
       return (props.reverse ? [...rawItems.value].reverse() : rawItems.value) as StepItem[]
@@ -222,7 +228,7 @@ const Timeline = defineComponent<
       return (
         <Steps
           {...omit(attrs, ['class', 'style'])}
-          {...omit(props, ['items', 'prefixCls', 'titleSpan'])}
+          {...omit(props, ['items', 'prefixCls', 'titleSpan', 'dotRender', 'labelRender', 'contentRender'])}
           class={clsx(
             contextClassName.value,
             timeline.value?.class,

--- a/packages/antdv-next/src/timeline/Timeline.tsx
+++ b/packages/antdv-next/src/timeline/Timeline.tsx
@@ -6,6 +6,7 @@ import type { ComponentBaseProps } from '../config-provider/context.ts'
 import type { StepItem, StepsProps, StepsSemanticClassNames, StepsSemanticName, StepsSemanticStyles } from '../steps'
 import { useUnstableProvider } from '@v-c/steps/dist/UnstableContext.js'
 import { classNames as clsx } from '@v-c/util'
+import { filterEmpty } from '@v-c/util/dist/props-util'
 import { omit } from 'es-toolkit'
 import { computed, defineComponent, ref, toRefs } from 'vue'
 import { useMergeSemantic, useToArr, useToProps } from '../_util/hooks'
@@ -165,11 +166,25 @@ const Timeline = defineComponent<
     }))
 
     // ===================== Data =======================
-    // 插槽优先，其次 props(与 getSlotPropFnRun 的约定一致)
+    // 插槽优先，其次 props(与 getSlotPropFnRun 的约定一致)。
+    // 插槽结果是规范化后的 VNode 数组(条件不渲染时为注释节点),须过滤后
+    // 判空,空结果返回 undefined 以触发 item 自身字段的回退。
+    const wrapRender = (fn: any): TimelineProps['dotRender'] => {
+      if (typeof fn !== 'function')
+        return undefined
+      return (params) => {
+        const node = fn(params)
+        const nodes = filterEmpty(Array.isArray(node) ? node : [node])
+          .filter(n => n !== undefined && n !== null)
+        if (!nodes.length)
+          return undefined
+        return nodes.length === 1 ? nodes[0] : nodes
+      }
+    }
     const itemRenders = computed(() => ({
-      dotRender: (slots.dotRender ?? props.dotRender) as TimelineProps['dotRender'],
-      labelRender: (slots.labelRender ?? props.labelRender) as TimelineProps['labelRender'],
-      contentRender: (slots.contentRender ?? props.contentRender) as TimelineProps['contentRender'],
+      dotRender: wrapRender(slots.dotRender ?? props.dotRender),
+      labelRender: wrapRender(slots.labelRender ?? props.labelRender),
+      contentRender: wrapRender(slots.contentRender ?? props.contentRender),
     }))
     const rawItems = useItems(rootPrefixCls, prefixCls, mergedMode, items, pending, pendingDot, itemRenders)
 

--- a/packages/antdv-next/src/timeline/tests/Timeline.test.tsx
+++ b/packages/antdv-next/src/timeline/tests/Timeline.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { h, nextTick, ref } from 'vue'
+import { createCommentVNode, h, nextTick, ref } from 'vue'
 import Timeline, { TimelineItem } from '..'
 import ConfigProvider from '../../config-provider'
 import mountTest from '/@tests/shared/mountTest'
@@ -682,6 +682,24 @@ describe('timeline', () => {
       ))
       expect(wrapper.findAll('.item-icon')).toHaveLength(1)
       expect(wrapper.findAll('.custom-dot')).toHaveLength(1)
+    })
+
+    it('should fall back when slot renders nothing (comment node)', () => {
+      // 模板插槽中 v-if 不成立时,插槽返回的是含注释节点的数组而非 null
+      const wrapper = mount(() => (
+        <Timeline
+          items={[
+            { content: 'foo', icon: <span class="item-icon" /> },
+            { content: 'bar' },
+          ]}
+          v-slots={{
+            dotRender: ({ index }: any) =>
+              index === 1 ? [<span class="slot-dot" />] : [createCommentVNode('v-if')],
+          }}
+        />
+      ))
+      expect(wrapper.findAll('.item-icon')).toHaveLength(1)
+      expect(wrapper.findAll('.slot-dot')).toHaveLength(1)
     })
 
     it('should support labelRender and contentRender', () => {

--- a/packages/antdv-next/src/timeline/tests/Timeline.test.tsx
+++ b/packages/antdv-next/src/timeline/tests/Timeline.test.tsx
@@ -625,6 +625,85 @@ describe('timeline', () => {
     })
   })
 
+  // ============================ Render Functions ============================
+  describe('render functions', () => {
+    const items = [{ content: 'foo' }, { content: 'bar' }]
+
+    it('should support dotRender prop', () => {
+      const wrapper = mount(() => (
+        <Timeline
+          items={items}
+          dotRender={({ index }) => <span class="custom-dot">{index}</span>}
+        />
+      ))
+      const dots = wrapper.findAll('.custom-dot')
+      expect(dots).toHaveLength(2)
+      expect(dots[0]!.text()).toBe('0')
+      expect(dots[1]!.text()).toBe('1')
+    })
+
+    it('should support dotRender slot', () => {
+      const wrapper = mount(() => (
+        <Timeline
+          items={items}
+          v-slots={{
+            dotRender: ({ item, index }: any) => <span class="slot-dot">{`${item.content}-${index}`}</span>,
+          }}
+        />
+      ))
+      const dots = wrapper.findAll('.slot-dot')
+      expect(dots).toHaveLength(2)
+      expect(dots[0]!.text()).toBe('foo-0')
+    })
+
+    it('should prefer dotRender slot over prop', () => {
+      const wrapper = mount(() => (
+        <Timeline
+          items={items}
+          dotRender={() => <span class="prop-dot" />}
+          v-slots={{
+            dotRender: () => <span class="slot-dot" />,
+          }}
+        />
+      ))
+      expect(wrapper.findAll('.slot-dot')).toHaveLength(2)
+      expect(wrapper.findAll('.prop-dot')).toHaveLength(0)
+    })
+
+    it('should fall back to item icon when dotRender returns nullish', () => {
+      const wrapper = mount(() => (
+        <Timeline
+          items={[
+            { content: 'foo', icon: <span class="item-icon" /> },
+            { content: 'bar' },
+          ]}
+          dotRender={({ index }) => (index === 1 ? <span class="custom-dot" /> : null)}
+        />
+      ))
+      expect(wrapper.findAll('.item-icon')).toHaveLength(1)
+      expect(wrapper.findAll('.custom-dot')).toHaveLength(1)
+    })
+
+    it('should support labelRender and contentRender', () => {
+      const wrapper = mount(() => (
+        <Timeline
+          items={items}
+          labelRender={({ index }) => <span class="custom-label">{`L${index}`}</span>}
+          contentRender={({ item }: any) => <span class="custom-content">{`C-${item.content}`}</span>}
+        />
+      ))
+      expect(wrapper.findAll('.custom-label')).toHaveLength(2)
+      expect(wrapper.findAll('.custom-content')[0]!.text()).toBe('C-foo')
+    })
+
+    it('should not leak render props to DOM attrs', () => {
+      const wrapper = mount(() => (
+        <Timeline items={items} dotRender={() => <span class="custom-dot" />} />
+      ))
+      expect(wrapper.find('ol.ant-timeline').attributes('dotrender')).toBeUndefined()
+    })
+  })
+
   // ============================ Snapshot ============================
   it('should render correct snapshot', () => {
     const wrapper = mount(() => (

--- a/packages/antdv-next/src/timeline/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/timeline/tests/__snapshots__/demo.test.tsx.snap
@@ -1977,6 +1977,218 @@ exports[`timeline demo > renders custom correctly 1`] = `
 </ol>
 `;
 
+exports[`timeline demo > renders dot-render correctly 1`] = `
+<ol
+  class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-dot ant-timeline-css-var css-var-root ant-timeline css-var-root"
+  classes="[object Object]"
+  data-v-3676b70a=""
+  responsive="true"
+  style="--ant-cmp-steps-items-offset: 0;"
+  type="dot"
+>
+  <li
+    class="ant-steps-item ant-steps-item-finish ant-steps-item-custom ant-steps-item-empty-header ant-timeline-item-placement-start ant-timeline-item"
+    role="button"
+    state="done"
+    tabindex="0"
+  >
+    <div
+      class="ant-steps-item-wrapper ant-timeline-item-wrapper"
+    >
+      <div
+        class="ant-steps-item-icon ant-wave-target ant-timeline-item-icon"
+      >
+        <span
+          aria-label="check-circle"
+          class="anticon anticon-check-circle dot-icon"
+          data-v-3676b70a=""
+          role="img"
+          style="background: rgb(255, 255, 255);"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="check-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="ant-steps-item-section ant-timeline-item-section"
+      >
+        <div
+          class="ant-steps-item-header ant-timeline-item-header"
+        >
+          <!---->
+          <!---->
+          <div
+            class="ant-steps-item-rail ant-steps-item-rail-finish ant-timeline-item-rail"
+          />
+        </div>
+        <div
+          class="ant-steps-item-content ant-timeline-item-content"
+        >
+          Create a services site 2015-09-01
+        </div>
+      </div>
+    </div>
+  </li>
+  <li
+    class="ant-steps-item ant-steps-item-finish ant-steps-item-custom ant-steps-item-empty-header ant-timeline-item-placement-start ant-timeline-item"
+    role="button"
+    state="done"
+    tabindex="0"
+  >
+    <div
+      class="ant-steps-item-wrapper ant-timeline-item-wrapper"
+    >
+      <div
+        class="ant-steps-item-icon ant-wave-target ant-timeline-item-icon"
+      >
+        <span
+          aria-label="check-circle"
+          class="anticon anticon-check-circle dot-icon"
+          data-v-3676b70a=""
+          role="img"
+          style="background: rgb(255, 255, 255);"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="check-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="ant-steps-item-section ant-timeline-item-section"
+      >
+        <div
+          class="ant-steps-item-header ant-timeline-item-header"
+        >
+          <!---->
+          <!---->
+          <div
+            class="ant-steps-item-rail ant-steps-item-rail-finish ant-timeline-item-rail"
+          />
+        </div>
+        <div
+          class="ant-steps-item-content ant-timeline-item-content"
+        >
+          Solve initial network problems 2015-09-01
+        </div>
+      </div>
+    </div>
+  </li>
+  <li
+    class="ant-steps-item ant-steps-item-finish ant-steps-item-custom ant-steps-item-empty-header ant-timeline-item-color-red ant-timeline-item-placement-start ant-timeline-item"
+    role="button"
+    state="failed"
+    tabindex="0"
+  >
+    <div
+      class="ant-steps-item-wrapper ant-timeline-item-wrapper"
+    >
+      <div
+        class="ant-steps-item-icon ant-wave-target ant-timeline-item-icon"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle dot-icon"
+          data-v-3676b70a=""
+          role="img"
+          style="background: rgb(255, 255, 255);"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm0 76c-205.4 0-372 166.6-372 372s166.6 372 372 372 372-166.6 372-372-166.6-372-372-372zm128.01 198.83c.03 0 .05.01.09.06l45.02 45.01a.2.2 0 01.05.09.12.12 0 010 .07c0 .02-.01.04-.05.08L557.25 512l127.87 127.86a.27.27 0 01.05.06v.02a.12.12 0 010 .07c0 .03-.01.05-.05.09l-45.02 45.02a.2.2 0 01-.09.05.12.12 0 01-.07 0c-.02 0-.04-.01-.08-.05L512 557.25 384.14 685.12c-.04.04-.06.05-.08.05a.12.12 0 01-.07 0c-.03 0-.05-.01-.09-.05l-45.02-45.02a.2.2 0 01-.05-.09.12.12 0 010-.07c0-.02.01-.04.06-.08L466.75 512 338.88 384.14a.27.27 0 01-.05-.06l-.01-.02a.12.12 0 010-.07c0-.03.01-.05.05-.09l45.02-45.02a.2.2 0 01.09-.05.12.12 0 01.07 0c.02 0 .04.01.08.06L512 466.75l127.86-127.86c.04-.05.06-.06.08-.06a.12.12 0 01.07 0z"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="ant-steps-item-section ant-timeline-item-section"
+      >
+        <div
+          class="ant-steps-item-header ant-timeline-item-header"
+        >
+          <!---->
+          <!---->
+          <div
+            class="ant-steps-item-rail ant-steps-item-rail-finish ant-timeline-item-rail"
+          />
+        </div>
+        <div
+          class="ant-steps-item-content ant-timeline-item-content"
+        >
+          Technical testing 2015-09-01
+        </div>
+      </div>
+    </div>
+  </li>
+  <li
+    class="ant-steps-item ant-steps-item-finish ant-steps-item-active ant-steps-item-empty-header ant-timeline-item-placement-start ant-timeline-item"
+    role="button"
+    tabindex="0"
+  >
+    <div
+      class="ant-steps-item-wrapper ant-timeline-item-wrapper"
+    >
+      <div
+        class="ant-steps-item-icon ant-wave-target ant-timeline-item-icon"
+      >
+        <!---->
+      </div>
+      <div
+        class="ant-steps-item-section ant-timeline-item-section"
+      >
+        <div
+          class="ant-steps-item-header ant-timeline-item-header"
+        >
+          <!---->
+          <!---->
+          <!---->
+        </div>
+        <div
+          class="ant-steps-item-content ant-timeline-item-content"
+        >
+          Network problems being solved 2015-09-01
+        </div>
+      </div>
+    </div>
+  </li>
+</ol>
+`;
+
 exports[`timeline demo > renders end correctly 1`] = `
 <ol
   class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-dot ant-timeline-css-var css-var-root ant-timeline css-var-root"

--- a/packages/antdv-next/src/timeline/useItems.tsx
+++ b/packages/antdv-next/src/timeline/useItems.tsx
@@ -6,6 +6,12 @@ import { classNames as clsx } from '@v-c/util'
 import { computed } from 'vue'
 import { genCssVar } from '../theme/util/genStyleUtils'
 
+export interface TimelineItemRenders {
+  dotRender?: TimelineProps['dotRender']
+  labelRender?: TimelineProps['labelRender']
+  contentRender?: TimelineProps['contentRender']
+}
+
 function useItems(
   rootPrefixCls: ComputedRef<string>,
   prefixCls: ComputedRef<string>,
@@ -13,6 +19,7 @@ function useItems(
   items?: ComputedRef<TimelineItemType[] | undefined>,
   pending?: ComputedRef<TimelineProps['pending']>,
   pendingDot?: ComputedRef<TimelineProps['pendingDot']>,
+  renders?: ComputedRef<TimelineItemRenders>,
 ) {
   const itemCls = computed(() => `${prefixCls.value}-item`)
 
@@ -27,6 +34,7 @@ function useItems(
 
   // convert legacy type
   return computed(() => {
+    const { dotRender, labelRender, contentRender } = renders?.value ?? {}
     const mergedItems = parseItems.value.map<TimelineItemType>((item, index) => {
       const {
         label,
@@ -68,15 +76,15 @@ function useItems(
       mergedClass = clsx(mergedClass, `${itemCls.value}-placement-${mergedPlacement}`)
 
       // Icon
-      let mergedIcon = icon ?? dot
+      let mergedIcon = dotRender?.({ item, index }) ?? icon ?? dot
       if (!mergedIcon && loading) {
         mergedIcon = <LoadingOutlined />
       }
 
       return {
         ...restProps,
-        title: title ?? label,
-        content: content ?? children,
+        title: labelRender?.({ item, index }) ?? title ?? label,
+        content: contentRender?.({ item, index }) ?? content ?? children,
         style: mergedStyle,
         class: mergedClass,
         icon: mergedIcon,


### PR DESCRIPTION
Fixes #653

## 问题

Timeline 的 `dotRender` / `labelRender` / `contentRender` 三个 API 在文档中同时作为 props 和插槽公开，类型也有声明，但实现层从未接线：

- `useItems` 不接收这三个函数，构建 StepItem 时只认 items 里的 `icon`/`dot` 字段（所以 issue 里 `items` 写 `dot` 字段可用）；
- Timeline 透传给 Steps 的 `v-slots` 中，Steps 只识别 `iconRender`，`dotRender` 插槽被静默忽略；
- 三个函数 props 还随 `omit(props, ...)` 泄漏为 Steps 的未知属性。

（React 版 antd Timeline 没有这三个 API，属下游为 Vue 插槽习惯提供的扩展。）

## 修复

- Timeline 中按「插槽优先、props 兜底」合并三个渲染函数，传入 `useItems`；
- `useItems` 逐 item 调用：`dotRender` → icon、`labelRender` → title、`contentRender` → content，返回 nullish 时回退到 item 自身字段（`icon`/`dot`、`title`/`label`、`content`/`children`），pending 项不受影响；
- 三个 props 从 Steps 透传中排除；
- 返回类型从 `void` 修正为 `VueNode`。

## 测试

新增 6 个用例：prop 形式、插槽形式、插槽优先于 prop、nullish 回退、label/content 渲染、props 不泄漏为 DOM 属性。timeline 全部 92 个用例通过。