### PR TITLE
fix(form): make getFieldInstance return the control instance (#663)

### DIFF
--- a/packages/antdv-next/src/form/Form.tsx
+++ b/packages/antdv-next/src/form/Form.tsx
@@ -18,6 +18,7 @@ import type {
   ValidateOptions,
 } from './types.ts'
 import { clsx, get, set } from '@v-c/util'
+import { getDOM } from '@v-c/util/dist/Dom/findDOMNode'
 import { pick } from 'es-toolkit'
 import scrollIntoView from 'scroll-into-view-if-needed'
 import { computed, defineComponent, getCurrentInstance, inject, onBeforeUnmount, onMounted, provide, shallowRef, watch } from 'vue'
@@ -33,7 +34,7 @@ import useLocale from '../locale/useLocale.ts'
 import { NoFormStyle, useFormContextProvider, useVariantContextProvider } from './context.tsx'
 import { FormHookRegistryKey, FormInstanceContextKey } from './hooks/useForm.ts'
 import useStyle from './style'
-import { getFieldId, toArray } from './util.ts'
+import { getFieldId, toArray, toNamePathStr } from './util.ts'
 import { allPromiseFinish } from './utils/asyncUtil'
 import { defaultValidateMessages } from './utils/messages'
 import { cloneByNamePathList, containsNamePath, getNamePath, setValue } from './utils/valueUtil.ts'
@@ -265,6 +266,23 @@ const InternalForm = defineComponent<
       delete fields.value[eventKey]
     }
 
+    // `items` tracks the rendered control instance of each Form.Item, keyed by
+    // the joined name path (`toNamePathStr`). It is intentionally separate from
+    // `fields`, which holds the internal validation bookkeeping of each field.
+    const items = shallowRef<Record<string, any>>({})
+
+    const addItem = (namePathStr: string, instance: any) => {
+      items.value[namePathStr] = instance
+    }
+
+    const removeItem = (namePathStr: string) => {
+      delete items.value[namePathStr]
+    }
+
+    const getFieldInstance = (name: NamePath) => {
+      return items.value[toNamePathStr(getNamePath(name))]
+    }
+
     const getFieldsByNameList = (namePathList?: InternalNamePath[], partialMatch = false) => {
       const mergedNamePathList = namePathList?.length ? namePathList : undefined
       const fieldList = Object.values(fields.value)
@@ -440,6 +458,8 @@ const InternalForm = defineComponent<
         feedbackIcons: feedbackIcons.value,
         addField,
         removeField,
+        addItem,
+        removeItem,
         onValidate,
         triggerValuesChange,
         triggerFieldsChange,
@@ -621,8 +641,20 @@ const InternalForm = defineComponent<
         scrollToField(getNamePath(name), options)
       },
       focusField: (name: NamePath) => {
+        // Prefer the control instance so custom components can expose their own
+        // `focus`, and fall back to the rendered DOM node.
+        const instance = getFieldInstance(name)
+        if (typeof instance?.focus === 'function') {
+          try {
+            instance.focus()
+          }
+          finally {
+            // ignore focus error
+          }
+          return
+        }
         const targetId = getFieldId(getNamePath(name), props.name)
-        const node = targetId ? document.getElementById(targetId) : null
+        const node = getDOM(instance) ?? (targetId ? document.getElementById(targetId) : null)
         if (node) {
           try {
             node.focus?.()
@@ -632,12 +664,7 @@ const InternalForm = defineComponent<
           }
         }
       },
-      getFieldInstance: (name: NamePath) => {
-        const targetId = getFieldId(getNamePath(name), props.name)
-        if (targetId) {
-          return fields.value?.[targetId]
-        }
-      },
+      getFieldInstance,
     } as unknown as FormInstance
 
     expose(formInstance)

--- a/packages/antdv-next/src/form/Form.tsx
+++ b/packages/antdv-next/src/form/Form.tsx
@@ -269,18 +269,21 @@ const InternalForm = defineComponent<
     // `items` tracks the rendered control instance of each Form.Item, keyed by
     // the joined name path (`toNamePathStr`). It is intentionally separate from
     // `fields`, which holds the internal validation bookkeeping of each field.
