### PR TITLE
perf(docs): lazy-load demo source code on demand

### DIFF
--- a/docs/plugins/markdown/demo/index.ts
+++ b/docs/plugins/markdown/demo/index.ts
@@ -1,16 +1,20 @@
 import type { PluginOption } from 'vite'
 import fs from 'node:fs/promises'
+import path from 'node:path'
 import pm from 'picomatch'
 import { normalizePath } from 'vite'
 import { parse } from 'vue/compiler-sfc'
 import { createMarkdown, loadBaseMd, loadShiki } from '../markdown'
 import { tsToJs } from './tsToJs'
 
+interface ParsedDemoFile {
+  locales: Record<string, { html: string, title: string }>
+  sourceCode: string
+  jsSourceCode: string
+}
+
 /**
  * 将绝对路径转换为相对于项目根目录的路径
- * @param absolutePath 绝对路径
- * @param root 项目根目录
- * @returns 相对路径
  */
 export function toRelativePath(absolutePath: string, root: string): string {
   const normalizedPath = normalizePath(absolutePath)
@@ -20,42 +24,62 @@ export function toRelativePath(absolutePath: string, root: string): string {
     : normalizedPath
 }
 
-/**
- * 解析 demo 文件内容
- */
-async function parseDemoFile(filePath: string, md: any) {
-  const code = await fs.readFile(filePath, 'utf-8')
-  const { descriptor } = parse(code, {
-    filename: filePath,
-    sourceMap: false,
-  })
+function isDemoFile(filePath: string, root: string, patterns: string[]) {
+  const relativePath = toRelativePath(filePath, root)
+  return patterns.some(pattern => pm.isMatch(relativePath, pattern))
+}
 
-  const locales: Record<string, any> = {}
-  const docsBlock = descriptor.customBlocks.filter(block => block.type === 'docs')
-  await Promise.all(docsBlock?.map(async (block) => {
-    const lang = block.attrs.lang as string || 'zh-CN'
-    const env: any = {}
-    const content = block.content.trim()
-    const html = await md.renderAsync(content, env)
-    const title = env.formatters?.title ?? env?.title ?? ''
-    locales[lang] = {
-      html,
-      title,
-    }
-  }))
+function toDemoKey(filePath: string, root: string) {
+  const relativePath = toRelativePath(filePath, root)
+  return relativePath.startsWith('/') ? relativePath : `/${relativePath}`
+}
+
+/**
+ * 完整解析 demo 文件（用于 build 缓存和 dev source endpoint）
+ */
+async function parseDemoFile(
+  filePath: string,
+  md: ReturnType<ReturnType<typeof createMarkdown>>,
+): Promise<ParsedDemoFile> {
+  const code = await fs.readFile(filePath, 'utf-8')
+  const locales = await parseDemoLocales(code, filePath, md)
 
   const sourceCode = code.replace(/<docs[^>]*>[\s\S]*?<\/docs>/g, '').trim()
   const jsSourceCode = await tsToJs(sourceCode)
-  const sourceHtml = await md.renderAsync(`\`\`\`vue\n${sourceCode}\n\`\`\``)
-  const jsSourceHtml = await md.renderAsync(`\`\`\`vue\n${jsSourceCode}\n\`\`\``)
 
   return {
     locales,
     sourceCode,
     jsSourceCode,
-    sourceHtml,
-    jsSourceHtml,
   }
+}
+
+/**
+ * 仅解析 locales（用于 HMR 和 dev module code）
+ */
+async function parseDemoLocales(
+  code: string,
+  filePath: string,
+  md: ReturnType<ReturnType<typeof createMarkdown>>,
+) {
+  const { descriptor } = parse(code, {
+    filename: filePath,
+    sourceMap: false,
+  })
+
+  const locales: Record<string, { html: string, title: string }> = {}
+  const docsBlocks = descriptor.customBlocks.filter(block => block.type === 'docs')
+  await Promise.all(docsBlocks.map(async (block) => {
+    const lang = typeof block.attrs.lang === 'string' ? block.attrs.lang : 'zh-CN'
+    const env: Record<string, unknown> = {}
+    const html = await md.renderAsync(block.content.trim(), env)
+    const formatterTitle = (env.formatters as { title?: string } | undefined)?.title
+    locales[lang] = {
+      html,
+      title: formatterTitle || (typeof env.title === 'string' ? env.title : ''),
+    }
+  }))
+  return locales
 }
 
 export function demoPlugin(): PluginOption {
@@ -70,9 +94,85 @@ export function demoPlugin(): PluginOption {
   const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`
   const DEMO_SUFFIX = 'demo=true'
   const DEMO_GLOB = ['/src/pages/**/demo/*.vue']
+  const DEV_SOURCE_PATH = '/__demo_source'
+  let isServe = false
+  let root = process.cwd()
+  let base = '/'
+
+  // Build 解析缓存（每个 demo 只解析一次）
+  const buildDemoParseCache = new Map<string, ParsedDemoFile>()
+  // Dev 并发去重
+  const devDemoParseTasks = new Map<string, Promise<ParsedDemoFile>>()
+
+  async function getBuildParsedDemo(filePath: string) {
+    if (!buildDemoParseCache.has(filePath)) {
+      buildDemoParseCache.set(filePath, await parseDemoFile(filePath, md))
+    }
+    return buildDemoParseCache.get(filePath)!
+  }
+
+  function getDevParsedDemo(filePath: string) {
+    const currentTask = devDemoParseTasks.get(filePath)
+    if (currentTask) return currentTask
+
+    const task = parseDemoFile(filePath, md).finally(() => {
+      if (devDemoParseTasks.get(filePath) === task)
+        devDemoParseTasks.delete(filePath)
+    })
+    devDemoParseTasks.set(filePath, task)
+    return task
+  }
+
   return {
     name: 'vite:demo',
     enforce: 'pre',
+    configResolved(config) {
+      isServe = config.command === 'serve'
+      root = config.root
+      base = config.base
+    },
+    configureServer(server) {
+      // Dev 模式下按需提供源码的 HTTP 端点
+      const sourcePath = `${base === '/' ? '' : base.replace(/\/$/, '')}${DEV_SOURCE_PATH}`
+      server.middlewares.use(async (request, response, next) => {
+        const url = new URL(request.url ?? '', 'http://vite.local')
+        if (url.pathname !== sourcePath) return next()
+
+        const id = url.searchParams.get('id')
+        const filePath = id ? path.resolve(root, `.${id}`) : ''
+        const relativePath = filePath ? path.relative(root, filePath) : '..'
+        if (
+          !id?.startsWith('/') ||
+          relativePath.startsWith('..') ||
+          path.isAbsolute(relativePath) ||
+          !isDemoFile(filePath, root, DEMO_GLOB)
+        ) {
+          response.statusCode = 400
+          response.end('Invalid demo source path')
+          return
+        }
+
+        try {
+          const parsed = await getDevParsedDemo(filePath)
+          response.statusCode = 200
+          response.setHeader('Content-Type', 'application/json; charset=utf-8')
+          response.setHeader('Cache-Control', 'no-store')
+          response.end(
+            JSON.stringify({
+              source: parsed.sourceCode,
+              jsSource: parsed.jsSourceCode,
+            }),
+          )
+        }
+        catch (error) {
+          server.config.logger.error(
+            `Failed to load demo source ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+          )
+          response.statusCode = 500
+          response.end('Failed to load demo source')
+        }
+      })
+    },
     async resolveId(id, importer) {
       if (id === VIRTUAL_MODULE_ID) {
         return RESOLVED_VIRTUAL_MODULE_ID
@@ -104,42 +204,91 @@ export function demoPlugin(): PluginOption {
         const [filePath] = virtualId.split('?')
         const normalizedFile = normalizePath(filePath)
 
-        // 建立文件依赖关系，确保源文件变化时虚拟模块会被重新加载
+        // 建立文件依赖关系
         this.addWatchFile(filePath)
 
-        // 解析 demo 文件
-        const { locales, sourceCode, jsSourceCode, sourceHtml, jsSourceHtml } = await parseDemoFile(filePath, md)
+        // Dev: 只解析 locales；Build: 完整解析
+        const parsed = isServe ? undefined : await getBuildParsedDemo(filePath)
+        const locales = parsed
+          ? parsed.locales
+          : await parseDemoLocales(
+              await fs.readFile(filePath, 'utf-8'),
+              filePath,
+              md,
+            )
 
-        // 注入带 HMR 的代码
+        // Build: 生成 JSON asset
+        const sourceUrl = isServe
+          ? undefined
+          : this.getFileName(
+              this.emitFile({
+                type: 'asset',
+                name: `demo-source-${path.basename(filePath, '.vue')}.json`,
+                source: JSON.stringify({
+                  source: parsed!.sourceCode,
+                  jsSource: parsed!.jsSourceCode,
+                }),
+              }),
+            )
+
         return {
-          code: `
+          code: isServe
+            ? `
 import { ref } from 'vue'
 
 const localesRef = ref(${JSON.stringify(locales)})
-const sourceRef = ref(${JSON.stringify(sourceCode)})
-const jsSourceRef = ref(${JSON.stringify(jsSourceCode)})
-const htmlRef = ref(${JSON.stringify(sourceHtml)})
-const jsHtmlRef = ref(${JSON.stringify(jsSourceHtml)})
+const sourceVersionRef = ref(0)
 
 const demoData = {
-  component: () => import('${filePath}'),
+  component: () => import(${JSON.stringify(filePath)}),
   get locales() { return localesRef.value },
-  get source() { return sourceRef.value },
-  get jsSource() { return jsSourceRef.value },
-  get html() { return htmlRef.value },
-  get jsHtml() { return jsHtmlRef.value }
+  get sourceVersion() { return sourceVersionRef.value },
+  async loadSource(signal) {
+    const url = new URL(import.meta.env.BASE_URL + ${JSON.stringify(DEV_SOURCE_PATH.slice(1))}, window.location.origin)
+    url.searchParams.set('id', ${JSON.stringify(toDemoKey(filePath, root))})
+    url.searchParams.set('t', String(sourceVersionRef.value))
+    const res = await fetch(url.href, { cache: 'no-store', signal })
+    if (!res.ok)
+      throw new Error(\`Failed to load demo source: \${res.status} \${res.statusText}\`)
+    return res.json()
+  }
 }
 
-// HMR 支持
 if (import.meta.hot) {
   import.meta.hot.accept()
-  
-  import.meta.hot.on('demo-update:${normalizedFile.replace(/\\/g, '/')}', (data) => {
+  import.meta.hot.on('vite:beforeUpdate', () => {
+    sourceVersionRef.value = Date.now()
+  })
+  import.meta.hot.on(${JSON.stringify(`demo-update:${normalizedFile}`)}, (data) => {
     if ('locales' in data) localesRef.value = data.locales
-    if ('source' in data) sourceRef.value = data.source
-    if ('jsSource' in data) jsSourceRef.value = data.jsSource
-    if ('html' in data) htmlRef.value = data.html
-    if ('jsHtml' in data) jsHtmlRef.value = data.jsHtml
+    if ('timestamp' in data) sourceVersionRef.value = data.timestamp
+  })
+}
+
+export default demoData
+`
+            : `
+import { ref } from 'vue'
+
+const localesRef = ref(${JSON.stringify(locales)})
+
+const demoData = {
+  component: () => import(${JSON.stringify(filePath)}),
+  get locales() { return localesRef.value },
+  sourceVersion: 0,
+  async loadSource(signal) {
+    const url = new URL(import.meta.env.BASE_URL + ${JSON.stringify(sourceUrl)}, import.meta.url)
+    const res = await fetch(url.href, { signal })
+    if (!res.ok)
+      throw new Error(\`Failed to load demo source: \${res.status} \${res.statusText}\`)
+    return res.json()
+  }
+}
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+  import.meta.hot.on(${JSON.stringify(`demo-update:${normalizedFile}`)}, (data) => {
+    if ('locales' in data) localesRef.value = data.locales
   })
 }
 
@@ -150,31 +299,29 @@ export default demoData
       }
     },
     async handleHotUpdate(ctx) {
-      const relativePath = toRelativePath(ctx.file, ctx.server.config.root)
-      const isDemo = DEMO_GLOB.some(pattern => pm.isMatch(relativePath, pattern))
-      if (isDemo) {
-        const normalizedFile = normalizePath(ctx.file)
-        const server = ctx.server
+      if (!isDemoFile(ctx.file, ctx.server.config.root, DEMO_GLOB)) return
 
-        // 重新解析文件获取最新内容
-        const { locales, sourceCode, jsSourceCode, sourceHtml, jsSourceHtml } = await parseDemoFile(ctx.file, md)
+      const normalizedFile = normalizePath(ctx.file)
 
-        // 发送自定义 HMR 事件更新数据
-        server.ws.send({
-          type: 'custom',
-          event: `demo-update:${normalizedFile.replace(/\\/g, '/')}`,
-          data: {
-            locales,
-            source: sourceCode,
-            jsSource: jsSourceCode,
-            html: sourceHtml,
-            jsHtml: jsSourceHtml,
-          },
-        })
+      // 清除 build 缓存并重新解析 locales
+      buildDemoParseCache.delete(ctx.file)
+      const locales = await parseDemoLocales(
+        await fs.readFile(ctx.file, 'utf-8'),
+        ctx.file,
+        md,
+      )
 
-        // 只返回原始 Vue 文件模块，让 Vue 的 HMR 处理组件更新
-        return ctx.modules
-      }
+      ctx.server.ws.send({
+        type: 'custom',
+        event: `demo-update:${normalizedFile}`,
+        data: {
+          locales,
+          timestamp: Date.now(),
+        },
+      })
+
+      // 只返回原始 Vue 文件模块，让 Vue 的 HMR 处理组件更新
+      return ctx.modules
     },
   }
 }

--- a/docs/plugins/markdown/demo/index.ts
+++ b/docs/plugins/markdown/demo/index.ts
@@ -113,7 +113,8 @@ export function demoPlugin(): PluginOption {
 
   function getDevParsedDemo(filePath: string) {
     const currentTask = devDemoParseTasks.get(filePath)
-    if (currentTask) return currentTask
+    if (currentTask)
+      return currentTask
 
     const task = parseDemoFile(filePath, md).finally(() => {
       if (devDemoParseTasks.get(filePath) === task)
@@ -136,16 +137,17 @@ export function demoPlugin(): PluginOption {
       const sourcePath = `${base === '/' ? '' : base.replace(/\/$/, '')}${DEV_SOURCE_PATH}`
       server.middlewares.use(async (request, response, next) => {
         const url = new URL(request.url ?? '', 'http://vite.local')
-        if (url.pathname !== sourcePath) return next()
+        if (url.pathname !== sourcePath)
+          return next()
 
         const id = url.searchParams.get('id')
         const filePath = id ? path.resolve(root, `.${id}`) : ''
         const relativePath = filePath ? path.relative(root, filePath) : '..'
         if (
-          !id?.startsWith('/') ||
-          relativePath.startsWith('..') ||
-          path.isAbsolute(relativePath) ||
-          !isDemoFile(filePath, root, DEMO_GLOB)
+          !id?.startsWith('/')
+          || relativePath.startsWith('..')
+          || path.isAbsolute(relativePath)
+          || !isDemoFile(filePath, root, DEMO_GLOB)
         ) {
           response.statusCode = 400
           response.end('Invalid demo source path')
@@ -299,7 +301,8 @@ export default demoData
       }
     },
     async handleHotUpdate(ctx) {
-      if (!isDemoFile(ctx.file, ctx.server.config.root, DEMO_GLOB)) return
+      if (!isDemoFile(ctx.file, ctx.server.config.root, DEMO_GLOB))
+        return
 
       const normalizedFile = normalizePath(ctx.file)
 

--- a/docs/src/components/code-demo/index.vue
+++ b/docs/src/components/code-demo/index.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
+import type { DemoModule, DemoSourceData } from 'virtual:demos'
 import type { CSSProperties } from 'vue'
 import { CheckOutlined, CodeOutlined, CopyOutlined, EditOutlined, ThunderboltOutlined } from '@antdv-next/icons'
 import { aquaBlue, atomDark } from '@codesandbox/sandpack-themes'
 import { useClipboard, useDebounceFn } from '@vueuse/core'
 import { SandpackProvider } from 'sandpack-vue3'
 import demos from 'virtual:demos'
-import { computed, defineAsyncComponent, markRaw, shallowRef, watch } from 'vue'
+import { computed, defineAsyncComponent, markRaw, onBeforeUnmount, shallowRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CodeEditorBridge from '@/components/code-demo/code-editor-bridge.vue'
 import ExpandIcon from '@/components/code-demo/expand-icon.vue'
@@ -20,18 +21,6 @@ import antdvPkg from '../../../../packages/antdv-next/package.json'
 import { openStackBlitz } from './utils/stackblitz'
 
 type DemoCodeType = 'ts' | 'js'
-
-interface DemoMeta {
-  component?: any
-  locales?: Record<string, {
-    html?: string
-    title?: string
-  }>
-  source?: string
-  jsSource?: string
-  html?: string
-  jsHtml?: string
-}
 
 defineOptions({
   name: 'Demo',
@@ -48,7 +37,63 @@ const { src, compact, background, simplify, debug } = defineProps<{
 
 // Debug demos are visible while developing but stripped from the production docs.
 const hidden = computed(() => Boolean(debug) && import.meta.env.PROD)
-const demo = computed<DemoMeta | undefined>(() => demos[src])
+const demo = computed<DemoModule | undefined>(() => demos[src])
+
+// 按需加载的源码数据
+const sourceData = shallowRef<DemoSourceData | null>(null)
+const sourceLoading = shallowRef(false)
+const sourceLoadError = shallowRef<Error | null>(null)
+let sourceLoadPromise: Promise<void> | null = null
+let sourceAbortController: AbortController | null = null
+// HMR 发生在面板收起期间时标记过期，下次展开时重新加载
+let sourceStale = false
+
+function releaseSource() {
+  sourceAbortController?.abort()
+  sourceAbortController = null
+  sourceData.value = null
+  sourceLoadError.value = null
+  sourceLoadPromise = null
+  sourceLoading.value = false
+  sourceStale = false
+}
+
+async function ensureSourceLoaded() {
+  // 如果源码已过期（HMR 发生在收起期间），先释放旧数据
+  if (sourceStale) releaseSource()
+  if (sourceData.value || !demo.value) return
+  if (sourceLoadPromise) return sourceLoadPromise
+
+  const currentDemo = demo.value
+  const abortController = new AbortController()
+  sourceAbortController = abortController
+  sourceLoading.value = true
+  sourceLoadError.value = null
+
+  const request = currentDemo
+    .loadSource(abortController.signal)
+    .then(data => {
+      if (demo.value === currentDemo && !abortController.signal.aborted)
+        sourceData.value = data
+    })
+    .catch(error => {
+      if (abortController.signal.aborted) return
+      const loadError =
+        error instanceof Error ? error : new Error(String(error))
+      if (demo.value === currentDemo) sourceLoadError.value = loadError
+      throw loadError
+    })
+    .finally(() => {
+      if (sourceLoadPromise === request) {
+        sourceAbortController = null
+        sourceLoadPromise = null
+        sourceLoading.value = false
+      }
+    })
+
+  sourceLoadPromise = request
+  return request
+}
 const route = useRoute()
 const router = useRouter()
 const appStore = useAppStore()
@@ -64,7 +109,7 @@ const codeType = computed<DemoCodeType>({
 })
 
 const hasJsSource = computed(() => {
-  const jsSource = demo.value?.jsSource?.trim()
+  const jsSource = sourceData.value?.jsSource?.trim()
   return Boolean(jsSource)
 })
 
@@ -81,8 +126,8 @@ const activeCodeType = computed<DemoCodeType>({
 
 const activeSourceCode = computed(() => {
   if (activeCodeType.value === 'js')
-    return demo.value?.jsSource ?? demo.value?.source ?? ''
-  return demo.value?.source ?? ''
+    return sourceData.value?.jsSource ?? sourceData.value?.source ?? ''
+  return sourceData.value?.source ?? ''
 })
 
 const description = computed(() => {
@@ -105,12 +150,42 @@ const editorBridgeRef = shallowRef<{ resetCode: (code: string) => void }>()
 function handleShowCode() {
   showCode.value = !showCode.value
   if (!showCode.value) {
-    // Revert to original when code collapsed
+    // 收起时只重置实时编辑状态，保留源码以便快速重新展开
     liveComponent.value = null
     compileError.value = null
     currentCode.value = null
   }
+  else {
+    // 展开时按需加载源码（ensureSourceLoaded 内部会处理过期重载）
+    void ensureSourceLoaded().catch(() => {})
+  }
 }
+
+// 切换 demo 时释放旧源码
+watch(demo, releaseSource, { flush: 'sync' })
+
+// 展开代码面板时触发加载（收起时不释放，保留源码）
+watch([showCode, demo], ([visible, currentDemo]) => {
+  if (!visible) return
+  if (currentDemo) void ensureSourceLoaded().catch(() => {})
+})
+
+// HMR 触发的 sourceVersion 变化：展开时立即重载，收起时标记过期
+watch(
+  () => demo.value?.sourceVersion,
+  (version, previousVersion) => {
+    if (version === previousVersion) return
+    if (showCode.value) {
+      releaseSource()
+      void ensureSourceLoaded().catch(() => {})
+    }
+    else if (sourceData.value) {
+      sourceStale = true
+    }
+  },
+)
+
+onBeforeUnmount(releaseSource)
 
 // Reset live component and editor code when tab changes
 watch(activeCodeType, () => {
@@ -155,7 +230,14 @@ function handleScroll(e: Event) {
 
 const titleRef = shallowRef<HTMLElement>()
 
-function handleStackBlitz() {
+async function handleStackBlitz() {
+  try {
+    await ensureSourceLoaded()
+  }
+  catch {
+    showCode.value = true
+    return
+  }
   if (activeSourceCode.value) {
     const title = `${titleRef.value?.textContent || 'Antdv Next Demo'} - antdv-next@${antdvPkg.version}`
     openStackBlitz(title, activeSourceCode.value)
@@ -197,7 +279,14 @@ const cls = computed(() => {
   return cls
 })
 
-function handleOpenPlayground() {
+async function handleOpenPlayground() {
+  try {
+    await ensureSourceLoaded()
+  }
+  catch {
+    showCode.value = true
+    return
+  }
   const url = loadPlaygroundUrl(activeSourceCode.value ?? '')
   if (url) {
     window.open(url, '_blank', 'noopener,noreferrer')
@@ -267,6 +356,16 @@ function handleOpenPlayground() {
       </section>
       <!-- Code editor (only when expanded) -->
       <template v-if="showCode">
+        <!-- 加载中 -->
+        <div v-if="sourceLoading" class="ant-doc-demo-box-code-loading">
+          <a-spin />
+        </div>
+        <!-- 加载失败 -->
+        <div v-else-if="sourceLoadError" class="ant-doc-demo-box-code">
+          <a-alert type="error" :message="t('ui.codeDemo.action.loadError')" />
+        </div>
+        <!-- 正常展示 -->
+        <template v-else>
         <div class="ant-doc-demo-box-code-tabs">
           <a-tabs
             v-model:active-key="activeCodeType"
@@ -301,6 +400,7 @@ function handleOpenPlayground() {
           <ExpandIcon :expanded="showCode" />
           <span>{{ t('ui.codeDemo.action.expandedCode') }}</span>
         </div>
+        </template>
       </template>
     </template>
   </section>
@@ -424,6 +524,13 @@ function handleOpenPlayground() {
     &:hover {
       color: var(--ant-color-primary);
     }
+  }
+
+  &-code-loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 0;
   }
 
   &-code {

--- a/docs/src/components/code-demo/index.vue
+++ b/docs/src/components/code-demo/index.vue
@@ -60,9 +60,12 @@ function releaseSource() {
 
 async function ensureSourceLoaded() {
   // 如果源码已过期（HMR 发生在收起期间），先释放旧数据
-  if (sourceStale) releaseSource()
-  if (sourceData.value || !demo.value) return
-  if (sourceLoadPromise) return sourceLoadPromise
+  if (sourceStale)
+    releaseSource()
+  if (sourceData.value || !demo.value)
+    return
+  if (sourceLoadPromise)
+    return sourceLoadPromise
 
   const currentDemo = demo.value
   const abortController = new AbortController()
@@ -72,15 +75,17 @@ async function ensureSourceLoaded() {
 
   const request = currentDemo
     .loadSource(abortController.signal)
-    .then(data => {
+    .then((data) => {
       if (demo.value === currentDemo && !abortController.signal.aborted)
         sourceData.value = data
     })
-    .catch(error => {
-      if (abortController.signal.aborted) return
-      const loadError =
-        error instanceof Error ? error : new Error(String(error))
-      if (demo.value === currentDemo) sourceLoadError.value = loadError
+    .catch((error) => {
+      if (abortController.signal.aborted)
+        return
+      const loadError
+        = error instanceof Error ? error : new Error(String(error))
+      if (demo.value === currentDemo)
+        sourceLoadError.value = loadError
       throw loadError
     })
     .finally(() => {
@@ -166,15 +171,18 @@ watch(demo, releaseSource, { flush: 'sync' })
 
 // 展开代码面板时触发加载（收起时不释放，保留源码）
 watch([showCode, demo], ([visible, currentDemo]) => {
-  if (!visible) return
-  if (currentDemo) void ensureSourceLoaded().catch(() => {})
+  if (!visible)
+    return
+  if (currentDemo)
+    void ensureSourceLoaded().catch(() => {})
 })
 
 // HMR 触发的 sourceVersion 变化：展开时立即重载，收起时标记过期
 watch(
   () => demo.value?.sourceVersion,
   (version, previousVersion) => {
-    if (version === previousVersion) return
+    if (version === previousVersion)
+      return
     if (showCode.value) {
       releaseSource()
       void ensureSourceLoaded().catch(() => {})
@@ -366,40 +374,40 @@ async function handleOpenPlayground() {
         </div>
         <!-- 正常展示 -->
         <template v-else>
-        <div class="ant-doc-demo-box-code-tabs">
-          <a-tabs
-            v-model:active-key="activeCodeType"
-            centered
-            size="small"
-          >
-            <a-tab-pane key="ts" :tab="t('ui.codeDemo.type.typescript')" />
-            <a-tab-pane key="js" :tab="t('ui.codeDemo.type.javascript')" />
-          </a-tabs>
-        </div>
-        <div class="ant-doc-demo-box-code">
-          <a-tooltip :title="t(`ui.codeDemo.action.${copied ? 'copied' : 'copy'}`)">
-            <div class="ant-doc-demo-box-code-copy" :class="copied ? 'ant-doc-demo-box-code-copied' : ''" @click="copy()">
-              <CopyOutlined v-if="!copied" />
-              <CheckOutlined v-else />
-            </div>
-          </a-tooltip>
-          <SandpackProvider
-            template="vite-vue-ts"
-            :files="sandpackFiles"
-            :theme="sandpackTheme"
-            :options="{ autorun: false }"
-          >
-            <CodeEditorBridge
-              ref="editorBridgeRef"
-              @update:code="handleCodeChange"
-            />
-          </SandpackProvider>
-        </div>
-        <!-- Collapse button at bottom -->
-        <div class="ant-doc-demo-box-collapse-btn" @click="handleShowCode">
-          <ExpandIcon :expanded="showCode" />
-          <span>{{ t('ui.codeDemo.action.expandedCode') }}</span>
-        </div>
+          <div class="ant-doc-demo-box-code-tabs">
+            <a-tabs
+              v-model:active-key="activeCodeType"
+              centered
+              size="small"
+            >
+              <a-tab-pane key="ts" :tab="t('ui.codeDemo.type.typescript')" />
+              <a-tab-pane key="js" :tab="t('ui.codeDemo.type.javascript')" />
+            </a-tabs>
+          </div>
+          <div class="ant-doc-demo-box-code">
+            <a-tooltip :title="t(`ui.codeDemo.action.${copied ? 'copied' : 'copy'}`)">
+              <div class="ant-doc-demo-box-code-copy" :class="copied ? 'ant-doc-demo-box-code-copied' : ''" @click="copy()">
+                <CopyOutlined v-if="!copied" />
+                <CheckOutlined v-else />
+              </div>
+            </a-tooltip>
+            <SandpackProvider
+              template="vite-vue-ts"
+              :files="sandpackFiles"
+              :theme="sandpackTheme"
+              :options="{ autorun: false }"
+            >
+              <CodeEditorBridge
+                ref="editorBridgeRef"
+                @update:code="handleCodeChange"
+              />
+            </SandpackProvider>
+          </div>
+          <!-- Collapse button at bottom -->
+          <div class="ant-doc-demo-box-collapse-btn" @click="handleShowCode">
+            <ExpandIcon :expanded="showCode" />
+            <span>{{ t('ui.codeDemo.action.expandedCode') }}</span>
+          </div>
         </template>
       </template>
     </template>

--- a/docs/src/locales/en-US/ui.ts
+++ b/docs/src/locales/en-US/ui.ts
@@ -28,6 +28,7 @@ export default {
       stackblitz: 'Open in StackBlitz',
       copied: 'Copied Success',
       copy: 'Copy Code',
+      loadError: 'Failed to load source code',
     },
   },
 

--- a/docs/src/locales/zh-CN/ui.ts
+++ b/docs/src/locales/zh-CN/ui.ts
@@ -28,6 +28,7 @@ export default {
       stackblitz: '在 StackBlitz 中打开',
       copied: '复制成功',
       copy: '复制代码',
+      loadError: '源码加载失败',
     },
   },
 

--- a/docs/types/md.d.ts
+++ b/docs/types/md.d.ts
@@ -1,4 +1,21 @@
 declare module 'virtual:demos' {
-  const obj: Record<string, any> = {}
-  export default obj
+  interface DemoLocale {
+    html?: string
+    title?: string
+  }
+
+  export interface DemoSourceData {
+    source: string
+    jsSource: string
+  }
+
+  export interface DemoModule {
+    component?: () => Promise<unknown>
+    locales?: Record<string, DemoLocale>
+    sourceVersion: number
+    loadSource: (signal?: AbortSignal) => Promise<DemoSourceData>
+  }
+
+  const demos: Record<string, DemoModule>
+  export default demos
 }


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [x] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

> 参考上游 x 项目 PR：antdv-next/x#168、antdv-next/x#155、antdv-next/x#156

### 💡 背景与方案

#### 问题

此前每个 demo 的完整源码（`source`、`jsSource` 以及 shiki 高亮后的 HTML）都在 build/dev 阶段被内联到虚拟模块中。无论用户是否展开代码面板，浏览器都需要预先解析所有 demo 的全部源码内容，导致：

1. Dev 启动慢 —— 大量源码字符串内联在 JS module 中，增加模块解析开销
2. 内存占用高 —— 所有 demo 源码常驻内存
3. HMR 开销大 —— 每次文件变更都通过 websocket 全量推送源码

#### 方案

从 x 项目移植 demo 源码懒加载优化，并根据 antdv-next 使用 Sandpack 代码编辑器的特点做了裁剪：

**Dev 模式：**
- 新增 `/__demo_source` HTTP 端点，按需提供源码
- 虚拟模块只内联 `locales`，源码通过 `loadSource(signal)` 异步获取
- `sourceVersion` ref 在 HMR 时递增，触发客户端重新 fetch

**Build 模式：**
- 源码作为 per-demo JSON asset 发出，按需 fetch

**HMR：**
- websocket 只推送 `locales` + `timestamp`，不再传输完整源码

**组件侧（code-demo/index.vue）：**
- `AbortController` 支持请求取消
- 加载中 / 加载失败 状态展示
- `sourceStale` 标记：收起面板时保留源码以便快速重新展开，HMR 发生在收起期间则标记过期，下次展开时重新加载

**移除不必要的计算：**
- antdv-next 使用 Sandpack 展示代码，不需要 shiki 高亮 HTML（`sourceHtml`/`jsSourceHtml`）
- 组件无 extra files UI，移除 `collectExtraFiles` / `extraFiles`
- 彻底消除 per-demo 的 shiki 渲染开销（原先最昂贵的操作）

#### 源码生命周期

| 场景 | 行为 |
| --- | --- |
| 首次展开 | loading → 显示源码 |
| 收起面板 | 重置实时编辑状态，**保留源码** |
| 重新展开 | **立即显示**（无 loading） |
| HMR（展开时） | 重新加载源码 |
| HMR（收起时） | 标记 `sourceStale`，下次展开/StackBlitz 时重新加载 |
| 切换 demo | 释放旧源码 |
| 卸载 | 释放源码 |

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Demo source code is now lazy-loaded on demand instead of being inlined into the bundle. The code panel fetches source via an HTTP endpoint (dev) or JSON asset (build) only when expanded, with AbortController-based cancellation and HMR support. Removed unused shiki HTML rendering and extra-files collection for faster loading. |
| 🇨🇳 中文 | Demo 源码改为按需懒加载，不再内联到 bundle 中。代码面板展开时才通过 HTTP 端点（dev）或 JSON asset（build）获取源码，支持 AbortController 取消和 HMR 刷新。移除了未使用的 shiki HTML 渲染和额外文件收集，加载更快。 |