### PR TITLE
docs(faq): note in-DOM template lowercasing breaks camelCase slots on CDN (#671)

### DIFF
--- a/docs/src/pages/docs/vue/faq.en-US.md
+++ b/docs/src/pages/docs/vue/faq.en-US.md
@@ -25,3 +25,38 @@ npm ls dayjs
 ```
 
 If you are using a mismatched version of dayjs with antdv-next dependent dayjs in your project. That would be a problem cause locale not working.
+
+## Camelcase slots / render props (e.g. `#tagRender`) don't work when using the CDN (UMD) build?
+
+This is a limitation of Vue **in-DOM templates**, not a component bug. When the template is written directly in the page's HTML (e.g. inside `<div id="app">`), the browser's HTML parser **lowercases** tag and attribute names — including slot names, so `#tagRender` reaches the component as `tagrender` instead of `tagRender`, and the camelCase slot never fires. This applies to every camelCase slot (`tagRender`, `maxTagPlaceholder`, `popupRender`, …), and writing `#tagrender` in lowercase does not help either. See the Vue docs on [in-DOM template parsing caveats](https://vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats).
+
+Pick any of the following (the first two need no build tooling):
+
+**Option 1: Write the template as a JS string** (recommended for CDN usage, smallest change). Instead of putting the markup in the page HTML, move it into the `template` option string, which Vue's runtime compiler parses case-sensitively:
+
+```js
+const App = {
+  template: `
+    <a-tree-select :tree-data="treeData" multiple style="width: 100%">
+      <template #tagRender="tagProps">
+        <span style="color: red">{{ tagProps.label }}</span>
+      </template>
+    </a-tree-select>
+  `,
+  setup() {
+    return { treeData }
+  },
+}
+Vue.createApp(App).use(window.antd).mount('#app')
+```
+
+**Option 2: Use a render function `h`**:
+
+```js
+const { h } = Vue
+h(window.antd.TreeSelect, { treeData, multiple: true }, {
+  tagRender: props => h('span', { style: 'color: red' }, props.label),
+})
+```
+
+**Option 3: Use a Single-File Component (`.vue`) with a build tool** such as Vite / webpack. Recommended for real projects — the SFC compiler preserves case and is not affected by this limitation.

--- a/docs/src/pages/docs/vue/faq.zh-CN.md
+++ b/docs/src/pages/docs/vue/faq.zh-CN.md
@@ -31,3 +31,38 @@ npm ls dayjs
 ```
 
 一般来说，如果项目中依赖的 dayjs 版本和 antdv-next 依赖的 dayjs 版本 无法兼容（semver 无法匹配，比如项目中的 dayjs 版本写死且较低），则会导致使用两个不同版本的 dayjs 实例，这样也会导致国际化失效。
+
+## 通过 CDN（UMD 产物）使用时，`#tagRender` 等驼峰插槽 / 渲染属性不生效？
+
+这是 Vue **DOM 内模板（in-DOM template）** 的解析限制，并非组件的问题。当你把模板直接写在页面的 HTML 里（例如写在 `<div id="app">` 内部）时，浏览器的 HTML 解析器会把标签名和属性名（包括插槽名 `#tagRender`）**强制转为小写**，组件实际收到的是 `tagrender` 而不是 `tagRender`，因此驼峰命名的插槽和渲染属性都不会生效。这对所有驼峰插槽（如 `tagRender`、`maxTagPlaceholder`、`popupRender` 等）都成立，把插槽名改成小写 `#tagrender` 同样无效。详见 Vue 官方文档 [DOM 内模板解析注意事项](https://cn.vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats)。
+
+解决方式任选其一（前两种无需构建工具）：
+
+**方式一：把模板写成 JS 字符串**（CDN 场景推荐，改动最小）。不要把组件写进页面 HTML，改放到 `template` 选项字符串里，Vue 运行时编译器会大小写敏感地解析：
+
+```js
+const App = {
+  template: `
+    <a-tree-select :tree-data="treeData" multiple style="width: 100%">
+      <template #tagRender="tagProps">
+        <span style="color: red">{{ tagProps.label }}</span>
+      </template>
+    </a-tree-select>
+  `,
+  setup() {
+    return { treeData }
+  },
+}
+Vue.createApp(App).use(window.antd).mount('#app')
+```
+
+**方式二：使用渲染函数 `h`**：
+
+```js
+const { h } = Vue
+h(window.antd.TreeSelect, { treeData, multiple: true }, {
+  tagRender: props => h('span', { style: 'color: red' }, props.label),
+})
+```
+
+**方式三：使用单文件组件（`.vue`）配合 Vite / webpack 等构建工具**。正式项目推荐此方式，SFC 编译器完整保留大小写，不受该限制影响。


### PR DESCRIPTION
关联 #671。

CDN（UMD）用户在 in-DOM 模板里用 `#tagRender` 等驼峰插槽不生效，根因是 Vue 的 in-DOM 模板解析限制（浏览器 HTML parser 把插槽名小写成 `tagrender`，而组件读的是 camelCase）。这不是组件 bug，且波及所有 camelCase 插槽，逐个在代码里兜底成本过高。

因此在 FAQ（中英）补一条说明 + 三种 workaround（JS 字符串模板 / render 函数 / SFC + 构建工具），前两种无需构建工具。

前两种 workaround 已用 1.4.5 的 UMD 产物在真实浏览器实测通过。`docs` 构建通过（faq.zh-CN / faq.en-US 正常编译）。