-    const items = shallowRef<Record<string, any>>({})
+    // A `Map` is used because the key comes from the user supplied field name,
+    // and inherited `Object` keys such as `__proto__` would otherwise be written
+    // to the prototype rather than stored as own entries.
+    const items = new Map<string, any>()
 
     const addItem = (namePathStr: string, instance: any) => {
-      items.value[namePathStr] = instance
+      items.set(namePathStr, instance)
     }
 
     const removeItem = (namePathStr: string) => {
-      delete items.value[namePathStr]
+      items.delete(namePathStr)
     }
 
     const getFieldInstance = (name: NamePath) => {
-      return items.value[toNamePathStr(getNamePath(name))]
+      return items.get(toNamePathStr(getNamePath(name)))
     }
 
     const getFieldsByNameList = (namePathList?: InternalNamePath[], partialMatch = false) => {

--- a/packages/antdv-next/src/form/FormItem/index.tsx
+++ b/packages/antdv-next/src/form/FormItem/index.tsx
@@ -14,7 +14,7 @@ import { useComponentBaseConfig } from '../../config-provider/context'
 import useCSSVarCls from '../../config-provider/hooks/useCSSVarCls'
 import { useFormContext, useFormItemProvider, useNoStyleItemContext } from '../context.tsx'
 import useStyle from '../style'
-import { getFieldId, initialValueFormat, toArray } from '../util.ts'
+import { getFieldId, initialValueFormat, toArray, toNamePathStr } from '../util.ts'
 import { validateRules } from '../utils/validateUtil.ts'
 import { getNamePath, getValue, setValue } from '../utils/valueUtil.ts'
 import ItemHolder from './ItemHolder.tsx'
@@ -452,6 +452,44 @@ const InternalFormItem = defineComponent<
     const rootClassName = computed(() => clsx(cssVarCls.value, rootCls.value, hashId.value, props.rootClass))
 
     const eventKey = computed(() => `form-item-${fieldId.value || namePath.value.join('-') || Math.random().toString(36).slice(2)}`)
+
+    // Register the rendered control instance under the joined name path so the
+    // form instance can hand it back through `getFieldInstance`.
+    let itemInstanceKey: string | undefined
+    let itemInstance: any = null
+
+    const setItemInstance = (instance: any) => {
+      itemInstance = instance
+      if (!hasName.value) {
+        return
+      }
+      const nextKey = toNamePathStr(namePath.value)
+      if (itemInstanceKey && itemInstanceKey !== nextKey) {
+        formContext.value?.removeItem?.(itemInstanceKey)
+      }
+      itemInstanceKey = nextKey
+      if (instance) {
+        formContext.value?.addItem?.(nextKey, instance)
+      }
+      else {
+        formContext.value?.removeItem?.(nextKey)
+      }
+    }
+
+    // Keep the registration in sync when the field is renamed while mounted.
+    watch(
+      [namePath, hasName],
+      () => {
+        if (itemInstanceKey) {
+          formContext.value?.removeItem?.(itemInstanceKey)
+          itemInstanceKey = undefined
+        }
+        if (itemInstance) {
+          setItemInstance(itemInstance)
+        }
+      },
+      { flush: 'post' },
+    )
     watch(
       hasName,
       (val, _, onCleanup) => {
@@ -500,6 +538,10 @@ const InternalFormItem = defineComponent<
         )
       }
       formContext.value?.removeField?.(eventKey.value)
+      if (itemInstanceKey) {
+        formContext.value?.removeItem?.(itemInstanceKey)
+        itemInstanceKey = undefined
+      }
     })
 
     useFormItemProvider({
@@ -569,6 +611,10 @@ const InternalFormItem = defineComponent<
               }
             }
           },
+          // Track the rendered control so `form.getFieldInstance(name)` can reach
+          // it. `createVNode(vnode, props)` merges refs, so a user supplied `ref`
+          // on the control still fires.
+          ref: setItemInstance,
         }
         baseChildren = createVNode(child, newChildProps)
       }

