### PR TITLE
fix(build): fix browser bundles — process.env crash and app.use(window.antd) (#666)

### DIFF
--- a/packages/antdv-next/package.json
+++ b/packages/antdv-next/package.json
@@ -177,7 +177,8 @@
   },
   "scripts": {
     "test": "vitest run",
-    "build": "run-s build:esm build:vite:parallel build:p",
+    "build": "run-s build:esm build:vite:parallel build:verify build:p",
+    "build:verify": "tsx ./scripts/verify-browser-bundle.ts",
     "build:p": "run-p build:web-types build:style",
     "build:esm": "tsdown",
     "build:with-locales": "run-p build:with-locales:esm build:with-locales:umd",

--- a/packages/antdv-next/scripts/verify-browser-bundle.ts
+++ b/packages/antdv-next/scripts/verify-browser-bundle.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const distDir = path.resolve(__dirname, '../dist')
+
+// The browser-facing bundles must not reference the `process` global unguarded:
+// unpkg/jsdelivr and native ESM users run them where `process` does not exist,
+// so a bare `process.env.NODE_ENV` throws `ReferenceError: process is not
+// defined` and the whole bundle fails to load (#666). `typeof process` guards
+// are fine — they short-circuit to "undefined" in the browser.
+const BROWSER_BUNDLES = [
+  'antd.js',
+  'antd.esm.js',
+  'antd-with-locales.js',
+  'antd-with-locales.esm.js',
+]
+
+function findUnguardedProcess(code: string): number[] {
+  const offsets: number[] = []
+  let i = -1
+  // eslint-disable-next-line no-cond-assign
+  while ((i = code.indexOf('process.env', i + 1)) !== -1) {
+    const before = code.slice(Math.max(0, i - 40), i)
+    if (!/typeof process\s*[<!=]/.test(before)) {
+      offsets.push(i)
+    }
+  }
+  return offsets
+}
+
+async function main() {
+  const failures: string[] = []
+
+  for (const file of BROWSER_BUNDLES) {
+    const filePath = path.join(distDir, file)
+    let code: string
+    try {
+      code = await fs.readFile(filePath, 'utf8')
+    }
+    catch {
+      failures.push(`${file}: missing — build it before running this check`)
+      continue
+    }
+
+    const offsets = findUnguardedProcess(code)
+    if (offsets.length) {
+      const sample = code.slice(offsets[0] - 20, offsets[0] + 25).replace(/\n/g, ' ')
+      failures.push(`${file}: ${offsets.length} unguarded \`process.env\` reference(s), e.g. ...${sample}...`)
+    }
+    else {
+      console.log(`✓ ${file}: no unguarded process reference`)
+    }
+  }
+
+  if (failures.length) {
+    console.error('\n✗ Browser bundle verification failed:')
+    for (const f of failures) {
+      console.error(`  - ${f}`)
+    }
+    console.error('\nAdd `define: { \'process.env.NODE_ENV\': JSON.stringify(\'production\') }` to the offending vite config.')
+    process.exit(1)
+  }
+}
+
+main()

--- a/packages/antdv-next/src/index.ts
+++ b/packages/antdv-next/src/index.ts
@@ -14,20 +14,28 @@ export type {
 export type { ThemeConfig } from './config-provider/context'
 let prefix = 'A'
 export { useBreakpoint } from './grid'
+
+export function setPrefix(newPrefix: string) {
+  prefix = newPrefix
+}
+
+export function install(app: App) {
+  app.config.globalProperties._ant_prefix = prefix
+  Object.keys(components).forEach((key) => {
+    const component = (components as any)[key]
+    if ('install' in component) {
+      app.use(component)
+    }
+  })
+  app.component('AStyleProvider', StyleProvider)
+}
+
+// The default export doubles as a Vue plugin. `install` and `setPrefix` are also
+// exposed as named exports so the UMD/ESM globals (`window.antd`) carry `install`
+// directly, letting `app.use(window.antd)` work without reaching for `.default`.
 export default {
-  setPrefix(newPrefix: string) {
-    prefix = newPrefix
-  },
-  install(app: App) {
-    app.config.globalProperties._ant_prefix = prefix
-    Object.keys(components).forEach((key) => {
-      const component = (components as any)[key]
-      if ('install' in component) {
-        app.use(component)
-      }
-    })
-    app.component('AStyleProvider', StyleProvider)
-  },
+  setPrefix,
+  install,
   version,
 } as Plugin
 

--- a/packages/antdv-next/src/index.with-locales.ts
+++ b/packages/antdv-next/src/index.with-locales.ts
@@ -1,5 +1,10 @@
 import type { Locale } from './locale'
-import * as antd from '.'
+import antd from '.'
+
+// Re-export the full named surface (components, `install`, `theme`, …) so the
+// with-locales UMD/ESM global carries `install` at the top level and
+// `app.use(window.antd)` works directly. See src/index.ts.
+export * from '.'
 
 interface LocaleModule { default: Locale }
 

--- a/packages/antdv-next/vite.config.ts
+++ b/packages/antdv-next/vite.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     }),
     vueJsx(),
   ],
