### PR TITLE
[sync] Splitter ARIA fix, InputNumber feedback demo & Anchor docs (#58702, #58703, #58710)

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React 主组件库 -> antdv-next 主包"
         }
       ],
-      "last_synced_commit": "b6e8bdc29f9db4ef4f3909c6129240327601ad9d",
-      "last_synced_commit_short": "b6e8bdc29f",
-      "last_synced_at": "2026-07-13T00:00:00Z",
+      "last_synced_commit": "534e5b265077a25ae91d5f8d28c058fd8c8152e8",
+      "last_synced_commit_short": "534e5b2650",
+      "last_synced_at": "2026-07-15T00:00:00Z",
       "last_synced_tag": "6.5.1",
-      "sync_count": 20
+      "sync_count": 21
     },
     {
       "name": "cssinjs",

--- a/docs/src/pages/components/anchor/index.en-US.md
+++ b/docs/src/pages/components/anchor/index.en-US.md
@@ -47,7 +47,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | classes | Customize class for each semantic structure inside the component. Supports object or function. | Record&lt;[SemanticDOM](#semantic-dom), string&gt; \| (info: &#123; props &#125;)=&gt; Record&lt;[SemanticDOM](#semantic-dom), string&gt; | - | - | ✓ |
 | getContainer | Scrolling container | () =&gt; HTMLElement | () =&gt; window | - | × |
 | getCurrentAnchor | Customize the anchor highlight | (activeLink: string) =&gt; string | - | - | × |
-| offsetTop | Pixels to offset from top when calculating position of scroll | number | - | - | × |
+| offsetTop | Pixels to offset from top when calculating position of scroll | number | 0 | - | × |
 | showInkInFixed | Whether show ink-square when `affix={false}` | boolean| false | - | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record&lt;[SemanticDOM](#semantic-dom), CSSProperties&gt; \| (info: &#123; props &#125;)=&gt; Record&lt;[SemanticDOM](#semantic-dom), CSSProperties&gt; | - | - | ✓ |
 | targetOffset | Anchor scroll offset, default as `offsetTop`, [example](#anchor-demo-targetoffset) | number | - | - | × |

--- a/docs/src/pages/components/anchor/index.zh-CN.md
+++ b/docs/src/pages/components/anchor/index.zh-CN.md
@@ -44,7 +44,7 @@ group:
 | classes | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record&lt;[SemanticDOM](#semantic-dom), string&gt; \| (info: &#123; props &#125;)=&gt; Record&lt;[SemanticDOM](#semantic-dom), string&gt; | - | - | ✓ |
 | getContainer | 指定滚动的容器 | () =&gt; HTMLElement | () =&gt; window | - | × |
 | getCurrentAnchor | 自定义高亮的锚点 | (activeLink: string) =&gt; string | - | - | × |
-| offsetTop | 距离窗口顶部达到指定偏移量后触发 | number | - | - | × |
+| offsetTop | 距离窗口顶部达到指定偏移量后触发 | number | 0 | - | × |
 | showInkInFixed | `affix={false}` 时是否显示小方块 | boolean | false | - | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record&lt;[SemanticDOM](#semantic-dom), CSSProperties&gt; \| (info: &#123; props &#125;)=&gt; Record&lt;[SemanticDOM](#semantic-dom), CSSProperties&gt; | - | - | ✓ |
 | targetOffset | 锚点滚动偏移量，默认与 offsetTop 相同，[例子](#anchor-demo-targetoffset) | number | - | - | × |

--- a/docs/src/pages/components/input-number/demo/feedback-suffix-debug.vue
+++ b/docs/src/pages/components/input-number/demo/feedback-suffix-debug.vue
@@ -1,0 +1,18 @@
+<docs lang="zh-CN">
+带反馈图标时展示后缀 Debug。
+</docs>
+
+<docs lang="en-US">
+Suffix with form feedback debug.
+</docs>
+
+<script setup lang="ts">
+</script>
+
+<template>
+  <a-form layout="vertical" :style="{ maxWidth: '320px' }">
+    <a-form-item label="Suffix with feedback" validate-status="success" has-feedback>
+      <a-input-number :default-value="100" suffix="RMB" :style="{ width: '100%' }" />
+    </a-form-item>
+  </a-form>
+</template>

--- a/docs/src/pages/components/input-number/index.en-US.md
+++ b/docs/src/pages/components/input-number/index.en-US.md
@@ -30,6 +30,7 @@ When a numeric value needs to be provided.
   <demo src="./demo/status.vue">Status</demo>
   <demo src="./demo/focus.vue">Focus</demo>
   <demo src="./demo/style-class.vue">Custom semantic dom styling</demo>
+  <demo src="./demo/feedback-suffix-debug.vue" debug>Suffix with feedback debug</demo>
 </demo-group>
 
 ## API

--- a/docs/src/pages/components/input-number/index.zh-CN.md
+++ b/docs/src/pages/components/input-number/index.zh-CN.md
@@ -31,6 +31,7 @@ demo:
   <demo src="./demo/status.vue">自定义状态</demo>
   <demo src="./demo/focus.vue">聚焦</demo>
   <demo src="./demo/style-class.vue">自定义语义结构的样式和类</demo>
+  <demo src="./demo/feedback-suffix-debug.vue" debug>带反馈图标的后缀 Debug</demo>
 </demo-group>
 
 ## API

--- a/packages/antdv-next/src/input-number/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/input-number/tests/__snapshots__/demo.test.tsx.snap
@@ -1386,6 +1386,165 @@ exports[`input-number demo > renders disabled correctly 1`] = `
 </div>
 `;
 
+exports[`input-number demo > renders feedback-suffix-debug correctly 1`] = `
+<form
+  class="ant-form ant-form-vertical css-var-root ant-form-css-var"
+  style="max-width: 320px;"
+>
+  <div
+    class="ant-form-item css-var-root ant-form-css-var ant-form-item-has-feedback ant-form-item-has-success ant-form-item-vertical"
+  >
+    <div
+      class="ant-row css-var-root ant-form-item-row"
+    >
+      <div
+        class="ant-col css-var-root ant-form-item-label"
+      >
+        <label
+          title="Suffix with feedback"
+        >
+          Suffix with feedback
+        </label>
+      </div>
+      <div
+        class="ant-col css-var-root ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-input-number ant-input-number-mode-input css-var-root ant-input-number-css-var ant-input-number-status-success ant-input-number-has-feedback ant-input-number-outlined ant-input-number-in-form-item"
+              style="width: 100%;"
+            >
+              <!---->
+              <!---->
+              <input
+                autocomplete="off"
+                class="ant-input-number-input"
+                role="spinbutton"
+                step="1"
+                value=""
+              />
+              <div
+                class="ant-input-number-suffix"
+              >
+                RMB
+                <span
+                  class="ant-form-item-feedback-icon ant-form-item-feedback-icon-success"
+                >
+                  <span
+                    aria-label="check-circle"
+                    class="anticon anticon-check-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <!---->
+              <div
+                class="ant-input-number-actions"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-label="Increase Value"
+                  class="ant-input-number-action ant-input-number-action-up"
+                  role="button"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="up"
+                    class="anticon anticon-up"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="up"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <span
+                  aria-disabled="false"
+                  aria-label="Decrease Value"
+                  class="ant-input-number-action ant-input-number-action-down"
+                  role="button"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="down"
+                    class="anticon anticon-down"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item-additional"
+        >
+          <transition-stub
+            appear="true"
+            css="true"
+            enteractiveclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare "
+            enterfromclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare ant-form-show-help-enter-start"
+            entertoclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-active ant-form-show-help-enter-active"
+            leaveactiveclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+            leavefromclass="ant-form-show-help ant-form-show-help-leave"
+            leavetoclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+            name="ant-form-show-help"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <!---->
+        </div>
+      </div>
+      <!---->
+    </div>
+    <!---->
+  </div>
+</form>
+`;
+
 exports[`input-number demo > renders focus correctly 1`] = `
 <div
   class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-root"

--- a/packages/antdv-next/src/splitter/Splitter.tsx
+++ b/packages/antdv-next/src/splitter/Splitter.tsx
@@ -231,11 +231,13 @@ const Splitter = defineComponent<
 
               const resizableInfo = resizableInfos.value[idx]
               if (resizableInfo) {
-                const ariaMinStart = (stackSizes.value[idx - 1] || 0) + itemPtgMinSizes.value[idx]!
-                const ariaMinEnd = (stackSizes.value[idx + 1] || 100) - itemPtgMaxSizes.value[idx + 1]!
+                const prevStackSize = Number.isFinite(stackSizes.value[idx - 1]) ? stackSizes.value[idx - 1]! : 0
+                const nextStackSize = Number.isFinite(stackSizes.value[idx + 1]) ? stackSizes.value[idx + 1]! : 1
+                const ariaMinStart = prevStackSize + itemPtgMinSizes.value[idx]!
+                const ariaMinEnd = nextStackSize - itemPtgMaxSizes.value[idx + 1]!
 
-                const ariaMaxStart = (stackSizes.value[idx - 1] || 0) + itemPtgMaxSizes.value[idx]!
-                const ariaMaxEnd = (stackSizes.value[idx + 1] || 100) - itemPtgMinSizes.value[idx + 1]!
+                const ariaMaxStart = prevStackSize + itemPtgMaxSizes.value[idx]!
+                const ariaMaxEnd = nextStackSize - itemPtgMinSizes.value[idx + 1]!
 
                 splitBar = (
                   <SplitBar

--- a/packages/antdv-next/src/splitter/tests/Splitter.test.tsx
+++ b/packages/antdv-next/src/splitter/tests/Splitter.test.tsx
@@ -489,6 +489,15 @@ describe('splitter', () => {
       expect(wrapper.find('[aria-valuemin]').attributes('aria-valuemin')).not.toBe('NaN')
       expect(wrapper.find('[aria-valuemax]').attributes('aria-valuemax')).not.toBe('NaN')
     })
+
+    it('should render percentage-based aria value range before resize', () => {
+      const wrapper = mountSplitter({
+        items: [{ defaultSize: 100, min: 100, max: 200 }, { min: 100, max: 200 }, { min: '20%' }],
+      })
+
+      const draggers = wrapper.findAll('.ant-splitter-bar-dragger')
+      expect(draggers[1]?.attributes('aria-valuemax')).toBe('80')
+    })
   })
 
   describe('collapsible', () => {

--- a/packages/antdv-next/src/splitter/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/splitter/tests/__snapshots__/demo.test.tsx.snap
@@ -1776,7 +1776,7 @@ exports[`splitter demo > renders size-mix correctly 1`] = `
       <div
         aria-disabled="true"
         aria-orientation="vertical"
-        aria-valuemax="9980"
+        aria-valuemax="80"
         aria-valuemin="0"
         aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"

--- a/packages/antdv-next/src/splitter/tests/lazy.test.tsx
+++ b/packages/antdv-next/src/splitter/tests/lazy.test.tsx
@@ -170,6 +170,38 @@ describe('splitter lazy', () => {
     expect(wrapper.element.querySelector('.ant-splitter-mask')).toBeFalsy()
   })
 
+  it('should not move preview when adjacent panels have zero size', async () => {
+    const onResize = vi.fn()
+    const onResizeEnd = vi.fn()
+
+    const wrapper = mount(SplitterDemo, {
+      props: {
+        items: [{ defaultSize: 0 }, { defaultSize: 0 }, {}],
+        onResize,
+        onResizeEnd,
+        lazy: true,
+      },
+      attachTo: document.body,
+    })
+    mountedWrappers.push(wrapper)
+
+    await resizeSplitter(wrapper)
+
+    const dragger = wrapper.element.querySelector('.ant-splitter-bar-dragger')!
+    dispatchMouseEvent(dragger, 'mousedown', 0, 0)
+    await nextTick()
+    dispatchMouseEvent(window, 'mousemove', 1000, 1000)
+    await nextTick()
+
+    const preview = wrapper.element.querySelector<HTMLElement>('.ant-splitter-bar-preview')!
+    expect(preview.style.getPropertyValue('--ant-splitter-bar-preview-offset')).toBe('0px')
+    expect(onResize).not.toHaveBeenCalled()
+
+    dispatchMouseEvent(window, 'mouseup', 1000, 1000)
+    await nextTick()
+    expect(onResizeEnd).toHaveBeenCalledWith([0, 0, 100])
+  })
+
   it('should work with touch events when lazy', async () => {
     const onResize = vi.fn()
     const onResizeEnd = vi.fn()


### PR DESCRIPTION
## 同步说明

同步上游 ant-design `b6e8bdc29f` → `534e5b2650`，共 8 个新提交，其中 3 个需要同步。

### 同步内容

| 类型 | 内容 | 上游 PR |
| --- | --- | --- |
| fix | Splitter 百分比 ARIA 值域计算：`stackSizes[idx±1] \|\| 0/100` 在相邻面板为 0 时误判、且 100 与 0-1 比例量纲不符（demo 快照里 `aria-valuemax` 曾为荒谬的 9980），改用 `Number.isFinite` 判定并以 1 为右边界 | [ant-design#58702](https://github.com/ant-design/ant-design/pull/58702) |
| docs | InputNumber 新增「带反馈图标的后缀」debug demo。**注**：上游修复的 bug（hasFeedback 时 suffix 被顶掉）在下游实现中不存在——我们的 `mergedSuffixFn` 本就合并渲染 suffix + feedbackIcon，故只同步 demo，快照证实两者共存 | [ant-design#58703](https://github.com/ant-design/ant-design/pull/58703) |
| docs | Anchor `offsetTop` 默认值 `-` → `0`（中英文都改，上游只改了中文；已核对实现 `getInternalCurrentAnchor` 默认 0） | [ant-design#58710](https://github.com/ant-design/ant-design/pull/58710) |

### 跳过项

- #58707：即我们提前修复并已合并的 #651，逐行比对合入版与我们的 `genNoMotionRawStyle` 语义一致（仅箭头函数/JSDoc 风格差异）
- #58695：demo 动态前缀改造，依赖 React 站点的 antd-style `createStyles({ prefixCls })` 基建，下游 demo 为 scoped CSS 硬编码前缀且站点无前缀切换功能，不适用
- 其余 3 个为上游 CI 依赖升级

### 验证

- splitter 76 个用例全过（含新增 2 个上游测试：百分比 ARIA 值域、lazy 模式零尺寸面板不移动预览条），size-mix demo 快照 `aria-valuemax` 9980 → 80 正是修复的直接证据
- input-number 46 个用例全过，新 demo 快照确认 suffix 与 feedback icon 共存
- `.sync-upstream.json` 位点推进到 `534e5b2650`