--- a/packages/antdv-next/src/form/context.tsx
+++ b/packages/antdv-next/src/form/context.tsx
@@ -42,6 +42,8 @@ export interface FormContextProps {
   clearOnDestroy?: boolean
   addField?: (eventKey: string, field: FormFieldRegister) => void
   removeField?: (eventKey: string) => void
+  addItem?: (namePathStr: string, instance: any) => void
+  removeItem?: (namePathStr: string) => void
   onValidate?: (name: InternalNamePath, status: boolean, errors: any[] | null) => void
   triggerValuesChange?: (namePath: InternalNamePath, value: any) => void
   triggerFieldsChange?: (namePathList?: InternalNamePath[]) => void

--- a/packages/antdv-next/src/form/tests/get-field-instance.test.tsx
+++ b/packages/antdv-next/src/form/tests/get-field-instance.test.tsx
@@ -1,0 +1,163 @@
+import type { FormInstance } from '..'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick, reactive, ref } from 'vue'
+import Form, { FormItem } from '..'
+import Input from '../../input'
+import { mount } from '/@tests/utils'
+
+describe('form getFieldInstance', () => {
+  it('returns the rendered control for a native element', async () => {
+    const formRef = ref<FormInstance>()
+    const model = reactive({ username: '' })
+
+    const wrapper = mount(() => (
+      <Form ref={formRef} model={model}>
+        <FormItem name="username" label="Username">
+          <input />
+        </FormItem>
+      </Form>
+    ))
+    await nextTick()
+
+    const instance = formRef.value!.getFieldInstance('username')
+    expect(instance).toBeTruthy()
+    expect(instance).toBe(wrapper.find('input').element)
+  })
+
+  it('returns the component instance for antdv controls', async () => {
+    const formRef = ref<FormInstance>()
+    const model = reactive({ username: '' })
+
+    mount(() => (
+      <Form ref={formRef} model={model}>
+        <FormItem name="username" label="Username">
+          <Input v-model={[model.username, 'value']} />
+        </FormItem>
+      </Form>
+    ))
+    await nextTick()
+
+    const instance = formRef.value!.getFieldInstance('username')
+    expect(instance).toBeTruthy()
+    expect(typeof instance.focus).toBe('function')
+  })
+
+  // The form name is not part of the lookup key — this used to be prefixed
+  // through `getFieldId`, which made every lookup miss. See #663.
+  it('works when the form declares a name', async () => {
+    const formRef = ref<FormInstance>()
+    const model = reactive({ username: '' })
+
+    mount(() => (
+      <Form ref={formRef} name="basic" model={model}>
+        <FormItem name="username" label="Username">
+          <input />
+        </FormItem>
+      </Form>
+    ))
+    await nextTick()
+
+    expect(formRef.value!.getFieldInstance('username')).toBeTruthy()
+  })
+
+  it('supports nested name paths', async () => {
+    const formRef = ref<FormInstance>()
+    const model = reactive({ profile: { nickname: '' } })
+
+    mount(() => (
+      <Form ref={formRef} model={model}>
+        <FormItem name={['profile', 'nickname']} label="Nickname">
+          <input />
+        </FormItem>
+      </Form>
+    ))
+    await nextTick()
+
+    expect(formRef.value!.getFieldInstance(['profile', 'nickname'])).toBeTruthy()
+    expect(formRef.value!.getFieldInstance('missing')).toBeUndefined()
+  })
+
+  it('does not break a user supplied ref on the control', async () => {
+    const formRef = ref<FormInstance>()
+    const inputRef = ref<any>()
+    const model = reactive({ username: '' })
+
+    mount(() => (
+      <Form ref={formRef} model={model}>
+        <FormItem name="username" label="Username">
+          <input ref={inputRef} />
+        </FormItem>
+      </Form>
+    ))
+    await nextTick()
+
+    expect(inputRef.value).toBeTruthy()
+    expect(formRef.value!.getFieldInstance('username')).toBe(inputRef.value)
+  })
+
+  it('releases the instance when the field unmounts', async () => {
+    const formRef = ref<FormInstance>()
+    const model = reactive({ username: '' })
+    const visible = ref(true)
+
+    mount(() => (
+      <Form ref={formRef} model={model}>
+        {visible.value
+          ? (
+              <FormItem name="username" label="Username">
+                <input />
+              </FormItem>
+            )
+          : null}
+      </Form>
+    ))
+    await nextTick()
+    expect(formRef.value!.getFieldInstance('username')).toBeTruthy()
+
+    visible.value = false
+    await nextTick()
+    expect(formRef.value!.getFieldInstance('username')).toBeUndefined()
+  })
+
+  it('focusField prefers the control focus method', async () => {
+    const formRef = ref<FormInstance>()
+    const model = reactive({ username: '' })
+    const focus = vi.fn()
+
+    const CustomControl = defineComponent({
+      setup(_, { expose }) {
+        expose({ focus })
+        return () => <input />
+      },
+    })
+
+    mount(() => (
+      <Form ref={formRef} model={model}>
+        <FormItem name="username" label="Username">
+          <CustomControl />
+        </FormItem>
+      </Form>
+    ))
+    await nextTick()
+
+    formRef.value!.focusField('username')
+    expect(focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('focusField falls back to the rendered DOM node', async () => {
+    const formRef = ref<FormInstance>()
+    const model = reactive({ username: '' })
+
+    const wrapper = mount(() => (
+      <Form ref={formRef} model={model}>
+        <FormItem name="username" label="Username">
+          <input />
+        </FormItem>
+      </Form>
+    ), { attachTo: document.body })
+    await nextTick()
+
+    formRef.value!.focusField('username')
+    expect(document.activeElement).toBe(wrapper.find('input').element)
+  })
+})

--- a/packages/antdv-next/src/form/tests/get-field-instance.test.tsx
+++ b/packages/antdv-next/src/form/tests/get-field-instance.test.tsx
@@ -119,6 +119,43 @@ describe('form getFieldInstance', () => {
     expect(formRef.value!.getFieldInstance('username')).toBeUndefined()
   })
 
+  // The key comes from the user supplied field name, so inherited Object keys
+  // must not reach the registry prototype.
+  it('handles field names that collide with Object prototype keys', async () => {
+    const formRef = ref<FormInstance>()
+    const model = reactive({ __proto__: '', constructor: '' } as any)
+    const visible = ref(true)
+
+    mount(() => (
+      <Form ref={formRef} model={model}>
+        {visible.value
+          ? (
+              <>
+                <FormItem name="__proto__" label="Proto">
+                  <input class="proto-input" />
+                </FormItem>
+                <FormItem name="constructor" label="Ctor">
+                  <input class="ctor-input" />
+                </FormItem>
+              </>
+            )
+          : null}
+      </Form>
+    ))
+    await nextTick()
+
+    expect(formRef.value!.getFieldInstance('__proto__')).toBeTruthy()
+    expect(formRef.value!.getFieldInstance('constructor')).toBeTruthy()
+    expect(formRef.value!.getFieldInstance('__proto__'))
+      .not
+      .toBe(formRef.value!.getFieldInstance('constructor'))
+
+    visible.value = false
+    await nextTick()
+    expect(formRef.value!.getFieldInstance('__proto__')).toBeUndefined()
+    expect(formRef.value!.getFieldInstance('constructor')).toBeUndefined()
+  })
+
   it('focusField prefers the control focus method', async () => {
     const formRef = ref<FormInstance>()
     const model = reactive({ username: '' })

--- a/packages/antdv-next/src/form/util.ts
+++ b/packages/antdv-next/src/form/util.ts
@@ -17,6 +17,15 @@ export function toArray<T>(candidate?: T | T[] | false): T[] {
   return Array.isArray(candidate) ? candidate : [candidate]
 }
 
+/**
+ * Key used to track the rendered control instance of a Form.Item.
+ * Unlike `getFieldId`, this is not prefixed with the form name, so it stays
+ * stable no matter whether the Form declares a `name`.
+ */
+export function toNamePathStr(namePath: InternalNamePath): string {
+  return namePath.join('_')
+}
+
 export function getFieldId(namePath: InternalNamePath, formName?: string): string | undefined {
   if (!namePath.length) {
     return undefined


### PR DESCRIPTION
close #663

## 问题

`form.getFieldInstance(name)` 在任何情况下都返回 `undefined`。

### 根因 1：注册键与查找键不一致

`FormItem` 注册时带 `form-item-` 前缀：

```ts
// form/FormItem/index.tsx
const eventKey = computed(() => `form-item-${fieldId.value || ...}`)
formContext.value.addField(eventKey.value, { ... })   // → fields['form-item-username']
```

而 `Form` 查找时用的是裸 `fieldId`：

```ts
// form/Form.tsx
const targetId = getFieldId(getNamePath(name), props.name)   // → 'username'
return fields.value?.[targetId]                              // → 恒为 undefined
```

### 根因 2：返回值语义与 antd 不一致

`fields` 存的是 `FormFieldRegister` —— 校验用的内部记账对象（`namePath` / `getValue` / `getMeta` / `validateRules`…）。而上游 antd 返回的是 **Form.Item 包裹的那个控件实例**：

```ts
// ant-design/components/form/hooks/useForm.ts
getFieldInstance: (name) => itemsRef.current[toNamePathStr(name)]
```

它的契约是「能 `.focus()`、能被 `getDOM()` 解析」。只对齐 key 的话，用户拿到的仍然是个调不了 `.focus()` 的内部对象。

## 改动

- `Form` 新增 `items` 注册表，与校验用的 `fields` 分离，key 为 `namePath.join('_')`（对齐上游 `toNamePathStr`，**不带** form name 前缀，所以 Form 有没有 `name` 都不影响查找）
- `FormItem` 在给单一子节点注入 `id`/`onBlur`/`onFocus` 的同一处挂上函数 ref，把控件实例登记进去。因为 `createVNode(vnode, props)` 会**合并** ref，用户自己写在控件上的 `ref` 照常触发
- 字段重命名时同步迁移 key，卸载时清理
- `focusField` 对齐上游：优先调用实例自己的 `focus()`（自定义控件更准），回落到 `getDOM()`，再回落到原来的 `document.getElementById`

## 测试

`src/form/tests/get-field-instance.test.tsx`，8 个用例：原生元素 / antdv 控件 / Form 带 name / 嵌套 name path / 不破坏用户自己的 ref / 卸载后释放 / focusField 两条路径。

把源码改动 stash 掉后 **8 个里有 7 个失败**，剩下那个是 `focusField` 的 DOM 回落路径 —— 它本来就走 `getElementById`，没被这个 bug 波及，保留作回归护栏。

`npx vitest run form` 21 文件 151 用例全绿，`pnpm lint` 通过。
