### PR TITLE
fix(wave): avoid touching global window in the attachListener watch callback

### DIFF
--- a/packages/antdv-next/src/_util/wave/index.tsx
+++ b/packages/antdv-next/src/_util/wave/index.tsx
@@ -97,7 +97,10 @@ export default defineComponent<WaveProps, WaveEmits, string, SlotsType<WaveSlots
       teardown = null
 
       const node = containerRef.value
-      if (!node || node.nodeType !== window.Node.ELEMENT_NODE || props.disabled) {
+      // 用字面量 1(Node.ELEMENT_NODE)而非 window.Node:该回调经 watch 异步调度,
+      // 可能在环境卸载后(如 vitest 拆掉 jsdom 全局)才执行,触碰 window 会抛
+      // "window is not defined" 的 unhandled rejection
+      if (!node || node.nodeType !== 1 || props.disabled) {
         return
       }
 


### PR DESCRIPTION
## 问题

CI/本地全量测试偶发 unhandled rejection：

```
ReferenceError: window is not defined
 ❯ attachListener packages/antdv-next/src/_util/wave/index.tsx:100
```

报错被归因到 `Button.test.tsx`，但这是误导：全部测试都跑在 jsdom 下，真正的时序是——Wave 的 `attachListener` 经 watch 异步调度，某个测试文件结束、vitest 拆掉 jsdom 全局之后回调才执行，`window.Node.ELEMENT_NODE` 触碰已不存在的全局 `window`，unhandled rejection 落到同 worker 中正在跑的下一个文件头上（所以单跑 button 或 style-extract 都无法复现）。

## 修复

`nodeType` 与规范冻结的字面量 `1`（`Node.ELEMENT_NODE`）比较，不再依赖全局 `window`。上游 React 同样写 `window.Node.ELEMENT_NODE`（`components/_util/wave/index.ts:43`），但 React 的 useEffect 不存在环境卸载后才执行的调度路径，属 Vue 移植特有问题，无需反馈上游。

## 验证

button / wave / radio 共 256 个用例全过。