### PR TITLE
fix(table): keep dataIndex accessible on the columns union (#673)

### DIFF
--- a/docs/src/pages/docs/vue/faq.en-US.md
+++ b/docs/src/pages/docs/vue/faq.en-US.md
@@ -25,3 +25,38 @@ npm ls dayjs
 ```
 
 If you are using a mismatched version of dayjs with antdv-next dependent dayjs in your project. That would be a problem cause locale not working.
+
+## Camelcase slots / render props (e.g. `#tagRender`) don't work when using the CDN (UMD) build?
+
+This is a limitation of Vue **in-DOM templates**, not a component bug. When the template is written directly in the page's HTML (e.g. inside `<div id="app">`), the browser's HTML parser **lowercases** tag and attribute names — including slot names, so `#tagRender` reaches the component as `tagrender` instead of `tagRender`, and the camelCase slot never fires. This applies to every camelCase slot (`tagRender`, `maxTagPlaceholder`, `popupRender`, …), and writing `#tagrender` in lowercase does not help either. See the Vue docs on [in-DOM template parsing caveats](https://vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats).
+
+Pick any of the following (the first two need no build tooling):
+
+**Option 1: Write the template as a JS string** (recommended for CDN usage, smallest change). Instead of putting the markup in the page HTML, move it into the `template` option string, which Vue's runtime compiler parses case-sensitively:
+
+```js
+const App = {
+  template: `
+    <a-tree-select :tree-data="treeData" multiple style="width: 100%">
+      <template #tagRender="tagProps">
+        <span style="color: red">{{ tagProps.label }}</span>
+      </template>
+    </a-tree-select>
+  `,
+  setup() {
+    return { treeData }
+  },
+}
+Vue.createApp(App).use(window.antd).mount('#app')
+```
+
+**Option 2: Use a render function `h`**:
+
+```js
+const { h } = Vue
+h(window.antd.TreeSelect, { treeData, multiple: true }, {
+  tagRender: props => h('span', { style: 'color: red' }, props.label),
+})
+```
+
+**Option 3: Use a Single-File Component (`.vue`) with a build tool** such as Vite / webpack. Recommended for real projects — the SFC compiler preserves case and is not affected by this limitation.

--- a/docs/src/pages/docs/vue/faq.zh-CN.md
+++ b/docs/src/pages/docs/vue/faq.zh-CN.md
@@ -31,3 +31,38 @@ npm ls dayjs
 ```
 
 一般来说，如果项目中依赖的 dayjs 版本和 antdv-next 依赖的 dayjs 版本 无法兼容（semver 无法匹配，比如项目中的 dayjs 版本写死且较低），则会导致使用两个不同版本的 dayjs 实例，这样也会导致国际化失效。
+
+## 通过 CDN（UMD 产物）使用时，`#tagRender` 等驼峰插槽 / 渲染属性不生效？
+
+这是 Vue **DOM 内模板（in-DOM template）** 的解析限制，并非组件的问题。当你把模板直接写在页面的 HTML 里（例如写在 `<div id="app">` 内部）时，浏览器的 HTML 解析器会把标签名和属性名（包括插槽名 `#tagRender`）**强制转为小写**，组件实际收到的是 `tagrender` 而不是 `tagRender`，因此驼峰命名的插槽和渲染属性都不会生效。这对所有驼峰插槽（如 `tagRender`、`maxTagPlaceholder`、`popupRender` 等）都成立，把插槽名改成小写 `#tagrender` 同样无效。详见 Vue 官方文档 [DOM 内模板解析注意事项](https://cn.vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats)。
+
+解决方式任选其一（前两种无需构建工具）：
+
+**方式一：把模板写成 JS 字符串**（CDN 场景推荐，改动最小）。不要把组件写进页面 HTML，改放到 `template` 选项字符串里，Vue 运行时编译器会大小写敏感地解析：
+
+```js
+const App = {
+  template: `
+    <a-tree-select :tree-data="treeData" multiple style="width: 100%">
+      <template #tagRender="tagProps">
+        <span style="color: red">{{ tagProps.label }}</span>
+      </template>
+    </a-tree-select>
+  `,
+  setup() {
+    return { treeData }
+  },
+}
+Vue.createApp(App).use(window.antd).mount('#app')
+```
+
+**方式二：使用渲染函数 `h`**：
+
+```js
+const { h } = Vue
+h(window.antd.TreeSelect, { treeData, multiple: true }, {
+  tagRender: props => h('span', { style: 'color: red' }, props.label),
+})
+```
+
+**方式三：使用单文件组件（`.vue`）配合 Vite / webpack 等构建工具**。正式项目推荐此方式，SFC 编译器完整保留大小写，不受该限制影响。

--- a/packages/antdv-next/src/table/interface.ts
+++ b/packages/antdv-next/src/table/interface.ts
@@ -1,4 +1,4 @@
-import type { FixedType, GetComponentProps, Reference, RenderedCell as VcRenderedCell } from '@v-c/table'
+import type { FixedType, GetComponentProps, Reference, ColumnType as VcColumnType, RenderedCell as VcRenderedCell } from '@v-c/table'
 import type { Breakpoint } from '../_util/responsiveObserver.ts'
 import type { AnyObject, VueNode } from '../_util/type.ts'
 import type { CheckboxProps } from '../checkbox'
@@ -115,7 +115,7 @@ export interface CoverableDropdownProps extends DropdownProps {
 }
 
 export interface ColumnType<RecordType = AnyObject>
-  extends Omit<import('@v-c/table').ColumnType<RecordType>, 'title'> {
+  extends Omit<VcColumnType<RecordType>, 'title'> {
   title?: ColumnTitle<RecordType>
   // Sorter
   sorter?:
@@ -170,6 +170,14 @@ export interface ColumnType<RecordType = AnyObject>
 export interface ColumnGroupType<RecordType = AnyObject>
   extends Omit<ColumnType<RecordType>, 'dataIndex'> {
   children: ColumnsType<RecordType>
+  /**
+   * A group column carries no `dataIndex`. Declaring it as `never` (rather than
+   * omitting it) keeps the property present across the `ColumnGroupType |
+   * ColumnType` union, so `column.dataIndex` stays directly accessible without
+   * narrowing (a group reads back as `undefined`), while still forbidding an
+   * actual value. Narrow to a group with `'children' in column`. See #673.
+   */
+  dataIndex?: never
 }
 
 export type ColumnsType<RecordType = AnyObject> = (

--- a/packages/antdv-next/src/table/tests/Table.types.test.tsx
+++ b/packages/antdv-next/src/table/tests/Table.types.test.tsx
@@ -7,7 +7,7 @@
  * and are verified by `vue-tsc` (editors / manual typecheck). Keep this file
  * free of `@ts-expect-error` suppressions around the `h()` calls.
  */
-import type { TableProps } from '..'
+import type { ColumnsType, ColumnType, TableProps } from '..'
 import { describe, expect, it } from 'vitest'
 import { h, ref, shallowRef } from 'vue'
 import Table from '..'
@@ -15,6 +15,35 @@ import Table from '..'
 interface DataType {
   key: number
   name: string
+}
+
+// ============ issue #673: dataIndex accessible on the columns union ============
+// `TableProps['columns']` is `(ColumnGroupType | ColumnType)[]`. A group carries
+// `dataIndex?: never` (rather than omitting it), so `.dataIndex` stays directly
+// accessible when mapping the union — no narrowing required.
+export function mapColumnsDataIndex() {
+  const columns: TableProps['columns'] = [
+    { title: 'ID', dataIndex: 'id' },
+    { title: 'Name', dataIndex: 'name' },
+  ]
+  return columns.map(column => ({ dataIndex: column.dataIndex }))
+}
+
+// A mixed array (with a group) still exposes `.dataIndex`; the group reads back
+// as `undefined`. Narrow to the group with `'children' in column`.
+export function mapMixedColumns() {
+  const columns: ColumnsType<DataType> = [
+    { title: 'Group', children: [{ title: 'Name', dataIndex: 'name' }] },
+    { title: 'Key', dataIndex: 'key' },
+  ]
+  return columns.map((column) => {
+    if ('children' in column) {
+      const children: ColumnsType<DataType> = column.children
+      return children.length
+    }
+    const _dataIndex: ColumnType<DataType>['dataIndex'] = column.dataIndex
+    return _dataIndex
+  })
 }
 
 // ============ issue #634: wrapper forwarding props via h() ============


### PR DESCRIPTION
close #673

## 问题

`TableProps['columns']`（即 `ColumnsType = (ColumnGroupType | ColumnType)[]`）在 `.map` 时访问 `column.dataIndex` 报错 `TS2339: Property 'dataIndex' does not exist on type 'ColumnGroupType<AnyObject>'`，因为 `ColumnGroupType` 从 `Omit<ColumnType, 'dataIndex'>` 把 `dataIndex` 整个去掉了，联合上就取不到。

## 改动（一行类型）

把分组的 `dataIndex` 从「Omit 掉」改成「`never`」：

```ts
export interface ColumnGroupType<RecordType = AnyObject>
  extends Omit<ColumnType<RecordType>, 'dataIndex'> {
  children: ColumnsType<RecordType>
  dataIndex?: never   // ← 保留属性存在（值仍禁止），联合上即可直接访问
}
```

属性在联合的**所有成员上都存在**后，`column.dataIndex` 就能直接访问（分组侧读出来是 `undefined`）；同时 `dataIndex?: never` 仍然禁止给分组真的写 `dataIndex` 值。收窄到分组用 `'children' in column`。

顺带把 `import('@v-c/table').ColumnType` 内联动态导入改成顶部 `import type { ColumnType as VcColumnType }`。

## 为什么不做更强的「children 判别联合」

原本还试过给普通列加 `children?: never` 做成严格互斥的可辨识联合，但那会让 `ColumnGroupType` 不再可赋值给 `ColumnType`，而 table 核心（useSorter / useFilter / useSelection / useTitleColumns / Column.tsx）有 **28 处**把任意列当 `ColumnType` 用 —— 全量 `vue-tsc` 直接冒出 28 个内部类型错，在表格热点路径上逐个加收窄/断言风险太高、且和 rc-table/antd 的结构模型分道。当前最小改动保留了「分组可赋给普通列」这一内部依赖，因此**零内部 fallout**。

## 验证

- `vue-tsc --noEmit` 全量：改动前后**均为 121 个既有报错**（都是测试文件的历史噪声），本次改动**新增 0 个**（`comm` 差集为空）；table 实现文件（非 test）新增报错 0。
- 新增类型回归测试 `Table.types.test.tsx`（#673 段）：用户原样 `.map(c => c.dataIndex)` 编译通过、混合分组 `'children' in column` 收窄通过。
- `vitest run table`：13 文件 188 passed。
- tsdown `build:esm` 生成 .d.ts 通过；lint 通过。
