### PR TITLE
docs: fix English introduction links

### DIFF
--- a/docs/src/pages/docs/vue/introduce.en-US.md
+++ b/docs/src/pages/docs/vue/introduce.en-US.md
@@ -121,5 +121,5 @@ We provide `antd.js` and `reset.css` under the `dist` folder in antdv-next's npm
 
 ## Links
 
-- [Home page](/index-cn)
-- [Components](/components/overview-cn)
+- [Home page](/)
+- [Components](/components/overview)


### PR DESCRIPTION
## What
- point the English introduction page home link to `/`
- point its components link to `/components/overview`

## Why
The English page currently sends both links to the Chinese locale routes.

## Test
- `git diff --check`
- static assertions for the corrected links and local home page
- `pnpm -F docs build` (cannot complete locally because generated `docs/src/assets/token.json` and `token-meta.json` are absent)