### PR TITLE
chore(sync): sync ant-design upstream changes up to ee9a9ab678

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React 主组件库 -> antdv-next 主包"
         }
       ],
-      "last_synced_commit": "78c3d8461978044558287f83aff911d9c4973eb9",
-      "last_synced_commit_short": "78c3d84619",
-      "last_synced_at": "2026-07-19T00:00:00Z",
+      "last_synced_commit": "ee9a9ab678f53a78c02307d27521511660afd6b2",
+      "last_synced_commit_short": "ee9a9ab678",
+      "last_synced_at": "2026-07-21T00:00:00Z",
       "last_synced_tag": "6.5.1",
-      "sync_count": 22
+      "sync_count": 23
     },
     {
       "name": "cssinjs",

--- a/docs/src/pages/components/alert/demo/style-class.vue
+++ b/docs/src/pages/components/alert/demo/style-class.vue
@@ -1,5 +1,5 @@
 <docs lang="zh-CN">
-通过 `classes` 和 `styles` 传入对象/函数可以自定义 Alert 的[语义化结构](#semantic-dom)样式。
+通过 `classes` 和 `styles` 传入对象/函数可以自定义 Alert 的 [语义化结构](#semantic-dom) 样式。
 </docs>
 
 <docs lang="en-US">

--- a/docs/src/pages/components/tag/demo/icon.vue
+++ b/docs/src/pages/components/tag/demo/icon.vue
@@ -1,9 +1,13 @@
 <docs lang="zh-CN">
-你可以通过 `icon` 插槽为标签添加自定义图标
+你可以通过 `icon` 插槽为标签添加自定义图标。
+
+`icon` 插槽也支持第三方图标库的裸 `<svg>` 元素，无论其尺寸以 `em` 还是 `px` 设置，都会自动与文字居中对齐。
 </docs>
 
 <docs lang="en-US">
 You can add a custom icon to the tag via the `icon` slot.
+
+The `icon` slot also accepts a bare `<svg>` element from a third-party icon library. It stays vertically centred with the label whether it is sized in `em` or in `px`.
 </docs>
 
 <script setup lang="ts">
@@ -87,5 +91,36 @@ function handleChange(index: number, value: boolean) {
       </template>
       LinkedIn
     </a-checkable-tag>
+  </a-flex>
+  <a-divider title-placement="start">
+    Tag with third-party icon
+  </a-divider>
+  <a-flex gap="small" wrap align="center">
+    <a-tag color="#f50">
+      <template #icon>
+        <!-- Sized in `em` -->
+        <svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor" aria-hidden="true">
+          <path d="M12 2l2.9 6.3 6.9.8-5.1 4.7 1.4 6.8L12 17.2 5.9 20.6l1.4-6.8L2.2 9.1l6.9-.8z" />
+        </svg>
+      </template>
+      Star (em)
+    </a-tag>
+    <a-tag color="#eb2f96">
+      <template #icon>
+        <!-- Sized in `px`, like lucide's default -->
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+          <path d="M12 20.7l-1.4-1.3C5.4 14.8 2 11.7 2 8a5 5 0 0 1 10-1.7A5 5 0 0 1 22 8c0 3.7-3.4 6.8-8.6 11.4L12 20.7z" />
+        </svg>
+      </template>
+      Heart (px)
+    </a-tag>
+    <a-tag closable>
+      <template #icon>
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+          <path d="M12 20.7l-1.4-1.3C5.4 14.8 2 11.7 2 8a5 5 0 0 1 10-1.7A5 5 0 0 1 22 8c0 3.7-3.4 6.8-8.6 11.4L12 20.7z" />
+        </svg>
+      </template>
+      Closable
+    </a-tag>
   </a-flex>
 </template>

--- a/packages/antdv-next/src/button/style/variant.ts
+++ b/packages/antdv-next/src/button/style/variant.ts
@@ -6,7 +6,7 @@ import { PresetColors } from '../../theme/interface'
 import { genCssVar } from '../../theme/util/genStyleUtils'
 
 const genVariantStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
-  const { componentCls, antCls, lineWidth } = token
+  const { componentCls, antCls, lineWidth, lineType } = token
 
   const [varName, varRef] = genCssVar(antCls, 'btn')
 
@@ -24,7 +24,7 @@ const genVariantStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
         [varName('border-color-active')]: varRef('border-color'),
         [varName('border-color-disabled')]: varRef('border-color'),
 
-        [varName('border-style')]: 'solid',
+        [varName('border-style')]: lineType,
 
         // Text
         [varName('text-color')]: '#000',

--- a/packages/antdv-next/src/color-picker/style/index.ts
+++ b/packages/antdv-next/src/color-picker/style/index.ts
@@ -93,14 +93,14 @@ const genRtlStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
 }
 
 function genClearStyle(token: ColorPickerToken, size: number, extraStyle?: CSSObject): CSSObject {
-  const { componentCls, borderRadiusSM, lineWidth, colorSplit, colorBorder, red6 } = token
+  const { componentCls, borderRadiusSM, lineWidth, lineType, colorSplit, colorBorder, red6 } = token
 
   return {
     [`${componentCls}-clear`]: {
       width: size,
       height: size,
       borderRadius: borderRadiusSM,
-      border: `${unit(lineWidth)} solid ${colorSplit}`,
+      border: `${unit(lineWidth)} ${lineType} ${colorSplit}`,
       position: 'relative',
       overflow: 'hidden',
       cursor: 'inherit',
@@ -222,6 +222,7 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
     colorPickerPresetColorSize,
     colorPickerPreviewSize,
     lineWidth,
+    lineType,
     colorBorder,
     paddingXXS,
     fontSize,
@@ -266,7 +267,7 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
           minWidth: controlHeight,
           minHeight: controlHeight,
           borderRadius,
-          border: `${unit(lineWidth)} solid ${colorBorder}`,
+          border: `${unit(lineWidth)} ${lineType} ${colorBorder}`,
           cursor: 'pointer',
           display: 'inline-flex',
           alignItems: 'flex-start',

--- a/packages/antdv-next/src/select/style/select-input-multiple.ts
+++ b/packages/antdv-next/src/select/style/select-input-multiple.ts
@@ -16,6 +16,7 @@ const genSelectInputMultipleStyle: GenerateStyle<SelectToken, CSSObject> = (toke
     paddingXXS,
     INTERNAL_FIXED_ITEM_MARGIN,
     lineWidth,
+    lineType,
     colorIcon,
     colorIconHover,
     inputPaddingHorizontalBase,
@@ -91,7 +92,7 @@ const genSelectInputMultipleStyle: GenerateStyle<SelectToken, CSSObject> = (toke
 
         [`${componentCls}-selection-item`]: {
           lineHeight: `calc(${varRef('multi-item-height')} - ${lineWidth} * 2)`,
-          border: `${lineWidth} solid ${varRef('multi-item-border-color')}`,
+          border: `${lineWidth} ${lineType} ${varRef('multi-item-border-color')}`,
           display: 'flex',
           marginBlock: INTERNAL_FIXED_ITEM_MARGIN,
           marginInlineEnd: calc(INTERNAL_FIXED_ITEM_MARGIN).mul(2).equal(),

--- a/packages/antdv-next/src/space/style/addon.ts
+++ b/packages/antdv-next/src/space/style/addon.ts
@@ -26,6 +26,7 @@ const genSpaceAddonStyle: GenerateStyle<SpaceToken, CSSObject> = (token) => {
     borderRadiusSM,
     colorBgContainerDisabled,
     lineWidth,
+    lineType,
     antCls,
   } = token
 
@@ -44,7 +45,7 @@ const genSpaceAddonStyle: GenerateStyle<SpaceToken, CSSObject> = (token) => {
         paddingInline: paddingSM,
         margin: 0,
         borderWidth: lineWidth,
-        borderStyle: 'solid',
+        borderStyle: lineType,
         borderRadius,
 
         '&:hover': {

--- a/packages/antdv-next/src/table/style/bordered.ts
+++ b/packages/antdv-next/src/table/style/bordered.ts
@@ -3,9 +3,11 @@ import type { GenerateStyle } from '../../theme/internal'
 
 import type { TableToken } from './index'
 import { unit } from '@antdv-next/cssinjs'
+import { genCssVar } from '../../theme/util/genStyleUtils'
 
 const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
   const {
+    antCls,
     componentCls,
     lineWidth,
     lineType,
@@ -16,6 +18,7 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
     calc,
   } = token
   const tableBorder = `${unit(lineWidth)} ${lineType} ${tableBorderColor}`
+  const [varName, varRef] = genCssVar(antCls, 'table')
 
   const getSizeBorderStyle = (
     size: 'small' | 'medium',
@@ -41,6 +44,8 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
 
   return {
     [`${componentCls}-wrapper`]: {
+      [varName('nested-border-top')]: tableBorder,
+
       [`${componentCls}${componentCls}-bordered`]: {
         // ============================ Title =============================
         [`> ${componentCls}-title`]: {
@@ -52,6 +57,10 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
         [`> ${componentCls}-container`]: {
           borderInlineStart: tableBorder,
           borderTop: tableBorder,
+
+          '&:first-child': {
+            borderTop: varRef('nested-border-top', tableBorder),
+          },
 
           [`> ${componentCls}-header${componentCls}-sticky-holder`]: {
             marginTop: calc(lineWidth).mul(-1).equal(),
@@ -163,9 +172,11 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
 
       // ============================ Nested ============================
       [`${componentCls}-cell`]: {
-        [`${componentCls}-container:first-child`]: {
-          // :first-child to avoid the case when bordered and title is set
-          borderTop: 0,
+        [`
+          > ${componentCls}-wrapper:only-child,
+          > ${componentCls}-expanded-row-fixed > ${componentCls}-wrapper:only-child
+        `]: {
+          [varName('nested-border-top')]: 0,
         },
         // https://github.com/ant-design/ant-design/issues/35577
         '&-scrollbar:not([rowspan])': {

--- a/packages/antdv-next/src/tag/style/index.ts
+++ b/packages/antdv-next/src/tag/style/index.ts
@@ -143,8 +143,22 @@ const genBaseStyle: GenerateStyle<TagToken, CSSInterpolation> = (token) => {
         display: 'none',
       },
 
+      // Icons from third-party libraries are a bare `<svg>`, which none of the `.anticon`
+      // rules reach. An `<svg>` has no baseline of its own, so it is aligned by its bottom
+      // margin edge (CSS 2.1 §10.8.1) and rides above the text. Centre it instead: unlike an
+      // `.anticon` (whose `<svg>` is always `1em`, so a fixed `-0.125em` nudge suffices), a
+      // third-party `<svg>` may be sized in `px`, so the correction must not depend on size.
+      // `vertical-align: middle` centres the margin box on the x-height line; `margin-block-end`
+      // then lifts it by half its own value onto the cap-height centre (capHeight − xHeight ≈
+      // 0.2em across typical fonts), keeping it centred at any icon size.
+      // Only matches a bare `<svg>`: an `.anticon` keeps its `<svg>` one level deeper.
+      '> svg': {
+        verticalAlign: 'middle',
+        marginBlockEnd: '0.2em',
+      },
+
       // To ensure that a space will be placed between character and `Icon`.
-      [`> ${token.iconCls} + span, > span + ${token.iconCls}`]: {
+      [`> ${token.iconCls} + span, > span + ${token.iconCls}, > svg + span, > span + svg`]: {
         marginInlineStart: paddingInline,
       },
     },

--- a/packages/antdv-next/src/tag/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/tag/tests/__snapshots__/demo.test.tsx.snap
@@ -2480,6 +2480,111 @@ exports[`tag demo > renders icon correctly 1`] = `
       </span>
     </span>
   </div>
+  <div
+    class="ant-divider css-var-root ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+       Tag with third-party icon 
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-flex css-var-root ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-tag ant-tag-filled css-var-root"
+      style="background-color: rgb(255, 238, 229); color: rgb(255, 85, 0);"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+      >
+        <path
+          d="M12 2l2.9 6.3 6.9.8-5.1 4.7 1.4 6.8L12 17.2 5.9 20.6l1.4-6.8L2.2 9.1l6.9-.8z"
+        />
+      </svg>
+      <span>
+         Star (em) 
+      </span>
+      <!---->
+      <!---->
+      <!---->
+    </span>
+    <span
+      class="ant-tag ant-tag-filled css-var-root"
+      style="background-color: rgb(253, 232, 243); color: rgb(235, 47, 150);"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="16"
+        viewBox="0 0 24 24"
+        width="16"
+      >
+        <path
+          d="M12 20.7l-1.4-1.3C5.4 14.8 2 11.7 2 8a5 5 0 0 1 10-1.7A5 5 0 0 1 22 8c0 3.7-3.4 6.8-8.6 11.4L12 20.7z"
+        />
+      </svg>
+      <span>
+         Heart (px) 
+      </span>
+      <!---->
+      <!---->
+      <!---->
+    </span>
+    <span
+      class="ant-tag ant-tag-filled css-var-root"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="16"
+        viewBox="0 0 24 24"
+        width="16"
+      >
+        <path
+          d="M12 20.7l-1.4-1.3C5.4 14.8 2 11.7 2 8a5 5 0 0 1 10-1.7A5 5 0 0 1 22 8c0 3.7-3.4 6.8-8.6 11.4L12 20.7z"
+        />
+      </svg>
+      <span>
+         Closable 
+      </span>
+      <span
+        aria-label="Close"
+        class="anticon anticon-close ant-tag-close-icon"
+        role="button"
+        tabindex="0"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
+      </span>
+      <!---->
+      <!---->
+    </span>
+  </div>
 </div>
 `;
 

--- a/packages/antdv-next/src/transfer/Actions.tsx
+++ b/packages/antdv-next/src/transfer/Actions.tsx
@@ -47,15 +47,27 @@ const Action = defineComponent<ActionProps>(
       const icon = getArrowIcon(props.type, props.direction)
 
       if (isVNode(button)) {
+        const nodeProps = (button as any).props || {}
+        const mergedDisabled = nodeProps.disabled || props.disabled || !active
         const onClick = (event: MouseEvent) => {
-          const nodeProps = (button as any).props || {}
+          if (mergedDisabled) {
+            event.preventDefault()
+            return
+          }
           nodeProps?.onClick?.(event)
           moveHandler?.(event)
         }
-        return cloneVNode(button, {
-          disabled: props.disabled || !active,
+        const cloned = cloneVNode(button, {
+          disabled: mergedDisabled,
           onClick,
         })
+        // cloneVNode merges `onClick` into an array (both original and new
+        // handlers fire). Override it so our gated handler fully replaces the
+        // original, matching React's cloneElement behavior.
+        if (cloned.props) {
+          cloned.props.onClick = onClick
+        }
+        return cloned
       }
 
       return (

--- a/packages/antdv-next/src/transfer/tests/actions.test.tsx
+++ b/packages/antdv-next/src/transfer/tests/actions.test.tsx
@@ -4,17 +4,25 @@ import Transfer from '..'
 import Button from '../../button'
 import { mount } from '/@tests/utils'
 
-const CustomLink = defineComponent<{ disabled?: boolean, onClick?: (event: MouseEvent) => void }>(
-  (props) => {
+const CustomLink = defineComponent<
+  { disabled?: boolean },
+  { click: (event: MouseEvent) => void }
+>(
+  (props, { emit }) => {
     return () => (
-      <a href="#target" aria-disabled={props.disabled ? 'true' : undefined} onClick={props.onClick}>
+      <a
+        href="#target"
+        aria-disabled={props.disabled ? 'true' : undefined}
+        onClick={event => emit('click', event)}
+      >
         Custom Link
       </a>
     )
   },
   {
     name: 'CustomLink',
-    props: ['disabled', 'onClick'] as any,
+    props: ['disabled'] as any,
+    emits: ['click'],
   },
 )
 

--- a/packages/antdv-next/src/transfer/tests/actions.test.tsx
+++ b/packages/antdv-next/src/transfer/tests/actions.test.tsx
@@ -1,7 +1,22 @@
 import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
 import Transfer from '..'
 import Button from '../../button'
 import { mount } from '/@tests/utils'
+
+const CustomLink = defineComponent<{ disabled?: boolean, onClick?: (event: MouseEvent) => void }>(
+  (props) => {
+    return () => (
+      <a href="#target" aria-disabled={props.disabled ? 'true' : undefined} onClick={props.onClick}>
+        Custom Link
+      </a>
+    )
+  },
+  {
+    name: 'CustomLink',
+    props: ['disabled', 'onClick'] as any,
+  },
+)
 
 const listCommonProps: {
   dataSource: { key: string, title: string, disabled?: boolean }[]
@@ -45,6 +60,64 @@ describe('transfer.Actions', () => {
 
     expect(customButtonClick).toHaveBeenCalled()
     expect(handleChange).toHaveBeenCalled()
+  })
+
+  it('should preserve disabled state of custom actions', () => {
+    const wrapper = mount({
+      render: () => (
+        <Transfer
+          {...listCommonProps}
+          oneWay
+          actions={[<CustomLink key="test" disabled />]}
+        />
+      ),
+    })
+
+    const link = Array.from(wrapper.element.querySelectorAll('a') as unknown as HTMLAnchorElement[])
+      .find(a => a.textContent?.includes('Custom Link'))
+    expect(link).toBeTruthy()
+    expect(link?.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('should prevent default behavior of disabled custom actions', () => {
+    const wrapper = mount({
+      render: () => (
+        <Transfer
+          {...listCommonProps}
+          oneWay
+          actions={[<CustomLink key="test" disabled />]}
+        />
+      ),
+    })
+
+    const link = Array.from(wrapper.element.querySelectorAll('a') as unknown as HTMLAnchorElement[])
+      .find(a => a.textContent?.includes('Custom Link'))!
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    link.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('should prevent click handlers of disabled custom actions', () => {
+    const handleChange = vi.fn()
+    const customActionClick = vi.fn()
+
+    const wrapper = mount({
+      render: () => (
+        <Transfer
+          {...listCommonProps}
+          onChange={handleChange}
+          oneWay
+          actions={[<CustomLink key="test" disabled onClick={customActionClick} />]}
+        />
+      ),
+    })
+
+    const link = Array.from(wrapper.element.querySelectorAll('a') as unknown as HTMLAnchorElement[])
+      .find(a => a.textContent?.includes('Custom Link'))!
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+
+    expect(customActionClick).not.toHaveBeenCalled()
+    expect(handleChange).not.toHaveBeenCalled()
   })
 
   it('should accept multiple actions >= 3', () => {

--- a/packages/antdv-next/src/tree/style/index.ts
+++ b/packages/antdv-next/src/tree/style/index.ts
@@ -361,7 +361,7 @@ export function genBaseStyle(prefixCls: string, token: TreeToken): CSSObject {
             top: 0,
             insetInlineEnd: token.calc(switcherSize).div(2).equal(),
             bottom: token.calc(treeNodePadding).mul(-1).equal(),
-            marginInlineStart: -1,
+            marginInlineStart: token.calc(token.lineWidth).mul(-1).equal(),
             borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
             content: '""',
           },


### PR DESCRIPTION
同步 ant-design 上游 `78c3d84619` → `ee9a9ab678`，共 7 个新 commit，全部同步。

## 已同步

| 上游 PR | 变更 | 下游实现 |
|---|---|---|
| [#58755](https://github.com/ant-design/ant-design/pull/58755) | fix: line type token in borders | Button/ColorPicker/Select/Space 边框 `solid` → `lineType` token（延续 border token 系列，4 文件 5 处，默认主题 CSS 不变） |
| [#58745](https://github.com/ant-design/ant-design/pull/58745) | fix(Tree): margin-inline-start token | show-line 连接线 `marginInlineStart: -1` → `token.calc(lineWidth).mul(-1)`（默认 lineWidth=1 时输出 `-1px` 不变） |
| [#58723](https://github.com/ant-design/ant-design/pull/58723) | fix(Tag): 裸 `<svg>` 图标对齐与间距 | 新增 `> svg` 规则（`vertical-align: middle` + `margin-block-end: 0.2em`）并扩展间距选择器；补第三方 svg 图标 demo |
| [#58718](https://github.com/ant-design/ant-design/pull/58718) | fix(Transfer): 保留自定义 action disabled | 合并用户自定义按钮的 `disabled`，禁用时 `preventDefault` 并跳过 click/move |
| [#58746](https://github.com/ant-design/ant-design/pull/58746) | fix(Table): 嵌套表格顶部边框 | 引入 `--ant-table-nested-border-top` CSS 变量控制，仅 only-child 嵌套表清零 |
| [#58747](https://github.com/ant-design/ant-design/pull/58747) | docs(Alert): 间距修正 | style-class demo 链接周围补空格 |

## 需要 review 的一处 Vue 适配

**Transfer**（`transfer/Actions.tsx`）：`cloneVNode` 的第二参走 `mergeProps`，会把 `onClick` **合并成数组**（原 handler 与新 handler 都触发），而 React 的 `cloneElement` 是**替换**。若照字面移植，禁用门控会被原 handler 绕过。所以克隆后显式覆盖 `cloned.props.onClick = onClick`，对齐 React 语义——顺带修了启用态下自定义 `onClick` 被调用两次的既有隐患。测试里 stash 掉源码改动可复现失败，确认门控有效。

## 跳过

- [#58750](https://github.com/ant-design/ant-design/pull/58750) docs(Alert) revert：把 #58747 的 icon 描述改动回滚了，净效果为零，无需同步。
- Alert 的 `error-boundary` 描述修正：Vue 端无对应 demo。
- Table debug demo：Vue 端无 debug-demo 约定与前置 demo，跳过（不影响样式修复）。

## 测试

`pnpm lint` 通过。合并跑受影响组件：`vitest run button color-picker select space tree tag transfer table alert` → **65 文件 881 passed / 3 skipped**。Transfer 补了 3 条镜像上游的单测，Tag demo 快照按新增第三方图标 demo 更新。未触碰 calendar/date-picker 时区敏感快照。