+  // Browser-facing bundle: replace `process.env.NODE_ENV` so the output does
+  // not reference the missing `process` global in the browser (#666).
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('production'),
+  },
   build: {
     rolldownOptions: {
       external: [

--- a/packages/antdv-next/vite.esm.config.ts
+++ b/packages/antdv-next/vite.esm.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     }),
     vueJsx(),
   ],
+  // Browser-facing bundle: replace `process.env.NODE_ENV` so the output does
+  // not reference the missing `process` global in the browser (#666).
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('production'),
+  },
   build: {
     rolldownOptions: {
       external: [

--- a/packages/antdv-next/vite.with-locales.config.ts
+++ b/packages/antdv-next/vite.with-locales.config.ts
@@ -15,6 +15,11 @@ export default defineConfig(
         }),
         vueJsx(),
       ],
+      // Browser-facing bundle: replace `process.env.NODE_ENV` so the output
+      // does not reference the missing `process` global in the browser (#666).
+      define: {
+        'process.env.NODE_ENV': JSON.stringify('production'),
+      },
       build: {
         rolldownOptions: {
           external: isUmd ? ['vue', /^dayjs/] : ['vue'],


### PR DESCRIPTION
close #666

CDN 直接引用 `dist/antd.js` / `dist/antd-with-locales.js` 时的两个问题，都在浏览器实测验证过。

## 问题 1：`ReferenceError: process is not defined`（issue 原文）

四个面向浏览器的产物泄漏了裸 `process.env.NODE_ENV`（来自 antd/rc 的开发期警告分支）。打包器消费方会自动替换，所以 tsdown 的 `dist/index.js` 没事；但三个 `vite build` 配置都没配 `define`，Vite 在 library 模式下又不替换，于是 `process` 原样进产物，浏览器一加载即崩。

**修复**：给三个浏览器向 vite 配置各加 `define: { 'process.env.NODE_ENV': JSON.stringify('production') }`（`vite.config.ts` / `vite.esm.config.ts` / `vite.with-locales.config.ts`）。tsdown 入口不动——打包器消费方保留 `process.env.NODE_ENV` 才对。with-locales 配置顶层还在 Node 侧读 `process.env.WITH_LOCALES_FORMAT`，所以只精确替换 `NODE_ENV`。

## 问题 2：`app.use(window.antd)` 不注册组件（同 issue 复现，修完问题 1 才暴露）

崩溃修好后发现按钮仍不渲染：UMD 用 `exports: 'named'`，真正带 `install` 的 Plugin 埋在 `window.antd.default`；`antd-with-locales` 入口又多套一层 `export default { ...antd, locales }`，导致 install 埋到 `window.antd.default.default`。于是 issue 里的 `app.use(window.antd)` 静默 no-op（生产版 Vue 把「插件无 install」的警告 strip 了），组件永不注册。

**修复**：
- `src/index.ts`：把 `install` / `setPrefix` 抽成命名导出（default 仍是同一套函数，形状不变，向后兼容），于是 `window.antd.install` 直接存在。
- `src/index.with-locales.ts`：`export * from '.'` 把完整命名面（含 `install`）提到顶层，`import antd from '.'` 改取默认插件，`export default { ...antd, locales }` 不再双层嵌套。

两个 UMD 现在 `window.antd.install` 都在顶层，`app.use(window.antd)` 开箱即用；`window.antd.default` 也仍可用。

## 回归护栏

新增 `scripts/verify-browser-bundle.ts`，接入 build 链（`build:vite:parallel` 之后）。扫描四个浏览器产物，出现未被 `typeof process` 守卫的 `process.env` 即 `exit 1`，让 `pnpm build` 失败。CI 只跑 vitest 不构建，所以放构建期而非做成读 dist 的单测。

## 验证（headless Chrome 实测新产物）

- 用 issue 原样的 `app.use(window.antd)`：
  - `antd.js` → `hasInstall: function`，按钮渲染 `ant-btn ant-btn-primary …`，`errors: []`
  - `antd-with-locales.js` → 同上，`errors: []`
- 四产物 `process.env.NODE_ENV` 计数归零；仅剩 1 处 `typeof process<'u' && process.env` 守卫访问（浏览器安全短路）。
- 反例：临时移除 `define` 重建，`build:verify` 捕获 57 处并 exit 1。
- ESM/tsdown 入口：命名 `install` / `setPrefix` / `default` 均存在；with-locales ESM 的 `install` + `locales` + `default.install` + `default.locales` 均正常。
- `pnpm -F antdv-next build` 全链路通过；`vitest run config-provider button` 164 passed；lint 通过。
