### PR TITLE
fix(border-beam): guard getComputedStyle in useBorderSize

### DIFF
--- a/docs/src/pages/components/border-beam/demo/line-width.vue
+++ b/docs/src/pages/components/border-beam/demo/line-width.vue
@@ -7,9 +7,9 @@ Use `lineWidth` to adjust the beam width of an individual BorderBeam. The defaul
 </docs>
 
 <template>
-  <div :style="{ width: '320px' }">
+  <div :style="{ width: '360px' }">
     <a-border-beam :line-width="2">
-      <a-card title="Custom line width">
+      <a-card title="Custom line width" :style="{ borderWidth: '2px' }">
         Set lineWidth to match the border width of this container.
       </a-card>
     </a-border-beam>

--- a/packages/antdv-next/global.d.ts
+++ b/packages/antdv-next/global.d.ts
@@ -18,6 +18,7 @@ declare module 'vue' {
     ABadge: typeof import('antdv-next')['Badge']
     ABadgeRibbon: typeof import('antdv-next')['BadgeRibbon']
     ATag: typeof import('antdv-next')['Tag']
+    ABorderBeam: typeof import('antdv-next')['BorderBeam']
     ACheckableTag: typeof import('antdv-next')['CheckableTag']
     ALayout: typeof import('antdv-next')['Layout']
     ALayoutHeader: typeof import('antdv-next')['LayoutHeader']

--- a/packages/antdv-next/src/border-beam/hooks/useBorderSize.ts
+++ b/packages/antdv-next/src/border-beam/hooks/useBorderSize.ts
@@ -28,7 +28,18 @@ export default function useBorderSize(domNode: Ref<HTMLElement | SVGElement | nu
         borderInfo.value = DEFAULT_BORDER_INFO
         return
       }
-      const { borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth, borderRadius } = getComputedStyle(node)
+      // `getComputedStyle` may throw in non-browser environments (e.g. jsdom
+      // fails to fold border longhands back into a `var()`-based shorthand).
+      // Fall back to the default so the beam never breaks the host tree.
+      let computedStyle: CSSStyleDeclaration
+      try {
+        computedStyle = getComputedStyle(node)
+      }
+      catch {
+        borderInfo.value = DEFAULT_BORDER_INFO
+        return
+      }
+      const { borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth, borderRadius } = computedStyle
       borderInfo.value = {
         borderWidth: [
           parseBorderWidth(borderTopWidth),

--- a/packages/antdv-next/src/border-beam/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/border-beam/tests/__snapshots__/demo.test.tsx.snap
@@ -554,10 +554,11 @@ exports[`border-beam demo > renders hover correctly 1`] = `
 
 exports[`border-beam demo > renders line-width correctly 1`] = `
 <div
-  style="width: 320px;"
+  style="width: 360px;"
 >
   <div
     class="ant-card ant-card-bordered css-var-root"
+    style="border-width: 2px;"
   >
     <div
       class="ant-card-head"

--- a/packages/antdv-next/src/border-beam/tests/useBorderSize.test.ts
+++ b/packages/antdv-next/src/border-beam/tests/useBorderSize.test.ts
@@ -1,0 +1,102 @@
+import type { Ref } from 'vue'
+import type { BorderInfo } from '../hooks/useBorderSize'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick, shallowRef } from 'vue'
+import useBorderSize from '../hooks/useBorderSize'
+
+const DEFAULT_BORDER_INFO: BorderInfo = {
+  borderWidth: [0, 0, 0, 0],
+  borderRadius: '0px',
+}
+
+function createHost(cssText: string) {
+  const el = document.createElement('div')
+  el.style.cssText = cssText
+  document.body.appendChild(el)
+  return el
+}
+
+function renderHook(node: HTMLElement | null = null) {
+  const domNode = shallowRef<HTMLElement | null>(node)
+  let borderInfo!: Ref<BorderInfo>
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        borderInfo = useBorderSize(domNode)
+        return () => null
+      },
+    }),
+  )
+  return { domNode, wrapper, info: () => borderInfo.value }
+}
+
+describe('useBorderSize', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('reads each border side and the radius from the computed style', async () => {
+    const host = createHost(
+      'border-style: solid; border-top-width: 1px; border-right-width: 2px; border-bottom-width: 3px; border-left-width: 4px; border-radius: 12px;',
+    )
+    const { wrapper, info } = renderHook(host)
+    await nextTick()
+
+    expect(info().borderWidth).toEqual([1, 2, 3, 4])
+    expect(info().borderRadius).toBe('12px')
+
+    wrapper.unmount()
+  })
+
+  it('falls back to the default info when no node is supplied', async () => {
+    const { wrapper, info } = renderHook(null)
+    await nextTick()
+
+    expect(info()).toEqual(DEFAULT_BORDER_INFO)
+
+    wrapper.unmount()
+  })
+
+  it('resets to the default info once the node is detached', async () => {
+    const host = createHost('border: 2px solid red;')
+    const { domNode, wrapper, info } = renderHook(host)
+    await nextTick()
+    expect(info().borderWidth).toEqual([2, 2, 2, 2])
+
+    domNode.value = null
+    await nextTick()
+    expect(info()).toEqual(DEFAULT_BORDER_INFO)
+
+    wrapper.unmount()
+  })
+
+  it('coerces non-numeric border widths to 0', async () => {
+    // A `var()` border width cannot be resolved outside a real browser, so
+    // `Number.parseFloat` yields NaN and must be normalized to 0.
+    const host = createHost('border-style: solid; border-width: var(--not-defined);')
+    const { wrapper, info } = renderHook(host)
+    await nextTick()
+
+    expect(info().borderWidth).toEqual([0, 0, 0, 0])
+
+    wrapper.unmount()
+  })
+
+  it('falls back to the default info when getComputedStyle throws', async () => {
+    // jsdom's cssstyle throws while folding border longhands back into a
+    // `var()`-based `border` shorthand; the hook must not break the host tree.
+    const spy = vi.spyOn(window, 'getComputedStyle').mockImplementation(() => {
+      throw new TypeError('Cannot create property \'border-width\' on string')
+    })
+    const host = createHost('border: 2px solid red;')
+    const { wrapper, info } = renderHook(host)
+    await nextTick()
+
+    expect(spy).toHaveBeenCalled()
+    expect(info()).toEqual(DEFAULT_BORDER_INFO)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## 背景

`border-beam` 的 demo 测试报错：

```
TypeError: Cannot create property 'border-width' on string
  'var(--ant-line-width) var(--ant-line-type) var(--ant-color-border-secondary)'
 ❯ replaceBorderShorthandValue  cssstyle/lib/normalize.js:203:25
 ❯ window.getComputedStyle      jsdom/lib/jsdom/browser/Window.js:927:32
```

根因在 jsdom 依赖的 `cssstyle`，不在组件本身。当元素同时存在

- 样式表里含 `var()` 的 `border` 简写（CSS Variables 模式下 Card 就是这样），以及
- `border-width` / `border-style` / `border-color` 这类分组简写

`cssstyle` 的 `prepareBorderProperties` 会尝试把长写折回简写，而含 `var()` 的值属于 pending-substitution，`border.parse()` 返回的是原字符串而非对象，随后对字符串赋属性直接抛错。

最小复现（与组件无关）：

```js
const s = new CSSStyleDeclaration()
s.setProperty('border', 'var(--a) var(--b) var(--c)')
s.setProperty('border-width', '2px') // TypeError
```

这是 `cssstyle` 5.x 引入的回归：4.6.0 没有 `normalize.js`，不做折叠，因此不受影响。ant-design 走 `jest-environment-jsdom@30` → jsdom 26.1.0 → cssstyle 4.6.0，所以 React 侧同样的 demo 不会触发；本仓库是 jsdom 27.4.0 → cssstyle 5.3.4。

## 改动

- `useBorderSize` 给 `getComputedStyle` 加 `try/catch`，失败时回落 `DEFAULT_BORDER_INFO`，不让异常从 watcher 里逃出去打断宿主渲染。
- `line-width` demo 与 React 实现对齐：容器宽度 `320px` → `360px`，Card 用 `borderWidth: 2px`。
- 新增 `useBorderSize` 单测 5 例。
- `global.d.ts` 补上 `ABorderBeam` 的全局声明（自动生成产物）。

## 测试

`pnpm -F antdv-next test border-beam` — 23 passed。

新增用例覆盖：四边宽度与圆角读取、无节点回落、节点摘除后重置、非数值宽度归零、`getComputedStyle` 抛错时回落。

两处做了验证而非假设：

- 「非数值宽度归零」用例不是空跑 —— 实测 `border-width: var(--not-defined)` 在 jsdom 下 `getComputedStyle` 并不抛错，四边返回空字符串，走的确实是 `parseFloat('') → NaN → 0` 分支，而非悄悄掉进 catch。
- 「抛错时回落」用例是有效护栏 —— 临时删掉 `try/catch` 重跑，该用例如期失败。

## 备注

上游 `cssstyle` 的 bug 仍在（5.3.4，jsdom 27.4.0 锁定版本，npm 最新 6.2.0 未验证是否已修）。本 PR 只保证组件不被带崩；使用者在别处给元素写 `border-width` / `border-style` / `border-color` 仍会踩到。是否去 jsdom/cssstyle 提 issue 或用 pnpm overrides 升版，可另行讨论。