### PR TITLE
chore(sync): sync ant-design upstream changes up to 78c3d84619

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React 主组件库 -> antdv-next 主包"
         }
       ],
-      "last_synced_commit": "534e5b265077a25ae91d5f8d28c058fd8c8152e8",
-      "last_synced_commit_short": "534e5b2650",
-      "last_synced_at": "2026-07-15T00:00:00Z",
+      "last_synced_commit": "78c3d8461978044558287f83aff911d9c4973eb9",
+      "last_synced_commit_short": "78c3d84619",
+      "last_synced_at": "2026-07-19T00:00:00Z",
       "last_synced_tag": "6.5.1",
-      "sync_count": 21
+      "sync_count": 22
     },
     {
       "name": "cssinjs",

--- a/docs/src/pages/components/select/demo/search-users.vue
+++ b/docs/src/pages/components/select/demo/search-users.vue
@@ -62,6 +62,7 @@ function handleSearch(val: string) {
     mode="multiple"
     label-in-value
     show-search
+    :auto-clear-search-value="false"
     :filter-option="false"
     placeholder="Select users"
     style="width: 100%"

--- a/docs/src/pages/components/tree/index.en-US.md
+++ b/docs/src/pages/components/tree/index.en-US.md
@@ -64,7 +64,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | loadData | Load data asynchronously | function(node) | - | - | × |
 | loadedKeys | (Controlled) Set loaded tree nodes. Need to work with `loadData` | string[] | [] | - | × |
 | multiple | Allows selecting multiple treeNodes | boolean | false | - | × |
-| rootStyle | Style on the root element | CSSProperties | - | - | × |
+| ~~rootStyle~~ | Style on the root element, please use `styles.root` instead | CSSProperties | - | - | × |
 | selectable | Whether it can be selected | boolean | true | - | × |
 | selectedKeys | (Controlled) Specifies the keys of the selected treeNodes, multiple selection needs to set `multiple` to true, support `v-model:selected-keys` | string[] | - | - | × |
 | showIcon | Controls whether to display the `icon` node (no default style) | boolean | false | - | × |

--- a/docs/src/pages/components/tree/index.zh-CN.md
+++ b/docs/src/pages/components/tree/index.zh-CN.md
@@ -65,7 +65,7 @@ demo:
 | loadData | 异步加载数据 | function(node) | - | - | × |
 | loadedKeys | （受控）已经加载的节点，需要配合 `loadData` 使用 | string[] | [] | - | × |
 | multiple | 支持点选多个节点（节点本身） | boolean | false | - | × |
-| rootStyle | 添加在 Tree 最外层的 style | CSSProperties | - | - | × |
+| ~~rootStyle~~ | Tree 最外层样式，请使用 `styles.root` 替代 | CSSProperties | - | - | × |
 | selectable | 是否可选中 | boolean | true | - | × |
 | selectedKeys | （受控）设置选中的树节点，多选需设置 `multiple` 为 true，支持 `v-model:selected-keys` | string[] | - | - | × |
 | showIcon | 控制是否展示 `icon` 节点，没有默认样式 | boolean | false | - | × |

--- a/packages/antdv-next/src/collapse/style/index.ts
+++ b/packages/antdv-next/src/collapse/style/index.ts
@@ -304,7 +304,7 @@ const genBorderlessStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => {
       border: 0,
 
       [`> ${componentCls}-item`]: {
-        borderBottom: `1px solid ${colorBorder}`,
+        borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${colorBorder}`,
       },
 
       [`

--- a/packages/antdv-next/src/grid/col.tsx
+++ b/packages/antdv-next/src/grid/col.tsx
@@ -99,7 +99,7 @@ const Col = defineComponent<ColProps>(
         }
 
         // Responsive flex layout
-        if (sizeProps.flex) {
+        if (sizeProps.flex || sizeProps.flex === 0) {
           sizeClassObj[`${prefixCls.value}-${size}-flex`] = true
           sizeStyle[varName(`${size}-flex`)] = parseFlex(sizeProps.flex)
         }
@@ -128,7 +128,7 @@ const Col = defineComponent<ColProps>(
         mergedStyle.paddingLeft = `${horizontalGutter}px`
         mergedStyle.paddingRight = `${horizontalGutter}px`
       }
-      if (flex) {
+      if (flex || flex === 0) {
         mergedStyle.flex = parseFlex(flex)
         // Hack for Firefox to avoid size issue
         // https://github.com/ant-design/ant-design/pull/20023#issuecomment-564389553

--- a/packages/antdv-next/src/grid/tests/Grid.test.tsx
+++ b/packages/antdv-next/src/grid/tests/Grid.test.tsx
@@ -364,6 +364,17 @@ describe('grid', () => {
         expect(wrapper.find('.ant-col').attributes('style')).toContain('flex: 1 0 auto')
       })
 
+      it('should support zero flex', () => {
+        const wrapper = mount(Col, { props: { flex: 0 } })
+        expect(wrapper.find('.ant-col').attributes('style')).toContain('flex: 0 0 auto')
+      })
+
+      it('should support zero flex as string', () => {
+        const wrapper = mount(Col, { props: { flex: '0' } })
+        // jsdom expands the shorthand `flex: 0` to `0 1 0%`
+        expect(wrapper.find('.ant-col').attributes('style')).toContain('flex: 0 1 0%')
+      })
+
       it('should set minWidth 0 when flex is set and Row wrap is false', () => {
         const wrapper = mount(() => (
           <Row wrap={false}>
@@ -428,6 +439,15 @@ describe('grid', () => {
         })
         const classes = wrapper.find('.ant-col').classes()
         expect(classes).toContain('ant-col-xs-flex')
+      })
+
+      it('should support responsive zero flex', () => {
+        const wrapper = mount(Col, {
+          props: { xs: { flex: 0 } },
+        })
+        const col = wrapper.find('.ant-col')
+        expect(col.classes()).toContain('ant-col-xs-flex')
+        expect(col.attributes('style')).toContain('--ant-col-xs-flex: 0 0 auto')
       })
 
       it('should support all breakpoints', () => {

--- a/packages/antdv-next/src/input/Search.tsx
+++ b/packages/antdv-next/src/input/Search.tsx
@@ -15,6 +15,7 @@ import { getAttrStyleAndClass, useMergeSemantic, useToArr, useToProps } from '..
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools'
 import Button from '../button'
 import { useComponentBaseConfig } from '../config-provider/context'
+import { useDisabledContext } from '../config-provider/DisabledContext.tsx'
 import { useSize } from '../config-provider/hooks/useSize'
 import { SpaceCompact } from '../space'
 import { useCompactItemContext } from '../space/Compact.tsx'
@@ -143,6 +144,9 @@ const InternalSearch = defineComponent<
       'variant',
     )
 
+    const contextDisabled = useDisabledContext()
+    const mergedDisabled = computed(() => customDisabled.value ?? contextDisabled.value)
+
     const [hashId, cssVarCls] = useStyle(prefixCls)
     const { compactSize } = useCompactItemContext(prefixCls, direction)
     const mergedSize = useSize<SizeType>(ctx => (customizeSize.value ?? compactSize.value ?? ctx) as SizeType)
@@ -260,16 +264,18 @@ const InternalSearch = defineComponent<
       const isAntdButton = isButtonVNode && Boolean((enterButtonNode.type as any)?.__ANT_BUTTON)
       const isNativeButton = isButtonVNode && (enterButtonNode.type as any) === 'button'
       if (isAntdButton || isNativeButton) {
+        const enterButtonProps = (enterButtonNode as any)?.props ?? {}
         buttonNode = cloneVNode(enterButtonNode as any, {
+          disabled: mergedDisabled.value || enterButtonProps.disabled || (!isAntdButton && props.loading),
           onMousedown: onMouseDown,
           onClick: (e: MouseEvent) => {
-            ;(enterButtonNode as any)?.props?.onClick?.(e)
+            enterButtonProps.onClick?.(e)
             onSearchClick(e)
           },
-          class: clsx((enterButtonNode as any)?.props?.class, btnClassName),
+          class: clsx(enterButtonProps.class, btnClassName),
           ...(isAntdButton
             ? {
-                loading: props.loading,
+                loading: props.loading || enterButtonProps.loading,
                 size: mergedSize.value,
               }
             : {}),

--- a/packages/antdv-next/src/input/tests/Search.test.tsx
+++ b/packages/antdv-next/src/input/tests/Search.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h, nextTick, ref } from 'vue'
 import Input from '..'
+import Button from '../../button'
+import ConfigProvider from '../../config-provider'
 import rtlTest from '/@tests/shared/rtlTest'
 import { mount } from '/@tests/utils'
 
@@ -105,6 +107,97 @@ describe('search', () => {
       },
     })
     expect(wrapper.find('.ant-btn-loading').exists()).toBe(true)
+  })
+
+  describe('custom enterButton disabled/loading', () => {
+    it('should disable custom Button when disabled prop is true', async () => {
+      const onSearch = vi.fn()
+      const wrapper = mount(() => (
+        <Search disabled enterButton={<Button>ok</Button>} onSearch={onSearch} />
+      ))
+
+      const button = wrapper.find('button')
+      expect(button.attributes('disabled')).toBeDefined()
+      await button.trigger('click')
+      expect(onSearch).not.toHaveBeenCalled()
+    })
+
+    it('should disable custom native button when disabled prop is true', async () => {
+      const onSearch = vi.fn()
+      const wrapper = mount(() => (
+        <Search disabled enterButton={<button type="button">ok</button>} onSearch={onSearch} />
+      ))
+
+      const button = wrapper.find('button')
+      expect(button.attributes('disabled')).toBeDefined()
+      await button.trigger('click')
+      expect(onSearch).not.toHaveBeenCalled()
+    })
+
+    it('should preserve disabled context for custom Button', async () => {
+      const onSearch = vi.fn()
+      const wrapper = mount(() => (
+        <ConfigProvider componentDisabled>
+          <Search enterButton={<Button>ok</Button>} onSearch={onSearch} />
+        </ConfigProvider>
+      ))
+
+      const button = wrapper.find('button')
+      expect(button.attributes('disabled')).toBeDefined()
+      await button.trigger('click')
+      expect(onSearch).not.toHaveBeenCalled()
+    })
+
+    it('should disable custom native button with disabled context', async () => {
+      const onSearch = vi.fn()
+      const wrapper = mount(() => (
+        <ConfigProvider componentDisabled>
+          <Search enterButton={<button type="button">ok</button>} onSearch={onSearch} />
+        </ConfigProvider>
+      ))
+
+      const button = wrapper.find('button')
+      expect(button.attributes('disabled')).toBeDefined()
+      await button.trigger('click')
+      expect(onSearch).not.toHaveBeenCalled()
+    })
+
+    it('should set custom Button to loading when loading prop is true', () => {
+      const onSearch = vi.fn()
+      const wrapper = mount(() => (
+        <Search loading enterButton={<Button>ok</Button>} onSearch={onSearch} />
+      ))
+
+      expect(wrapper.find('.ant-btn-loading').exists()).toBe(true)
+    })
+
+    it('should keep custom Button loading when its own loading is true', () => {
+      const wrapper = mount(() => (
+        <Search enterButton={<Button loading>ok</Button>} />
+      ))
+
+      expect(wrapper.find('.ant-btn-loading').exists()).toBe(true)
+    })
+
+    it('should keep custom Button disabled when its own disabled is true', () => {
+      const wrapper = mount(() => (
+        <Search enterButton={<Button disabled>ok</Button>} />
+      ))
+
+      expect(wrapper.find('button').attributes('disabled')).toBeDefined()
+    })
+
+    it('should disable custom native button when loading prop is true', async () => {
+      const onSearch = vi.fn()
+      const wrapper = mount(() => (
+        <Search loading enterButton={<button type="button">ok</button>} onSearch={onSearch} />
+      ))
+
+      const button = wrapper.find('button')
+      expect(button.attributes('disabled')).toBeDefined()
+      await button.trigger('click')
+      expect(onSearch).not.toHaveBeenCalled()
+    })
   })
 
   it('should support size prop', () => {

--- a/packages/antdv-next/src/layout/style/sider.ts
+++ b/packages/antdv-next/src/layout/style/sider.ts
@@ -120,7 +120,7 @@ const genSiderStyle: GenerateStyle<LayoutToken, CSSObject> = (token) => {
         [`${componentCls}-zero-width-trigger`]: {
           color: lightTriggerColor,
           background: lightTriggerBg,
-          border: `1px solid ${bodyBg}`, // Safe to modify to any other color
+          border: `${unit(token.lineWidth)} ${token.lineType} ${bodyBg}`, // Safe to modify to any other color
           borderInlineStart: 0,
         },
       },

--- a/packages/antdv-next/src/tag/index.tsx
+++ b/packages/antdv-next/src/tag/index.tsx
@@ -142,6 +142,9 @@ const InternalTag = defineComponent<
       if (e.defaultPrevented) {
         return
       }
+      if (href.value) {
+        e.preventDefault()
+      }
       visible.value = false
     }
 

--- a/packages/antdv-next/src/tag/tests/Tag.test.tsx
+++ b/packages/antdv-next/src/tag/tests/Tag.test.tsx
@@ -194,6 +194,36 @@ describe('tag', () => {
     expect(wrapper.find('span').classes()).toContain(`${prefixCls}-hidden`)
   })
 
+  it('should prevent navigation when closing a link tag', async () => {
+    const onClose = vi.fn()
+    const wrapper = mount(Tag, {
+      props: { href: '#target', closable: true, onClose },
+      slots: { default: () => 'Link' },
+    })
+    const closeIcon = wrapper.find(`.${prefixCls}-close-icon`).element
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true })
+    closeIcon.dispatchEvent(clickEvent)
+    await nextTick()
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(clickEvent.defaultPrevented).toBe(true)
+    expect(wrapper.find('a').classes()).toContain(`${prefixCls}-hidden`)
+  })
+
+  it('should not preventDefault when closing a non-link tag', async () => {
+    const wrapper = mount(Tag, {
+      props: { closable: true },
+      slots: { default: () => 'Closable' },
+    })
+    const closeIcon = wrapper.find(`.${prefixCls}-close-icon`).element
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true })
+    closeIcon.dispatchEvent(clickEvent)
+    await nextTick()
+
+    expect(clickEvent.defaultPrevented).toBe(false)
+    expect(wrapper.find('span').classes()).toContain(`${prefixCls}-hidden`)
+  })
+
   it('should prevent hiding when close event calls preventDefault', async () => {
     const onClose = vi.fn((e: MouseEvent) => e.preventDefault())
     const wrapper = mount(Tag, {

--- a/packages/antdv-next/src/tree/Tree.tsx
+++ b/packages/antdv-next/src/tree/Tree.tsx
@@ -11,11 +11,13 @@ import { omit } from 'es-toolkit'
 import { computed, defineComponent, shallowRef } from 'vue'
 import {
   useMergeSemantic,
+  useSemanticRootStyle,
   useToArr,
   useToProps,
 } from '../_util/hooks'
 import initCollapseMotion from '../_util/motion.ts'
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools.ts'
+import { devUseWarning, isDev } from '../_util/warning'
 import { useComponentBaseConfig } from '../config-provider/context.ts'
 import { useDisabledContext } from '../config-provider/DisabledContext.tsx'
 import { useToken } from '../theme/internal'
@@ -153,6 +155,7 @@ export interface TreeProps<T extends BasicDataNode = DataNode>
     | 'switcherIcon'
     | 'classNames'
     | 'rootClassName'
+    | 'rootStyle'
     | 'styles'
     | 'onCheck'
     | 'onClick'
@@ -184,6 +187,8 @@ export interface TreeProps<T extends BasicDataNode = DataNode>
   showLine?: boolean | { showLeafIcon: boolean | TreeLeafIcon }
   classes?: TreeClassNamesType
   styles?: TreeStylesType
+  /** @deprecated Please use `styles.root` instead */
+  rootStyle?: CSSProperties
 
   /** Whether to support multiple selection */
   multiple?: boolean
@@ -318,7 +323,14 @@ const Tree = defineComponent<
       styles: contextStyles,
     } = useComponentBaseConfig('tree', props)
     const treeRef = shallowRef()
-    const { classes, styles, motion: customMotion } = toPropsRefs(props, 'classes', 'styles', 'motion')
+    const { classes, styles, motion: customMotion, rootStyle } = toPropsRefs(props, 'classes', 'styles', 'motion', 'rootStyle')
+
+    // =================Warning===================
+    if (isDev) {
+      const warning = devUseWarning('Tree')
+      warning.deprecated(!rootStyle.value, 'rootStyle', 'styles.root')
+    }
+
     const contextDisabled = useDisabledContext()
     const mergedDisabled = computed(() => props?.disabled ?? contextDisabled.value)
     const motion = computed(() => customMotion.value ?? {
@@ -335,11 +347,16 @@ const Tree = defineComponent<
       } as TreeProps
     })
 
+    const rootStyleRoot = useSemanticRootStyle(rootStyle)
     const [mergedClassNames, mergedStyles] = useMergeSemantic<
       TreeClassNamesType,
       TreeStylesType,
       TreeProps
-    >(useToArr(contextClassNames, classes), useToArr(contextStyles, styles), useToProps(mergedProps))
+    >(
+      useToArr(contextClassNames, classes),
+      useToArr(contextStyles, rootStyleRoot as any, styles),
+      useToProps(mergedProps),
+    )
     const [hashId, cssVarCls] = useStyle(prefixCls)
     const [, token] = useToken()
 

--- a/packages/antdv-next/src/tree/style/index.ts
+++ b/packages/antdv-next/src/tree/style/index.ts
@@ -177,7 +177,7 @@ export function genBaseStyle(prefixCls: string, token: TreeToken): CSSObject {
           [`${treeNodeCls}.dragging:after`]: {
             position: 'absolute',
             inset: 0,
-            border: `1px solid ${token.colorPrimary}`,
+            border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorPrimary}`,
             opacity: 0,
             animationName: treeNodeFX,
             animationDuration: token.motionDurationSlow,
@@ -362,7 +362,7 @@ export function genBaseStyle(prefixCls: string, token: TreeToken): CSSObject {
             insetInlineEnd: token.calc(switcherSize).div(2).equal(),
             bottom: token.calc(treeNodePadding).mul(-1).equal(),
             marginInlineStart: -1,
-            borderInlineEnd: `1px solid ${token.colorBorder}`,
+            borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
             content: '""',
           },
 
@@ -370,7 +370,7 @@ export function genBaseStyle(prefixCls: string, token: TreeToken): CSSObject {
             position: 'absolute',
             width: token.calc(token.calc(switcherSize).div(2).equal()).mul(0.8).equal(),
             height: token.calc(titleHeight).div(2).equal(),
-            borderBottom: `1px solid ${token.colorBorder}`,
+            borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
             content: '""',
           },
         },
@@ -439,7 +439,7 @@ export function genBaseStyle(prefixCls: string, token: TreeToken): CSSObject {
             top: 0,
             insetInlineEnd: token.calc(switcherSize).div(2).equal(),
             bottom: token.calc(treeNodePadding).mul(-1).equal(),
-            borderInlineEnd: `1px solid ${token.colorBorder}`,
+            borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
             content: '""',
           },
 

--- a/packages/antdv-next/src/tree/tests/semantic.test.tsx
+++ b/packages/antdv-next/src/tree/tests/semantic.test.tsx
@@ -2,6 +2,7 @@ import type { TreeProps } from '..'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import Tree from '..'
+import { resetWarned } from '../../_util/warning'
 import { mount } from '/@tests/utils'
 
 describe('tree.Semantic', () => {
@@ -101,5 +102,45 @@ describe('tree.Semantic', () => {
     expect(root.classes()).toContain('dynamic-tree-root')
     const lastCall = stylesFn.mock.calls[stylesFn.mock.calls.length - 1]
     expect(lastCall?.[0].props.disabled).toBeTruthy()
+  })
+
+  it('should support deprecated rootStyle and warn', async () => {
+    resetWarned()
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const wrapper = mount(Tree, {
+      props: {
+        treeData,
+        rootStyle: { color: 'rgb(255, 0, 0)' },
+      },
+    })
+    await nextTick()
+
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Warning: [antd: Tree] `rootStyle` is deprecated. Please use `styles.root` instead.',
+      ),
+    )
+    expect(wrapper.find('.ant-tree').element).toHaveStyle({ color: 'rgb(255, 0, 0)' })
+
+    errSpy.mockRestore()
+  })
+
+  it('styles.root should override deprecated rootStyle', async () => {
+    resetWarned()
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const wrapper = mount(Tree, {
+      props: {
+        treeData,
+        rootStyle: { color: 'rgb(255, 0, 0)' },
+        styles: { root: { color: 'rgb(0, 0, 255)' } },
+      },
+    })
+    await nextTick()
+
+    expect(wrapper.find('.ant-tree').element).toHaveStyle({ color: 'rgb(0, 0, 255)' })
+
+    errSpy.mockRestore()
   })
 })

--- a/packages/antdv-next/src/typography/style/mixins.ts
+++ b/packages/antdv-next/src/typography/style/mixins.ts
@@ -86,7 +86,7 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = token =
     fontSize: '85%',
     fontFamily: token.fontFamilyCode,
     background: 'rgba(150, 150, 150, 0.1)',
-    border: '1px solid rgba(100, 100, 100, 0.2)',
+    border: `${unit(token.lineWidth)} ${token.lineType} rgba(100, 100, 100, 0.2)`,
     borderRadius: 3,
   },
 
@@ -97,7 +97,7 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = token =
     fontSize: '90%',
     fontFamily: token.fontFamilyCode,
     background: 'rgba(150, 150, 150, 0.06)',
-    border: '1px solid rgba(100, 100, 100, 0.2)',
+    border: `${unit(token.lineWidth)} ${token.lineType} rgba(100, 100, 100, 0.2)`,
     borderBottomWidth: 2,
     borderRadius: 3,
   },
@@ -157,7 +157,7 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = token =
     whiteSpace: 'pre-wrap',
     wordWrap: 'break-word',
     background: 'rgba(150, 150, 150, 0.1)',
-    border: '1px solid rgba(100, 100, 100, 0.2)',
+    border: `${unit(token.lineWidth)} ${token.lineType} rgba(100, 100, 100, 0.2)`,
     borderRadius: 3,
     fontFamily: token.fontFamilyCode,
 


### PR DESCRIPTION
同步 ant-design 上游 `534e5b2650` (6.5.1) → `78c3d84619` 之间的变更，共 19 个 commit，其中 7 个 PR 需要同步。

## 已同步

| 上游 PR | 变更 | 下游实现 |
|---|---|---|
| [#58719](https://github.com/ant-design/ant-design/pull/58719) | fix(Grid): support zero flex values | `flex \|\| flex === 0` 双处守卫，含响应式 CSS 变量分支 |
| [#58720](https://github.com/ant-design/ant-design/pull/58720) | fix(Tag): prevent navigation when closing link tags | `href` 存在时在关闭处理里 `preventDefault()` |
| [#58709](https://github.com/ant-design/ant-design/pull/58709) | fix(Tree): restore rootStyle compatibility | 补 `rootStyle` 废弃警告并经 `useSemanticRootStyle` 接入语义样式链，同步中英 API 文档 |
| [#58726](https://github.com/ant-design/ant-design/pull/58726) | fix(Input.Search): sync custom button disabled and loading states | 接入 `useDisabledContext`，`loading` 改为 `props.loading \|\| enterButtonProps.loading` |
| [#58740](https://github.com/ant-design/ant-design/pull/58740) [#58741](https://github.com/ant-design/ant-design/pull/58741) [#58742](https://github.com/ant-design/ant-design/pull/58742) [#58743](https://github.com/ant-design/ant-design/pull/58743) | fix: respect border design tokens | Typography / Tree / Collapse / Layout 共 9 处 `1px solid` → `unit(token.lineWidth) token.lineType` |
| [#58736](https://github.com/ant-design/ant-design/pull/58736) | fix(demo): preserve search text in remote users demo | `search-users.vue` 增加 `:auto-clear-search-value="false"` |

### 值得注意的两处

- **Tree rootStyle**：Vue 端存在与上游相同的回归 —— `rootStyle` 虽从 `VcTreeProps` 继承，但渲染时被 `rootStyle={mergedStyles.root}` 静默覆盖，实际是 no-op。本次修复后可用，同时给出指向 `styles.root` 的废弃警告。
- **Input.Search loading**：原实现对自定义 antd Button 直接写 `loading: props.loading`，会把用户自己传的 `loading` 覆盖成 `undefined`。

## 跳过

- [#58716](https://github.com/ant-design/ant-design/pull/58716) [#58727](https://github.com/ant-design/ant-design/pull/58727) [#58734](https://github.com/ant-design/ant-design/pull/58734) [#58739](https://github.com/ant-design/ant-design/pull/58739) — demo 的 React `createStyles` CSS-in-JS 迁移。Vue demo 使用 SFC `<style>`，无对应问题。
- [#58731](https://github.com/ant-design/ant-design/pull/58731) refactor(type) — 逐条核对为 no-op：Vue 端 `mergeClassNames` / `mergeStyles` 自 `{}` reduce 且已 filter，返回值不可能为 undefined，上游新增的可选链无处可用；泛型放宽 (`extends AnyObject | undefined`) 反而是回退，正是它逼出了上游的 `NonNullable<>` 补丁。`isFunction` 本仓不存在，`resolveStyleOrClass` 已无 `as any`。
- [#58713](https://github.com/ant-design/ant-design/pull/58713) 博客、[#58721](https://github.com/ant-design/ant-design/pull/58721) `.dumirc`、[#58729](https://github.com/ant-design/ant-design/pull/58729) [#58732](https://github.com/ant-design/ant-design/pull/58732) 依赖升级、[#58737](https://github.com/ant-design/ant-design/pull/58737) demo transition 微调。

## 测试

`pnpm lint` 通过。全量 `vitest run`：**4610 passed / 15 failed**。

15 个失败全部位于 `calendar` 与 `date-picker` 的 demo 快照，为日期差一天（`2017-09-18` vs `2017-09-17`）的时区敏感问题，与本次改动文件无交集，属既有状态，未在本地更新这些快照。
