### PR TITLE
[codex] sync ant design 6.5.4 updates

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -23,11 +23,11 @@
           "description": "Ant Design React \u4e3b\u7ec4\u4ef6\u5e93 -> antdv-next \u4e3b\u5305"
         }
       ],
-      "last_synced_commit": "49c4a03cc93035087534d2b34f6ba257ac28e2a0",
-      "last_synced_commit_short": "49c4a03cc9",
-      "last_synced_at": "2026-08-02T00:00:00Z",
-      "last_synced_tag": "6.5.3",
-      "sync_count": 26
+      "last_synced_commit": "5ade9944d67cb53bc0e7eab3b4edd986625e8c76",
+      "last_synced_commit_short": "5ade9944d6",
+      "last_synced_at": "2026-08-07T07:58:26Z",
+      "last_synced_tag": "6.5.4",
+      "sync_count": 27
     },
     {
       "name": "cssinjs",

--- a/docs/src/pages/components/app/index.en-US.md
+++ b/docs/src/pages/components/app/index.en-US.md
@@ -138,4 +138,4 @@ Common props ref：[Common props](/docs/vue/common-props)
 
 ### CSS Var doesn't work inside `<a-app :component="false">` {#faq-css-var-component-false}
 
-Make sure the App `component` is a valid html tag, so when you're turning on CSS variables, there's a container to hold the CSS class name. If not set, it defaults to the `div` tag. If set to `false`, no additional DOM nodes will be created, and no default styles will be provided.
+Antdv Next uses CSS variables by default. App needs a valid HTML element to hold its CSS variable class name. When `component` is `false`, App only provides context without rendering a root DOM node, so no App root class name or default styles are applied. The `class`, `rootClass`, and `style` properties cannot be applied in this mode and trigger a development warning. Keep the default `div` or specify another valid element when these styles are required.

--- a/docs/src/pages/components/app/index.zh-CN.md
+++ b/docs/src/pages/components/app/index.zh-CN.md
@@ -139,4 +139,4 @@ App 组件只能在 `ConfigProvider` 之下才能使用 Design Token， 如果�
 
 ### CSS Var 在 `<a-app :component="false">` 内不起作用 {#faq-css-var-component-false}
 
-请确保 App 的 `component` 是一个有效的 html 标签名，以便在启用 CSS 变量时有一个容器来承载 CSS 类名。如果不设置，则默认为 `div` 标签，如果设置为 `false`，则不会创建额外的 DOM 节点，也不会提供默认样式。
+Antdv Next 默认使用 CSS 变量。App 需要一个有效的 HTML 元素来承载 CSS 变量类名。将 `component` 设置为 `false` 时，App 仅提供上下文而不渲染根 DOM 节点，因此不会应用 App 根节点的类名和默认样式。在此模式下无法应用 `class`、`rootClass` 和 `style` 属性，并会在开发环境下触发警告。如需消费这些样式，请保留默认的 `div` 或指定其他有效元素。

--- a/docs/src/pages/components/float-button/index.en-US.md
+++ b/docs/src/pages/components/float-button/index.en-US.md
@@ -103,7 +103,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| duration | Time to return to top（ms） | number | 450 | - |
+| duration | Time to return to top (ms). This property is ignored when reduced motion (`prefers-reduced-motion: reduce`) is enabled | number | 450 | - |
 | target | Specifies the scrollable area dom node | () =&gt; HTMLElement | () =&gt; window | - |
 | visibilityHeight | The BackTop button will not show until the scroll height reaches this value | number | 400 | - |
 | target | Specifies where to display the linked URL | '_self' \| '_blank' \| '_parent' \| '_top' \| string | - | - |

--- a/docs/src/pages/components/float-button/index.zh-CN.md
+++ b/docs/src/pages/components/float-button/index.zh-CN.md
@@ -104,7 +104,7 @@ demo:
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| duration | 回到顶部所需时间（ms） | number | 450 | - |
+| duration | 回到顶部所需时间（ms）；开启“减弱动态效果”（`prefers-reduced-motion: reduce`）时不生效 | number | 450 | - |
 | target | 设置需要监听其滚动事件的元素 | () =&gt; HTMLElement | () =&gt; window | - |
 | visibilityHeight | 滚动高度达到此参数值才出现 BackTop | number | 400 | - |
 | target | 相当于 a 标签的 target 属性，href 存在时生效 | '_self' \| '_blank' \| '_parent' \| '_top' \| string | - | - |

--- a/packages/antdv-next/src/_util/scrollTo.ts
+++ b/packages/antdv-next/src/_util/scrollTo.ts
@@ -16,27 +16,45 @@ export default function scrollTo(y: number, options: ScrollToOptions = {}) {
   const { getContainer = () => window, callback, duration = 450 } = options
   const container = getContainer()
   const scrollTop = getScroll(container)
+
+  const scroll = (top: number) => {
+    if (isWindow(container)) {
+      container.scrollTo(window.pageXOffset, top)
+    }
+    else if (isDocument(container)) {
+      container.documentElement.scrollTop = top
+    }
+    else {
+      container.scrollTop = top
+    }
+  }
+
+  if (duration <= 0) {
+    scroll(y)
+    if (typeof callback === 'function') {
+      callback()
+    }
+    return () => {}
+  }
+
   const startTime = Date.now()
+  let rafId: number
 
   const frameFunc = () => {
     const timestamp = Date.now()
     const time = timestamp - startTime
     const nextScrollTop = easeInOutCubic(time > duration ? duration : time, scrollTop, y, duration)
-    if (isWindow(container)) {
-      container.scrollTo(window.pageXOffset, nextScrollTop)
-    }
-    else if (isDocument(container)) {
-      container.documentElement.scrollTop = nextScrollTop
-    }
-    else {
-      container.scrollTop = nextScrollTop
-    }
+    scroll(nextScrollTop)
     if (time < duration) {
-      raf(frameFunc)
+      rafId = raf(frameFunc)
     }
     else if (typeof callback === 'function') {
       callback()
     }
   }
-  raf(frameFunc)
+  rafId = raf(frameFunc)
+
+  return () => {
+    raf.cancel(rafId)
+  }
 }

--- a/packages/antdv-next/src/_util/tests/scrollTo.test.ts
+++ b/packages/antdv-next/src/_util/tests/scrollTo.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest'
+import scrollTo from '../scrollTo'
+
+describe('scrollTo', () => {
+  it('should scroll immediately and call callback when duration is not positive', () => {
+    const callback = vi.fn()
+    const div = document.createElement('div')
+    const cancel = scrollTo(1000, {
+      callback,
+      duration: 0,
+      getContainer: () => div,
+    })
+
+    expect(div.scrollTop).toBe(1000)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(() => cancel()).not.toThrow()
+    expect(cancel()).toBeUndefined()
+  })
+})

--- a/packages/antdv-next/src/alert/Alert.tsx
+++ b/packages/antdv-next/src/alert/Alert.tsx
@@ -218,7 +218,7 @@ const Alert = defineComponent<
       // closeable when closeText or closeIcon is assigned
       const isClosableFn = () => {
         const closeIcon = getSlotPropsFnRun(slots, props, 'closeIcon')
-        if (typeof closable === 'object' && closable.closeIcon)
+        if (typeof closable === 'object')
           return true
         if (typeof closable === 'boolean') {
           return closable

--- a/packages/antdv-next/src/alert/tests/Alert.test.tsx
+++ b/packages/antdv-next/src/alert/tests/Alert.test.tsx
@@ -261,6 +261,24 @@ describe('alert', () => {
     expect(wrapper.find('[aria-label="Close"]').exists()).toBe(true)
   })
 
+  it('should show close button when closable is configured by object only', async () => {
+    const onClose = vi.fn()
+    const wrapper = mount(() => (
+      <Alert
+        title="Warning Text"
+        type="warning"
+        closable={{ 'aria-label': 'Dismiss' }}
+        onClose={onClose}
+      />
+    ))
+
+    const closeButton = wrapper.find('[aria-label="Dismiss"]')
+    expect(closeButton.exists()).toBe(true)
+
+    await closeButton.trigger('click')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   it('close button should be support custom icon by closable', async () => {
     const closable = ref<{ closeIcon?: string } | undefined>(undefined)
     const wrapper = mount(() => <Alert closable={closable.value} />)

--- a/packages/antdv-next/src/alert/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/alert/tests/__snapshots__/demo.test.tsx.snap
@@ -1738,7 +1738,33 @@ exports[`alert demo > renders closable correctly 1`] = `
         <!---->
       </div>
       <!---->
-      <!---->
+      <button
+        aria-label="close"
+        class="ant-alert-close-icon"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          aria-label="close"
+          class="anticon anticon-close"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
     </div>
   </transition-stub>
   <br />
@@ -1768,7 +1794,33 @@ exports[`alert demo > renders closable correctly 1`] = `
         <!---->
       </div>
       <!---->
-      <!---->
+      <button
+        aria-label="close"
+        class="ant-alert-close-icon"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          aria-label="close"
+          class="anticon anticon-close"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
     </div>
   </transition-stub>
   <br />
@@ -1798,7 +1850,33 @@ exports[`alert demo > renders closable correctly 1`] = `
         <!---->
       </div>
       <!---->
-      <!---->
+      <button
+        aria-label="close"
+        class="ant-alert-close-icon"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          aria-label="close"
+          class="anticon anticon-close"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
     </div>
   </transition-stub>
   <br />
@@ -1828,7 +1906,33 @@ exports[`alert demo > renders closable correctly 1`] = `
         <!---->
       </div>
       <!---->
-      <!---->
+      <button
+        aria-label="close"
+        class="ant-alert-close-icon"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          aria-label="close"
+          class="anticon anticon-close"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
     </div>
   </transition-stub>
 </div>

--- a/packages/antdv-next/src/app/App.tsx
+++ b/packages/antdv-next/src/app/App.tsx
@@ -57,6 +57,9 @@ const App = defineComponent<AppProps>(
     return () => {
       const { rootClass } = props
       const { className, style, restAttrs } = getAttrStyleAndClass(attrs)
+      const hasRootProps = Boolean(
+        className || rootClass || style || contextClassName.value || contextStyle.value,
+      )
       const customClassName = clsx(
         hashId.value,
         prefixCls.value,
@@ -70,8 +73,9 @@ const App = defineComponent<AppProps>(
       const { component = 'div' } = props
 
       // https://github.com/ant-design/ant-design/issues/48802#issuecomment-2097813526
+      // https://github.com/ant-design/ant-design/issues/58876
       devUseWarning('App')(
-        !(cssVarCls.value && component === false),
+        !(cssVarCls.value && component === false && hasRootProps),
         'usage',
         'When using cssVar, ensure `component` is assigned a valid Vue component string.',
       )

--- a/packages/antdv-next/src/app/tests/index.test.tsx
+++ b/packages/antdv-next/src/app/tests/index.test.tsx
@@ -256,10 +256,39 @@ describe('app', () => {
       wrapper.unmount()
     })
 
-    it('should warn if component is false and cssVarCls is not empty', () => {
+    it('should not warn if component is false without root props', () => {
       const wrapper = mount(() => (
         <ConfigProvider>
-          <App component={false} />
+          <App component={false}>
+            <p />
+          </App>
+        </ConfigProvider>
+      ))
+
+      expect(wrapper.find('.ant-app').exists()).toBe(false)
+      expect(errorSpy).not.toHaveBeenCalled()
+      wrapper.unmount()
+    })
+
+    it('should warn if component is false and root props are provided', () => {
+      const wrapper = mount(() => (
+        <App component={false} class="custom-class" rootClass="custom-root-class" style={{ color: 'red' }}>
+          <p />
+        </App>
+      ))
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Warning: [antd: App] When using cssVar, ensure `component` is assigned a valid Vue component string.',
+      )
+      wrapper.unmount()
+    })
+
+    it('should warn if component is false and context root props are provided', () => {
+      const wrapper = mount(() => (
+        <ConfigProvider app={{ class: 'custom-class', style: { color: 'red' } } as any}>
+          <App component={false}>
+            <p />
+          </App>
         </ConfigProvider>
       ))
 

--- a/packages/antdv-next/src/checkbox/Group.tsx
+++ b/packages/antdv-next/src/checkbox/Group.tsx
@@ -76,15 +76,19 @@ const CheckboxGroup = defineComponent<
       },
     )
     const memoizedOptions = computed(() => {
-      return (props?.options ?? []).map((option) => {
-        if (typeof option === 'string' || typeof option === 'number') {
-          return {
-            label: option,
-            value: option,
+      return (props?.options ?? [])
+        .map((option) => {
+          if (typeof option === 'string' || typeof option === 'number') {
+            return {
+              label: option,
+              value: option,
+            }
           }
-        }
-        return option
-      })
+          return option
+        })
+        .filter((item): item is CheckboxOptionType =>
+          item !== null && item !== undefined && item.value !== null && item.value !== undefined,
+        )
     })
 
     const cancelValue = (val: any) => {
@@ -133,13 +137,13 @@ const CheckboxGroup = defineComponent<
 
     useGroupContextProvider(memoizedContext)
     return () => {
-      const { options = [], rootClass, role } = props
+      const { rootClass, role } = props
       const restProps = omit(props, ['options', 'rootClass', 'defaultValue', 'prefixCls'])
       const children = slots?.default?.()
       const { restAttrs, className, style } = getAttrStyleAndClass(attrs)
 
       const labelRender = slots?.labelRender ?? props?.labelRender
-      const childrenNode = options.length
+      const childrenNode = memoizedOptions.value.length
         ? memoizedOptions.value.map((option, index) => {
             const _label = labelRender ? labelRender({ item: option, index }) : option.label
             return (

--- a/packages/antdv-next/src/checkbox/tests/Checkbox.test.tsx
+++ b/packages/antdv-next/src/checkbox/tests/Checkbox.test.tsx
@@ -282,6 +282,28 @@ describe('checkboxGroup', () => {
     expect(items![0]!.text()).toBe('1')
   })
 
+  it('should ignore options with nullish values', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount(CheckboxGroup, {
+      props: {
+        options: [
+          { label: 'undefined', value: undefined },
+          { label: 'null', value: null },
+          { label: 'valid', value: 0 },
+        ],
+        onChange,
+      },
+    })
+
+    const items = wrapper.findAll('.ant-checkbox-wrapper')
+    expect(items).toHaveLength(1)
+    expect(items[0]?.text()).toBe('valid')
+
+    await wrapper.find('input').trigger('change')
+    await nextTick()
+    expect(onChange).toHaveBeenCalledWith([0])
+  })
+
   it('should support value prop', () => {
     const wrapper = mount(CheckboxGroup, {
       props: { options, value: ['Apple'] },

--- a/packages/antdv-next/src/config-provider/define.ts
+++ b/packages/antdv-next/src/config-provider/define.ts
@@ -119,6 +119,7 @@ export interface ConfigProviderProps {
   theme?: ThemeConfig
   warning?: WarningContextProps
   alert?: AlertConfig
+  app?: ComponentStyleConfig
   anchor?: AnchorStyleConfig
   button?: ButtonConfig
   calendar?: CalendarConfig

--- a/packages/antdv-next/src/config-provider/index.tsx
+++ b/packages/antdv-next/src/config-provider/index.tsx
@@ -50,6 +50,7 @@ const PASSED_PROPS: Exclude<
   'treeSelect',
   'button',
   'alert',
+  'app',
   'cascader',
   'borderBeam',
   'transformCellText',

--- a/packages/antdv-next/src/date-picker/hooks/useMergedPickerSemantic.ts
+++ b/packages/antdv-next/src/date-picker/hooks/useMergedPickerSemantic.ts
@@ -54,5 +54,5 @@ export default function useMergedPickerSemantic<P extends AnyObject = AnyObject>
     }
   })
 
-  return [filledClassNames, filledStyles] as unknown as RequiredSemanticPicker
+  return [filledClassNames, filledStyles] as const as unknown as RequiredSemanticPicker
 }

--- a/packages/antdv-next/src/date-picker/tests/semantic.test.tsx
+++ b/packages/antdv-next/src/date-picker/tests/semantic.test.tsx
@@ -135,4 +135,30 @@ describe('date-picker.Semantic', () => {
     await nextTick()
     wrapper.unmount()
   })
+
+  it('should pass props to RangePicker semantic callbacks', () => {
+    const classesFn = vi.fn((info: { props: Record<string, unknown> }) => ({
+      root: info.props.disabled ? 'range-disabled-root' : 'range-enabled-root',
+    }))
+
+    const stylesFn = vi.fn((info: { props: Record<string, unknown> }) => ({
+      root: { fontSize: info.props.size === 'large' ? '18px' : '14px' },
+    }))
+
+    const wrapper = mount(DatePicker.RangePicker, {
+      props: {
+        disabled: true,
+        classes: classesFn as any,
+        styles: stylesFn as any,
+        size: 'large',
+      },
+    })
+
+    expect(classesFn).toHaveBeenCalled()
+    expect(stylesFn).toHaveBeenCalled()
+
+    const root = wrapper.find('.ant-picker')
+    expect(root.classes()).toContain('range-disabled-root')
+    expect((root.element as HTMLElement).style.fontSize).toBe('18px')
+  })
 })

--- a/packages/antdv-next/src/float-button/BackTop.tsx
+++ b/packages/antdv-next/src/float-button/BackTop.tsx
@@ -122,9 +122,10 @@ const BackTop = defineComponent<
     const transitionProps = computed(() => getTransitionProps(`${rootPrefixCls.value}-fade`))
 
     const scrollToTop = (e: MouseEvent) => {
+      const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')
       scrollTo(0, {
         getContainer: (target.value || getDefaultTarget) as any,
-        duration: duration.value ?? 450,
+        duration: prefersReducedMotion?.matches ? 0 : duration.value ?? 450,
       })
       emit('click', e)
     }

--- a/packages/antdv-next/src/float-button/tests/FloatButton.test.tsx
+++ b/packages/antdv-next/src/float-button/tests/FloatButton.test.tsx
@@ -483,6 +483,24 @@ describe('backTop', () => {
     expect(onClick).toHaveBeenCalled()
   })
 
+  it('should scroll to top immediately when reduced motion is enabled', async () => {
+    vi.spyOn(window, 'matchMedia').mockReturnValueOnce({ matches: true } as MediaQueryList)
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation((_, y) => {
+      window.scrollY = y
+      window.pageYOffset = y
+      document.documentElement.scrollTop = y
+    })
+    window.scrollTo(0, 400)
+
+    const wrapper = mount(BackTop, {
+      props: { visibilityHeight: 0 },
+    })
+    await wrapper.find('.ant-float-btn').trigger('click')
+
+    expect(document.documentElement.scrollTop).toBe(0)
+    scrollToSpy.mockRestore()
+  })
+
   it('should support content via default slot', () => {
     const wrapper = mount(BackTop, {
       props: { visibilityHeight: 0 },

--- a/packages/antdv-next/src/segmented/tests/Segmented.test.tsx
+++ b/packages/antdv-next/src/segmented/tests/Segmented.test.tsx
@@ -183,6 +183,31 @@ describe('segmented', () => {
     })
   })
 
+  describe('value prop', () => {
+    it('should keep controlled selected item when value is not updated after change', async () => {
+      const onChange = vi.fn()
+      const value = ref('Daily')
+      const wrapper = mount(() => (
+        <Segmented
+          value={value.value}
+          options={['Daily', 'Weekly', 'Monthly']}
+          onChange={onChange}
+        />
+      ))
+
+      const weeklyInput = wrapper.findAll(`.${prefixCls}-item-input`)[1]!.element as HTMLInputElement
+      weeklyInput.checked = true
+      weeklyInput.dispatchEvent(new Event('change', { bubbles: true }))
+      await nextTick()
+      await nextTick()
+
+      const items = wrapper.findAll(`.${prefixCls}-item`)
+      expect(onChange).toHaveBeenCalledWith('Weekly')
+      expect(items[0]!.classes()).toContain(`${prefixCls}-item-selected`)
+      expect(items[1]!.classes()).not.toContain(`${prefixCls}-item-selected`)
+    })
+  })
+
   describe('name prop', () => {
     it('should set name attribute on radio inputs', () => {
       const wrapper = mount(Segmented, {

--- a/packages/antdv-next/src/tour/interface.ts
+++ b/packages/antdv-next/src/tour/interface.ts
@@ -64,7 +64,7 @@ export interface TourProps extends ComponentBaseProps, Omit<
   prefixCls?: string
   current?: number
   indicatorsRender?: (current: number, total: number) => any
-  actionsRender?: TourStepProps['actionsRender']
+  actionsRender?: (originNode: any, info: { current: number, total: number }) => any
   // default type, affects the background color and text color
   type?: 'default' | 'primary'
   classes?: TourClassNamesType
@@ -106,8 +106,6 @@ export interface TourStepProps extends Omit<VcTourStepProps, 'className'> {
     class?: string
     style?: CSSProperties
   }
-  indicatorsRender?: (current: number, total: number) => any
-  actionsRender?: (originNode: any, info: { current: number, total: number }) => any
   // default type, affects the background color and text color
   type?: 'default' | 'primary'
   classes?: SemanticClassNames<TourSemanticName>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,8 +399,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@v-c/segmented':
-      specifier: ^1.0.3
-      version: 1.0.3
+      specifier: ^1.0.4
+      version: 1.0.4
     '@v-c/select':
       specifier: ^1.2.0
       version: 1.2.0
@@ -417,7 +417,7 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@v-c/table':
-      specifier: ^1.1.8
+      specifier: ^1.1.9
       version: 1.1.8
     '@v-c/tabs':
       specifier: ^1.3.0
@@ -886,7 +886,7 @@ importers:
         version: 1.1.3(vue@3.5.40(typescript@5.9.3))
       '@v-c/segmented':
         specifier: catalog:vc
-        version: 1.0.3(vue@3.5.40(typescript@5.9.3))
+        version: 1.0.4(vue@3.5.40(typescript@5.9.3))
       '@v-c/select':
         specifier: catalog:vc
         version: 1.2.0(vue@3.5.40(typescript@5.9.3))
@@ -1889,6 +1889,13 @@ packages:
 
   '@napi-rs/wasm-runtime@1.2.1':
     resolution: {integrity: sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     peerDependencies:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
@@ -3004,24 +3011,6 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/picker@1.3.0':
-    resolution: {integrity: sha512-Qn6miglyloid1YKQ+MtlMdPGAiA6JGtPq39IM9BFlf/Vl2pksOcXFqefK/LZmZV9NRXXr8Cr4Iigt2LrtHomWQ==}
-    peerDependencies:
-      date-fns: '>= 2.x'
-      dayjs: '>= 1.x'
-      luxon: '>= 3.x'
-      moment: '>= 2.x'
-      vue: ^3.0.0
-    peerDependenciesMeta:
-      date-fns:
-        optional: true
-      dayjs:
-        optional: true
-      luxon:
-        optional: true
-      moment:
-        optional: true
-
   '@v-c/picker@1.3.2':
     resolution: {integrity: sha512-XY9+cXmHBqPtyf7ks4lvc7664/vM5XybbCyeVtIm1Ukrx+0hnVgjnsjdfDN7qJLmjsye6Q/G0pE9ROCPKw7oMw==}
     peerDependencies:
@@ -3068,8 +3057,8 @@ packages:
   '@v-c/resolve-types@0.0.1':
     resolution: {integrity: sha512-M9ETzAuDE5ExNeYnrV5DGMMKpEqr3WbFEZQ747tpraXWe/gzJ+CzG3DNtauhvbneE33+e3Mmz5EgZt+uAL6Wog==}
 
-  '@v-c/segmented@1.0.3':
-    resolution: {integrity: sha512-+XHRu0Oou6FSAQUjIPnEQLjQUIDhMYQ4eUh8nRpg/S5BCju32/bh8ycmyqrGpQ2z7o+s2ZjKS5vy2b81Lh6xUw==}
+  '@v-c/segmented@1.0.4':
+    resolution: {integrity: sha512-QNEHEvT37gFlRaNuoO4IcHJvj2xwz+r8Nx/f7x+eLEoVectYn1cJN0b1uzpFeGWPNPUbz7u5TOLUR6VOWzr1qQ==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3100,6 +3089,11 @@ packages:
 
   '@v-c/table@1.1.8':
     resolution: {integrity: sha512-F/z+muG/aQ4+qZgVJbxp6DxdkZzje0iXKnAoiBpRURo90xr1xwv/eDIH6COvgTWsBPhT8l56t2ZiLAQRHIi4PA==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@v-c/table@1.1.9':
+    resolution: {integrity: sha512-W70JIN8DN5yequ1wLlIpDu8ghj1JePXNHmSoYingW4kCW/Vs43NYQj0qkirqvrFK6ie9GhbXtgm0CneqFNmkVg==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3663,8 +3657,8 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -7858,6 +7852,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8155,7 +8156,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -8456,8 +8457,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.1
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8829,16 +8830,6 @@ snapshots:
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
 
-  '@v-c/picker@1.3.0(dayjs@1.11.21)(vue@3.5.40(typescript@5.9.3))':
-    dependencies:
-      '@v-c/overflow': 1.1.1(vue@3.5.40(typescript@5.9.3))
-      '@v-c/resize-observer': 1.1.3(vue@3.5.40(typescript@5.9.3))
-      '@v-c/trigger': 1.1.0(vue@3.5.40(typescript@5.9.3))
-      '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
-      vue: 3.5.40(typescript@5.9.3)
-    optionalDependencies:
-      dayjs: 1.11.21
-
   '@v-c/picker@1.3.2(dayjs@1.11.21)(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.1.1(vue@3.5.40(typescript@5.9.3))
@@ -8891,7 +8882,7 @@ snapshots:
       - '@emnapi/runtime'
       - typescript
 
-  '@v-c/segmented@1.0.3(vue@3.5.40(typescript@5.9.3))':
+  '@v-c/segmented@1.0.4(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
@@ -8926,6 +8917,13 @@ snapshots:
       vue: 3.5.40(typescript@5.9.3)
 
   '@v-c/table@1.1.8(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@v-c/resize-observer': 1.1.3(vue@3.5.40(typescript@5.9.3))
+      '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
+      '@v-c/virtual-list': 1.1.0(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
+
+  '@v-c/table@1.1.9(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.1.3(vue@3.5.40(typescript@5.9.3))
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
@@ -9448,18 +9446,18 @@ snapshots:
       '@v-c/mutate-observer': 1.0.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/notification': 2.0.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/pagination': 1.1.0(vue@3.5.40(typescript@5.9.3))
-      '@v-c/picker': 1.3.0(dayjs@1.11.21)(vue@3.5.40(typescript@5.9.3))
+      '@v-c/picker': 1.3.2(dayjs@1.11.21)(vue@3.5.40(typescript@5.9.3))
       '@v-c/progress': 1.0.1(vue@3.5.40(typescript@5.9.3))
       '@v-c/qrcode': 1.0.1(vue@3.5.40(typescript@5.9.3))
       '@v-c/rate': 1.0.1(vue@3.5.40(typescript@5.9.3))
       '@v-c/resize-observer': 1.1.3(vue@3.5.40(typescript@5.9.3))
-      '@v-c/segmented': 1.0.3(vue@3.5.40(typescript@5.9.3))
+      '@v-c/segmented': 1.0.4(vue@3.5.40(typescript@5.9.3))
       '@v-c/select': 1.2.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/slick': 1.0.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/slider': 1.1.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/steps': 1.0.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/switch': 1.0.1(vue@3.5.40(typescript@5.9.3))
-      '@v-c/table': 1.1.8(vue@3.5.40(typescript@5.9.3))
+      '@v-c/table': 1.1.9(vue@3.5.40(typescript@5.9.3))
       '@v-c/tabs': 1.3.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/textarea': 1.1.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/tooltip': 1.1.0(vue@3.5.40(typescript@5.9.3))
@@ -9575,7 +9573,7 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11613,7 +11611,7 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -155,13 +155,13 @@ catalogs:
     '@v-c/qrcode': ^1.0.1
     '@v-c/rate': ^1.0.1
     '@v-c/resize-observer': ^1.1.3
-    '@v-c/segmented': ^1.0.3
+    '@v-c/segmented': ^1.0.4
     '@v-c/select': ^1.2.0
     '@v-c/slick': ^1.0.2
     '@v-c/slider': ^1.1.0
     '@v-c/steps': ^1.0.0
     '@v-c/switch': ^1.0.1
-    '@v-c/table': ^1.1.8
+    '@v-c/table': ^1.1.9
     '@v-c/tabs': ^1.3.0
     '@v-c/textarea': ^1.1.0
     '@v-c/tooltip': ^1.1.0


### PR DESCRIPTION
## Summary

Sync ant-design upstream from `49c4a03cc9` to `5ade9944d6` (`6.5.4`) and update the shared sync state.

Ported upstream changes:

- ant-design#58905: DatePicker.RangePicker semantic callbacks receive merged props
- ant-design#58885: Alert object-form `closable` shows the close affordance without `closeIcon`
- ant-design#58879: Checkbox.Group ignores options with nullish values
- ant-design#58849: BackTop respects reduced-motion preferences; `scrollTo` supports immediate scroll and cancellation
- ant-design#58877: App warns for `component=false` only when root props are ignored, and ConfigProvider now passes `app` config
- ant-design#58859: Tour drops unusable per-step render callback types

Skipped site/docs/dependency-only upstream commits that do not apply to the Vue port.

## Validation

- `git diff --check`
- `pnpm -F antdv-next test src/checkbox/tests/Checkbox.test.tsx src/_util/tests/scrollTo.test.ts src/float-button/tests/FloatButton.test.tsx src/app/tests/index.test.tsx src/alert/tests/Alert.test.tsx src/date-picker/tests/semantic.test.tsx src/alert/tests/demo.test.tsx`
- `TZ=Asia/Shanghai pnpm test`

Note: full `vue-tsc --noEmit -p packages/antdv-next/tsconfig.json` still reports existing test type issues outside this sync; filtering the modified file areas produced no output.