### PR TITLE
feat(docs): support multi-file demo tabs in the code panel

### DIFF
--- a/docs/plugins/markdown/demo/index.ts
+++ b/docs/plugins/markdown/demo/index.ts
@@ -11,6 +11,76 @@ interface ParsedDemoFile {
   locales: Record<string, { html: string, title: string }>
   sourceCode: string
   jsSourceCode: string
+  extraFiles: DemoExtraFile[]
+}
+
+interface DemoExtraFile {
+  name: string
+  lang: string
+  code: string
+  html: string
+}
+
+const EXT_LANG_MAP: Record<string, string> = {
+  '.json': 'json',
+  '.ts': 'ts',
+  '.tsx': 'tsx',
+  '.js': 'js',
+  '.jsx': 'jsx',
+  '.mjs': 'js',
+  '.cjs': 'js',
+  '.vue': 'vue',
+  '.css': 'css',
+  '.less': 'less',
+  '.scss': 'scss',
+  '.md': 'md',
+  '.html': 'html',
+}
+
+function extLang(ext: string) {
+  return EXT_LANG_MAP[ext.toLowerCase()] ?? 'text'
+}
+
+/**
+ * 收集 demo 内相对导入的伴生文件（用于多文件代码 tab 展示）。
+ * 跳过无扩展名的导入（如目录 index），避免内联无关模块。
+ */
+async function collectExtraFiles(
+  filePath: string,
+  sourceCode: string,
+  md: ReturnType<ReturnType<typeof createMarkdown>>,
+): Promise<DemoExtraFile[]> {
+  const dir = path.dirname(filePath)
+  const seen = new Set<string>()
+  const files: DemoExtraFile[] = []
+
+  // Match `from './xxx'` or side-effect `import './xxx'`.
+  const importRegex = /(?:from|import)\s*(?:\(\s*)?["'](\.{1,2}\/[^"']+)["']/g
+
+  // `for` 的 update 表达式在 continue 时也会执行，避免重复/无扩展名导入导致死循环
+  for (
+    let match = importRegex.exec(sourceCode);
+    match !== null;
+    match = importRegex.exec(sourceCode)
+  ) {
+    const rel = match[1]
+    const ext = path.extname(rel)
+    if (seen.has(rel) || !ext)
+      continue
+    seen.add(rel)
+
+    const resolved = path.resolve(dir, rel)
+    try {
+      const content = await fs.readFile(resolved, 'utf-8')
+      const lang = extLang(ext)
+      const html = await md.renderAsync(`\`\`\`${lang}\n${content}\n\`\`\``)
+      files.push({ name: rel, lang, code: content, html })
+    }
+    catch {
+      // ignore non-existent / non-readable files
+    }
+  }
+  return files
 }
 
 /**
@@ -46,11 +116,13 @@ async function parseDemoFile(
 
   const sourceCode = code.replace(/<docs[^>]*>[\s\S]*?<\/docs>/g, '').trim()
   const jsSourceCode = await tsToJs(sourceCode)
+  const extraFiles = await collectExtraFiles(filePath, sourceCode, md)
 
   return {
     locales,
     sourceCode,
     jsSourceCode,
+    extraFiles,
   }
 }
 
@@ -163,6 +235,7 @@ export function demoPlugin(): PluginOption {
             JSON.stringify({
               source: parsed.sourceCode,
               jsSource: parsed.jsSourceCode,
+              extraFiles: parsed.extraFiles,
             }),
           )
         }
@@ -219,6 +292,11 @@ export function demoPlugin(): PluginOption {
               md,
             )
 
+        // 监听伴生文件，保证多文件 demo 的 HMR 重新解析
+        for (const file of parsed?.extraFiles ?? []) {
+          this.addWatchFile(path.resolve(path.dirname(filePath), file.name))
+        }
+
         // Build: 生成 JSON asset
         const sourceUrl = isServe
           ? undefined
@@ -229,6 +307,7 @@ export function demoPlugin(): PluginOption {
                 source: JSON.stringify({
                   source: parsed!.sourceCode,
                   jsSource: parsed!.jsSourceCode,
+                  extraFiles: parsed!.extraFiles,
                 }),
               }),
             )

--- a/docs/src/components/code-demo/index.vue
+++ b/docs/src/components/code-demo/index.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import type { DemoModule, DemoSourceData } from 'virtual:demos'
+import type { DemoExtraFile, DemoModule, DemoSourceData } from 'virtual:demos'
 import type { CSSProperties } from 'vue'
 import { CheckOutlined, CodeOutlined, CopyOutlined, EditOutlined, ThunderboltOutlined } from '@antdv-next/icons'
 import { aquaBlue, atomDark } from '@codesandbox/sandpack-themes'
 import { useClipboard, useDebounceFn } from '@vueuse/core'
 import { SandpackProvider } from 'sandpack-vue3'
 import demos from 'virtual:demos'
-import { computed, defineAsyncComponent, markRaw, onBeforeUnmount, shallowRef, watch } from 'vue'
+import { computed, defineAsyncComponent, markRaw, nextTick, onBeforeUnmount, shallowRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CodeEditorBridge from '@/components/code-demo/code-editor-bridge.vue'
 import ExpandIcon from '@/components/code-demo/expand-icon.vue'
@@ -118,21 +118,63 @@ const hasJsSource = computed(() => {
   return Boolean(jsSource)
 })
 
-const activeCodeType = computed<DemoCodeType>({
+const extraFiles = computed<DemoExtraFile[]>(() => sourceData.value?.extraFiles ?? [])
+
+const codeTabKeys = computed(() => {
+  const keys: string[] = ['ts']
+  if (hasJsSource.value)
+    keys.push('js')
+  for (const file of extraFiles.value)
+    keys.push(file.name)
+  return keys
+})
+
+// 当前激活的代码 tab。ts/js 偏好持久化到全局 store，多文件 tab 仅作用于当前 demo。
+const localCodeKey = shallowRef<string | null>(null)
+
+const activeCodeType = computed<string>({
   get() {
-    if (codeType.value === 'js' && hasJsSource.value)
-      return 'js'
+    const preferred = localCodeKey.value ?? codeType.value
+    if (codeTabKeys.value.includes(preferred))
+      return preferred
     return 'ts'
   },
   set(value) {
-    codeType.value = value
+    if (value === 'ts' || value === 'js') {
+      codeType.value = value
+      localCodeKey.value = null
+    }
+    else {
+      localCodeKey.value = value
+    }
   },
 })
 
-const activeSourceCode = computed(() => {
+const activeExtraFile = computed(() =>
+  extraFiles.value.find(file => file.name === activeCodeType.value),
+)
+
+/** 将 demo 相对导入路径映射为 sandpack 虚拟文件路径 */
+function extraFileToSandpackPath(name: string) {
+  return `/src/${name.replace(/^(\.\.?\/)+/, '')}`
+}
+
+/** 代码 tab 显示名（去掉 ./ 前缀） */
+function displayFileName(name: string) {
+  return name.replace(/^(\.\.?\/)+/, '')
+}
+
+const mainSourceCode = computed(() => {
   if (activeCodeType.value === 'js')
     return sourceData.value?.jsSource ?? sourceData.value?.source ?? ''
   return sourceData.value?.source ?? ''
+})
+
+// 编辑器当前展示的源码（主 demo 或伴生文件）
+const activeSourceCode = computed(() => {
+  if (activeExtraFile.value)
+    return activeExtraFile.value.code
+  return mainSourceCode.value
 })
 
 const description = computed(() => {
@@ -166,8 +208,11 @@ function handleShowCode() {
   }
 }
 
-// 切换 demo 时释放旧源码
-watch(demo, releaseSource, { flush: 'sync' })
+// 切换 demo 时释放旧源码并重置多文件 tab
+watch(demo, () => {
+  localCodeKey.value = null
+  releaseSource()
+}, { flush: 'sync' })
 
 // 展开代码面板时触发加载（收起时不释放，保留源码）
 watch([showCode, demo], ([visible, currentDemo]) => {
@@ -200,13 +245,19 @@ watch(activeCodeType, () => {
   liveComponent.value = null
   compileError.value = null
   currentCode.value = null
-  editorBridgeRef.value?.resetCode(activeSourceCode.value)
+  // 等 sandpack 完成 activeFile 切换后再重置内容，避免写入错误的文件
+  nextTick(() => {
+    editorBridgeRef.value?.resetCode(activeSourceCode.value)
+  })
 })
 
 const handleCodeChange = useDebounceFn(async (newCode: string) => {
   currentCode.value = newCode
+  // 伴生文件 tab 不参与主 demo 的实时编译
+  if (activeExtraFile.value)
+    return
   // Code matches original source (e.g. after tab switch reset), skip compilation
-  if (newCode === activeSourceCode.value) {
+  if (newCode === mainSourceCode.value) {
     liveComponent.value = null
     compileError.value = null
     return
@@ -223,9 +274,22 @@ const handleCodeChange = useDebounceFn(async (newCode: string) => {
 
 const sandpackTheme = computed(() => appStore.darkMode ? atomDark : aquaBlue)
 
-const sandpackFiles = computed(() => ({
-  '/src/App.vue': activeSourceCode.value,
-}))
+const sandpackFiles = computed(() => {
+  const files: Record<string, string> = {
+    '/src/App.vue': mainSourceCode.value,
+  }
+  for (const file of extraFiles.value) {
+    files[extraFileToSandpackPath(file.name)] = file.code
+  }
+  return files
+})
+
+// 当前激活的 sandpack 文件（多文件 tab 时切换）
+const sandpackActiveFile = computed(() => {
+  if (activeExtraFile.value)
+    return extraFileToSandpackPath(activeExtraFile.value.name)
+  return '/src/App.vue'
+})
 const active = computed(() => route.hash === `#${id.value}`)
 function handleScroll(e: Event) {
   e.preventDefault()
@@ -246,9 +310,9 @@ async function handleStackBlitz() {
     showCode.value = true
     return
   }
-  if (activeSourceCode.value) {
+  if (mainSourceCode.value) {
     const title = `${titleRef.value?.textContent || 'Antdv Next Demo'} - antdv-next@${antdvPkg.version}`
-    openStackBlitz(title, activeSourceCode.value)
+    openStackBlitz(title, mainSourceCode.value)
   }
 }
 
@@ -295,7 +359,7 @@ async function handleOpenPlayground() {
     showCode.value = true
     return
   }
-  const url = loadPlaygroundUrl(activeSourceCode.value ?? '')
+  const url = loadPlaygroundUrl(mainSourceCode.value ?? '')
   if (url) {
     window.open(url, '_blank', 'noopener,noreferrer')
   }
@@ -382,6 +446,11 @@ async function handleOpenPlayground() {
             >
               <a-tab-pane key="ts" :tab="t('ui.codeDemo.type.typescript')" />
               <a-tab-pane key="js" :tab="t('ui.codeDemo.type.javascript')" />
+              <a-tab-pane
+                v-for="file in extraFiles"
+                :key="file.name"
+                :tab="displayFileName(file.name)"
+              />
             </a-tabs>
           </div>
           <div class="ant-doc-demo-box-code">
@@ -395,7 +464,7 @@ async function handleOpenPlayground() {
               template="vite-vue-ts"
               :files="sandpackFiles"
               :theme="sandpackTheme"
-              :options="{ autorun: false }"
+              :options="{ autorun: false, activeFile: sandpackActiveFile }"
             >
               <CodeEditorBridge
                 ref="editorBridgeRef"

--- a/docs/types/md.d.ts
+++ b/docs/types/md.d.ts
@@ -4,9 +4,17 @@ declare module 'virtual:demos' {
     title?: string
   }
 
+  export interface DemoExtraFile {
+    name: string
+    lang: string
+    code: string
+    html: string
+  }
+
   export interface DemoSourceData {
     source: string
     jsSource: string
+    extraFiles: DemoExtraFile[]
   }
 
   export interface DemoModule {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Ports the multi-file demo (companion files) feature from the `antdv-next/x` docs plugin (`packages/docs/plugins/markdown/demo/index.ts` + `packages/docs/src/components/doc-demo/demo.vue`).
> - Builds on the existing lazy-load demo-source pipeline (`loadSource()` / `DemoSourceData`).

### 💡 Background and Solution

**Background**

Demos that import companion files (e.g. `app/demo/config.vue` importing `./myPage.vue` / `./myPage2.vue`) currently only show the main demo file in the code panel — the companion sources are invisible to readers.

**Solution**

- The demo plugin now collects files imported via relative paths (`./x`, `../x`) and ships them as `extraFiles` in both the dev source endpoint and the production JSON asset, with a per-file `name` / `lang` / `code` / `html` payload. Extension-less imports (e.g. `../locales` directory indexes) are skipped to avoid inlining unrelated modules.
- The `code-demo` panel renders each companion file as an extra tab next to `TypeScript` / `JavaScript`. Clicking a tab switches the Sandpack editor to the corresponding virtual file (`/src/<name>`), where the file is fully editable and copyable.
- Live SFC compilation stays limited to the main demo file — companion tabs are for viewing/editing only, so no false compile errors are shown when an extra file is active.

Verified locally:
- Dev source endpoint returns `extraFiles` correctly (`config.vue` → `["./myPage2.vue"]`, extension-less imports skipped).
- Production build passes; emitted `demo-source-*.json` assets contain `extraFiles`.
- `eslint` clean and `vue-tsc` introduces no new errors for the touched files.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Demo code panels now show extra tabs for companion files imported by the demo, editable in the Sandpack editor. |
| 🇨🇳 Chinese | Demo 代码面板新增多文件 tab，可查看并编辑 demo 导入的伴生文件。 |