### PR TITLE
fix(tabs): infer item type of labelRender/contentRender from items

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React 主组件库 -> antdv-next 主包"
         }
       ],
-      "last_synced_commit": "b6e8bdc29f9db4ef4f3909c6129240327601ad9d",
-      "last_synced_commit_short": "b6e8bdc29f",
-      "last_synced_at": "2026-07-13T00:00:00Z",
+      "last_synced_commit": "534e5b265077a25ae91d5f8d28c058fd8c8152e8",
+      "last_synced_commit_short": "534e5b2650",
+      "last_synced_at": "2026-07-15T00:00:00Z",
       "last_synced_tag": "6.5.1",
-      "sync_count": 20
+      "sync_count": 21
     },
     {
       "name": "cssinjs",

--- a/docs/src/pages/components/anchor/index.en-US.md
+++ b/docs/src/pages/components/anchor/index.en-US.md
@@ -47,7 +47,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | classes | Customize class for each semantic structure inside the component. Supports object or function. | Record&lt;[SemanticDOM](#semantic-dom), string&gt; \| (info: &#123; props &#125;)=&gt; Record&lt;[SemanticDOM](#semantic-dom), string&gt; | - | - | ✓ |
 | getContainer | Scrolling container | () =&gt; HTMLElement | () =&gt; window | - | × |
 | getCurrentAnchor | Customize the anchor highlight | (activeLink: string) =&gt; string | - | - | × |
-| offsetTop | Pixels to offset from top when calculating position of scroll | number | - | - | × |
+| offsetTop | Pixels to offset from top when calculating position of scroll | number | 0 | - | × |
 | showInkInFixed | Whether show ink-square when `affix={false}` | boolean| false | - | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record&lt;[SemanticDOM](#semantic-dom), CSSProperties&gt; \| (info: &#123; props &#125;)=&gt; Record&lt;[SemanticDOM](#semantic-dom), CSSProperties&gt; | - | - | ✓ |
 | targetOffset | Anchor scroll offset, default as `offsetTop`, [example](#anchor-demo-targetoffset) | number | - | - | × |

--- a/docs/src/pages/components/anchor/index.zh-CN.md
+++ b/docs/src/pages/components/anchor/index.zh-CN.md
@@ -44,7 +44,7 @@ group:
 | classes | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record&lt;[SemanticDOM](#semantic-dom), string&gt; \| (info: &#123; props &#125;)=&gt; Record&lt;[SemanticDOM](#semantic-dom), string&gt; | - | - | ✓ |
 | getContainer | 指定滚动的容器 | () =&gt; HTMLElement | () =&gt; window | - | × |
 | getCurrentAnchor | 自定义高亮的锚点 | (activeLink: string) =&gt; string | - | - | × |
-| offsetTop | 距离窗口顶部达到指定偏移量后触发 | number | - | - | × |
+| offsetTop | 距离窗口顶部达到指定偏移量后触发 | number | 0 | - | × |
 | showInkInFixed | `affix={false}` 时是否显示小方块 | boolean | false | - | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record&lt;[SemanticDOM](#semantic-dom), CSSProperties&gt; \| (info: &#123; props &#125;)=&gt; Record&lt;[SemanticDOM](#semantic-dom), CSSProperties&gt; | - | - | ✓ |
 | targetOffset | 锚点滚动偏移量，默认与 offsetTop 相同，[例子](#anchor-demo-targetoffset) | number | - | - | × |

--- a/docs/src/pages/components/input-number/demo/feedback-suffix-debug.vue
+++ b/docs/src/pages/components/input-number/demo/feedback-suffix-debug.vue
@@ -1,0 +1,18 @@
+<docs lang="zh-CN">
+带反馈图标时展示后缀 Debug。
+</docs>
+
+<docs lang="en-US">
+Suffix with form feedback debug.
+</docs>
+
+<script setup lang="ts">
+</script>
+
+<template>
+  <a-form layout="vertical" :style="{ maxWidth: '320px' }">
+    <a-form-item label="Suffix with feedback" validate-status="success" has-feedback>
+      <a-input-number :default-value="100" suffix="RMB" :style="{ width: '100%' }" />
+    </a-form-item>
+  </a-form>
+</template>

--- a/docs/src/pages/components/input-number/index.en-US.md
+++ b/docs/src/pages/components/input-number/index.en-US.md
@@ -30,6 +30,7 @@ When a numeric value needs to be provided.
   <demo src="./demo/status.vue">Status</demo>
   <demo src="./demo/focus.vue">Focus</demo>
   <demo src="./demo/style-class.vue">Custom semantic dom styling</demo>
+  <demo src="./demo/feedback-suffix-debug.vue" debug>Suffix with feedback debug</demo>
 </demo-group>
 
 ## API

--- a/docs/src/pages/components/input-number/index.zh-CN.md
+++ b/docs/src/pages/components/input-number/index.zh-CN.md
@@ -31,6 +31,7 @@ demo:
   <demo src="./demo/status.vue">自定义状态</demo>
   <demo src="./demo/focus.vue">聚焦</demo>
   <demo src="./demo/style-class.vue">自定义语义结构的样式和类</demo>
+  <demo src="./demo/feedback-suffix-debug.vue" debug>带反馈图标的后缀 Debug</demo>
 </demo-group>
 
 ## API

--- a/packages/antdv-next/src/input-number/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/input-number/tests/__snapshots__/demo.test.tsx.snap
@@ -1386,6 +1386,165 @@ exports[`input-number demo > renders disabled correctly 1`] = `
 </div>
 `;
 
+exports[`input-number demo > renders feedback-suffix-debug correctly 1`] = `
+<form
+  class="ant-form ant-form-vertical css-var-root ant-form-css-var"
+  style="max-width: 320px;"
+>
+  <div
+    class="ant-form-item css-var-root ant-form-css-var ant-form-item-has-feedback ant-form-item-has-success ant-form-item-vertical"
+  >
+    <div
+      class="ant-row css-var-root ant-form-item-row"
+    >
+      <div
+        class="ant-col css-var-root ant-form-item-label"
+      >
+        <label
+          title="Suffix with feedback"
+        >
+          Suffix with feedback
+        </label>
+      </div>
+      <div
+        class="ant-col css-var-root ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-input-number ant-input-number-mode-input css-var-root ant-input-number-css-var ant-input-number-status-success ant-input-number-has-feedback ant-input-number-outlined ant-input-number-in-form-item"
+              style="width: 100%;"
+            >
+              <!---->
+              <!---->
+              <input
+                autocomplete="off"
+                class="ant-input-number-input"
+                role="spinbutton"
+                step="1"
+                value=""
+              />
+              <div
+                class="ant-input-number-suffix"
+              >
+                RMB
+                <span
+                  class="ant-form-item-feedback-icon ant-form-item-feedback-icon-success"
+                >
+                  <span
+                    aria-label="check-circle"
+                    class="anticon anticon-check-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <!---->
+              <div
+                class="ant-input-number-actions"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-label="Increase Value"
+                  class="ant-input-number-action ant-input-number-action-up"
+                  role="button"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="up"
+                    class="anticon anticon-up"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="up"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <span
+                  aria-disabled="false"
+                  aria-label="Decrease Value"
+                  class="ant-input-number-action ant-input-number-action-down"
+                  role="button"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="down"
+                    class="anticon anticon-down"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item-additional"
+        >
+          <transition-stub
+            appear="true"
+            css="true"
+            enteractiveclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare "
+            enterfromclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare ant-form-show-help-enter-start"
+            entertoclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-active ant-form-show-help-enter-active"
+            leaveactiveclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+            leavefromclass="ant-form-show-help ant-form-show-help-leave"
+            leavetoclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+            name="ant-form-show-help"
+            persisted="false"
+          >
+            <!---->
+          </transition-stub>
+          <!---->
+        </div>
+      </div>
+      <!---->
+    </div>
+    <!---->
+  </div>
+</form>
+`;
+
 exports[`input-number demo > renders focus correctly 1`] = `
 <div
   class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-root"

--- a/packages/antdv-next/src/splitter/Splitter.tsx
+++ b/packages/antdv-next/src/splitter/Splitter.tsx
@@ -231,11 +231,13 @@ const Splitter = defineComponent<
 
               const resizableInfo = resizableInfos.value[idx]
               if (resizableInfo) {
-                const ariaMinStart = (stackSizes.value[idx - 1] || 0) + itemPtgMinSizes.value[idx]!
-                const ariaMinEnd = (stackSizes.value[idx + 1] || 100) - itemPtgMaxSizes.value[idx + 1]!
+                const prevStackSize = Number.isFinite(stackSizes.value[idx - 1]) ? stackSizes.value[idx - 1]! : 0
+                const nextStackSize = Number.isFinite(stackSizes.value[idx + 1]) ? stackSizes.value[idx + 1]! : 1
+                const ariaMinStart = prevStackSize + itemPtgMinSizes.value[idx]!
+                const ariaMinEnd = nextStackSize - itemPtgMaxSizes.value[idx + 1]!
 
-                const ariaMaxStart = (stackSizes.value[idx - 1] || 0) + itemPtgMaxSizes.value[idx]!
-                const ariaMaxEnd = (stackSizes.value[idx + 1] || 100) - itemPtgMinSizes.value[idx + 1]!
+                const ariaMaxStart = prevStackSize + itemPtgMaxSizes.value[idx]!
+                const ariaMaxEnd = nextStackSize - itemPtgMinSizes.value[idx + 1]!
 
                 splitBar = (
                   <SplitBar

--- a/packages/antdv-next/src/splitter/tests/Splitter.test.tsx
+++ b/packages/antdv-next/src/splitter/tests/Splitter.test.tsx
@@ -489,6 +489,15 @@ describe('splitter', () => {
       expect(wrapper.find('[aria-valuemin]').attributes('aria-valuemin')).not.toBe('NaN')
       expect(wrapper.find('[aria-valuemax]').attributes('aria-valuemax')).not.toBe('NaN')
     })
+
+    it('should render percentage-based aria value range before resize', () => {
+      const wrapper = mountSplitter({
+        items: [{ defaultSize: 100, min: 100, max: 200 }, { min: 100, max: 200 }, { min: '20%' }],
+      })
+
+      const draggers = wrapper.findAll('.ant-splitter-bar-dragger')
+      expect(draggers[1]?.attributes('aria-valuemax')).toBe('80')
+    })
   })
 
   describe('collapsible', () => {

--- a/packages/antdv-next/src/splitter/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/splitter/tests/__snapshots__/demo.test.tsx.snap
@@ -1776,7 +1776,7 @@ exports[`splitter demo > renders size-mix correctly 1`] = `
       <div
         aria-disabled="true"
         aria-orientation="vertical"
-        aria-valuemax="9980"
+        aria-valuemax="80"
         aria-valuemin="0"
         aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"

--- a/packages/antdv-next/src/splitter/tests/lazy.test.tsx
+++ b/packages/antdv-next/src/splitter/tests/lazy.test.tsx
@@ -170,6 +170,38 @@ describe('splitter lazy', () => {
     expect(wrapper.element.querySelector('.ant-splitter-mask')).toBeFalsy()
   })
 
+  it('should not move preview when adjacent panels have zero size', async () => {
+    const onResize = vi.fn()
+    const onResizeEnd = vi.fn()
+
+    const wrapper = mount(SplitterDemo, {
+      props: {
+        items: [{ defaultSize: 0 }, { defaultSize: 0 }, {}],
+        onResize,
+        onResizeEnd,
+        lazy: true,
+      },
+      attachTo: document.body,
+    })
+    mountedWrappers.push(wrapper)
+
+    await resizeSplitter(wrapper)
+
+    const dragger = wrapper.element.querySelector('.ant-splitter-bar-dragger')!
+    dispatchMouseEvent(dragger, 'mousedown', 0, 0)
+    await nextTick()
+    dispatchMouseEvent(window, 'mousemove', 1000, 1000)
+    await nextTick()
+
+    const preview = wrapper.element.querySelector<HTMLElement>('.ant-splitter-bar-preview')!
+    expect(preview.style.getPropertyValue('--ant-splitter-bar-preview-offset')).toBe('0px')
+    expect(onResize).not.toHaveBeenCalled()
+
+    dispatchMouseEvent(window, 'mouseup', 1000, 1000)
+    await nextTick()
+    expect(onResizeEnd).toHaveBeenCalledWith([0, 0, 100])
+  })
+
   it('should work with touch events when lazy', async () => {
     const onResize = vi.fn()
     const onResizeEnd = vi.fn()

--- a/packages/antdv-next/src/tabs/index.tsx
+++ b/packages/antdv-next/src/tabs/index.tsx
@@ -1,5 +1,5 @@
 import type { GetIndicatorSize, MoreProps, TabsProps as VcTabsProps, Tab as VcTabType } from '@v-c/tabs'
-import type { App, CSSProperties, SlotsType } from 'vue'
+import type { App, CSSProperties, PublicProps, SlotsType } from 'vue'
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks'
 import type { VueNode } from '../_util/type.ts'
 import type { ComponentBaseProps } from '../config-provider/context.ts'
@@ -75,10 +75,12 @@ export interface Tab extends Omit<VcTabType, 'children' | 'className'> {
   class?: string
 }
 
+export type TabItem = Tab & Record<string, any>
+
 export interface TabsRef {
   nativeElement: any
 }
-export interface BaseTabsProps extends ComponentBaseProps {
+export interface BaseTabsProps<Item extends Tab = TabItem> extends ComponentBaseProps {
   type?: TabsType
   size?: SizeType
   hideAdd?: boolean
@@ -90,7 +92,7 @@ export interface BaseTabsProps extends ComponentBaseProps {
   tabPlacement?: TabPlacement
   /** @deprecated Please use `indicator={{ size: ... }}` instead */
   indicatorSize?: GetIndicatorSize
-  items?: Tab[]
+  items?: Item[]
 }
 
 export interface TabsEmits {
@@ -108,7 +110,7 @@ export interface TabsEmitsProps {
   'onUpdate:activeKey'?: TabsEmits['update:activeKey']
 }
 
-export interface TabsProps extends BaseTabsProps, CompatibilityProps, Omit<
+export interface TabsProps<Item extends Tab = TabItem> extends BaseTabsProps<Item>, CompatibilityProps, Omit<
   VcTabsProps,
   | 'editable'
   | 'items'
@@ -135,15 +137,13 @@ export interface TabsProps extends BaseTabsProps, CompatibilityProps, Omit<
   renderTabBar?: (args: { props: any, TabNavListComponent: any }) => any
 }
 
-export type TabItem = Tab & Record<string, any>
-
-export interface TabsSlots {
+export interface TabsSlots<Item extends Tab = TabItem> {
   default: () => any
   addIcon: () => any
   moreIcon: () => any
   removeIcon: () => any
-  labelRender: (args: { item: TabItem, index: number }) => any
-  contentRender: (args: { item: TabItem, index: number }) => any
+  labelRender: (args: { item: Item, index: number }) => any
+  contentRender: (args: { item: Item, index: number }) => any
   renderTabBar?: (args: { props: any, TabNavListComponent: any }) => any
   rightExtra?: () => any
   leftExtra?: () => any
@@ -438,12 +438,37 @@ const InternalTabs = defineComponent<
   },
 )
 
-const Tabs = InternalTabs
+interface TabsInstance<Item extends Tab = TabItem> {
+  $props: TabsProps<Item> & PublicProps
+  $emit: {
+    (event: 'edit', e: MouseEvent | KeyboardEvent | string, action: 'add' | 'remove'): void
+    (event: 'change', ...args: Parameters<TabsEmits['change']>): void
+    (event: 'tabClick', ...args: Parameters<TabsEmits['tabClick']>): void
+    (event: 'tabScroll', ...args: Parameters<TabsEmits['tabScroll']>): void
+    (event: 'update:activeKey', activeKey: string): void
+  }
+  $slots: TabsSlots<Item>
+}
 
-;(Tabs as any).TabPane = TabPane
+export interface TabsConstructor {
+  new<Item extends Tab = TabItem>(props: TabsProps<Item>): TabsInstance<Item>
+  /**
+   * Non-generic fallback signature. TypeScript infers from the last overload,
+   * so this keeps render-function usage like `h(Tabs, props)` resolvable
+   * against Vue's `Constructor<P>` overload of `h` (see #634), while the
+   * generic signature above still drives template/Volar inference.
+   */
+  new (props: TabsProps<any>): TabsInstance<any>
+  install: (app: App) => void
+  TabPane: typeof TabPane
+}
 
-;(Tabs as any).install = (app: App) => {
-  app.component(Tabs.name, Tabs)
+const Tabs = InternalTabs as unknown as TabsConstructor
+
+Tabs.TabPane = TabPane
+
+Tabs.install = (app: App) => {
+  app.component(InternalTabs.name, Tabs)
   app.component(TabPane.name, TabPane)
 }
 

--- a/packages/antdv-next/src/tabs/index.tsx
+++ b/packages/antdv-next/src/tabs/index.tsx
@@ -438,7 +438,7 @@ const InternalTabs = defineComponent<
   },
 )
 
-interface TabsInstance<Item extends Tab = TabItem> {
+type TabsInstance<Item extends Tab = TabItem> = {
   $props: TabsProps<Item> & PublicProps
   $emit: {
     (event: 'edit', e: MouseEvent | KeyboardEvent | string, action: 'add' | 'remove'): void
@@ -448,7 +448,7 @@ interface TabsInstance<Item extends Tab = TabItem> {
     (event: 'update:activeKey', activeKey: string): void
   }
   $slots: TabsSlots<Item>
-}
+} & TabsRef
 
 export interface TabsConstructor {
   new<Item extends Tab = TabItem>(props: TabsProps<Item>): TabsInstance<Item>


### PR DESCRIPTION
Fixes #660

## 问题定位

用户报告 `contentRender` 插槽的 `item` 类型与枚举 key 的 items 不兼容。实测复现（vue-tsc + 发布版 1.4.2 + issue 原始代码）：issue 里贴的片段本身能编译，真实报错发生在把插槽回传的 `item` **再当自己的类型使用**时（如传给参数为 `{ key: KeyEnum }` 的函数）：

```
Argument of type 'TabItem' is not assignable to parameter of type '{ key: KeyEnum; label: string }'.
  Type 'string' is not assignable to type 'KeyEnum'.
```

`TabsSlots` 把 item 硬编码为 `TabItem`（`key: string`），用户 items 的具体类型进入组件后被拓宽、无法流回。

## 修复

`BaseTabsProps` / `TabsProps` / `TabsSlots` 增加 `Item extends Tab = TabItem` 泛型参数（默认值保持全部现有用法兼容），Tabs 改用泛型构造器导出（与 Segmented/Transfer 同款模式，含 #634 的非泛型 `h()` 兜底重载）。`#contentRender="{ item }"` 中 `item` 现在推断为 `items` 数组元素的实际类型。

## 验证

- 独立 vue-tsc 工程双向验证：新 dist 类型下 issue 代码 + 反向传参零错误；换回发布版 1.4.2 类型精确复现 issue 报错
- tabs + timeline 199 个用例全过；`build:esm` 通过（tsx-resolve-types 对带默认值的泛型 props 正常生成 runtime props）

## 关联

issue 中提到的"切换 tab 内容飘动"是另一个独立问题：animated 模式下离场面板被 `-hidden` 类瞬间 display:none，交叉淡出被杀掉（与 React 不一致）。修复在 @v-c/tabs：antdv-next/vue-components#64，发版后 bump 依赖即可。