### PR TITLE
test: pin the test timezone to Asia/Shanghai

### DIFF
--- a/vitest-plugin.ts
+++ b/vitest-plugin.ts
@@ -47,4 +47,14 @@ export default defineConfig({
       },
     ],
   },
+  test: {
+    env: {
+      // Pin the timezone so date-dependent assertions and snapshots do not
+      // depend on where the suite happens to run. Several tests build dates
+      // from a UTC instant (e.g. `dayjs('2025-06-15T00:00:00Z')`) and assert
+      // the rendered day, which shifts by one in any UTC- zone; committed
+      // snapshots were recorded at UTC+8.
+      TZ: 'Asia/Shanghai',
+    },
+  },
 })


### PR DESCRIPTION
Nothing pins `TZ` for the test suite, so date-dependent tests take whatever timezone
the host happens to be in.

## The problem

Several tests build a date from a UTC instant and assert the rendered day:

```ts
props: { defaultValue: dayjs('2025-06-15T00:00:00Z') }
expect(selectedCell.text()).toContain('15')
```

In any UTC- zone that instant falls on the previous local day, so the cell renders `14`
and the assertion fails. The committed snapshots were likewise recorded at UTC+8.

Two concrete consequences:

- Contributors outside UTC+8 see failures that have nothing to do with their change —
  `calendar > should render with defaultValue`, `should render with controlled value`,
  and the calendar/date-picker/time-picker snapshots.
- Worse, running `vitest -u` there silently bakes the wrong timezone into those
  snapshots, which then breaks for everyone else. This nearly shipped during the 6.5.3
  sync ([#681](https://github.com/antdv-next/antdv-next/pull/681)) — the snapshots had
  to be reverted and regenerated under `TZ=Asia/Shanghai`.

## The change

One `test.env.TZ` entry in `vitest-plugin.ts`, the shared config both `packages/antdv-next`
and `packages/cssinjs` merge, so it covers the whole suite from a single place.

## Verification

Run from a **PDT** host with no `TZ` in the environment — i.e. relying purely on the
config:

```
Test Files  343 passed (343)
Tests       4641 passed | 7 skipped (4648)
```

Before this change the same command failed 2 tests. The date-heavy components
(calendar, date-picker, time-picker — 179 tests) also pass with the host forced to
`America/New_York`, `UTC`, `Europe/Berlin` and `Pacific/Auckland`.
