### PR TITLE
fix(site): harden mainland China detection for CN site switch

### DIFF
--- a/docs/src/utils/geo-redirect.ts
+++ b/docs/src/utils/geo-redirect.ts
@@ -9,19 +9,145 @@ interface IpAddrResponse {
   }
 }
 
+interface StoredPreference {
+  value: GeoRedirectPreference
+  time: number
+}
+
 const CN_SITE_ORIGIN = 'https://www.antdv-next.cn'
+const CN_SITE_PROBE_URL = `${CN_SITE_ORIGIN}/antdv-next.png`
+const CN_SITE_PROBE_TIMEOUT = 1500
 const GEO_IP_API_URL = 'https://v4_dx.boce.com:44433/ipaddr'
 const GEO_IP_TIMEOUT = 1200
 const GEO_REDIRECT_PREFERENCE_KEY = 'cn-site-redirect-preference'
+// Asking again after a month keeps the prompt useful for travellers without nagging.
+const GEO_REDIRECT_REJECTED_TTL = 30 * 24 * 60 * 60 * 1000
+const GEO_REDIRECT_DEBUG_VALUE = 'antdv-next'
+const GEO_REDIRECT_DISABLED_SEARCH = 'cn-redirect'
+
+const INTERNATIONAL_HOSTNAMES = ['antdv-next.com', 'www.antdv-next.com']
+
+// Mainland-only IANA zones. Hong Kong / Macao / Taipei are excluded on purpose:
+// those regions reach the international site without the mainland channel.
+const MAINLAND_TIME_ZONES = [
+  'Asia/Shanghai',
+  'Asia/Chongqing',
+  'Asia/Chungking',
+  'Asia/Harbin',
+  'Asia/Urumqi',
+  'Asia/Kashgar',
+  'PRC',
+]
+const NON_MAINLAND_TIME_ZONES = ['Asia/Hong_Kong', 'Asia/Macau', 'Asia/Macao', 'Asia/Taipei']
+const NON_MAINLAND_LANGUAGE_REGIONS = ['hk', 'mo', 'tw', 'sg', 'hant']
+const NON_MAINLAND_IP_REGIONS = ['香港', '澳门', '澳門', '台湾', '台灣']
+
+/** Score needed to prompt without asking the IP service. */
+const LOCAL_SIGNAL_CONFIDENT_SCORE = 3
 
 export type GeoRedirectPreference = 'accepted' | 'rejected'
 export type GeoRedirectDecision = 'redirect' | 'prompt' | 'skip'
 
-function isComHost(hostname: string): boolean {
-  const normalizedHostname = hostname.trim().toLowerCase().replace(/\.$/, '')
+let cnSiteReachablePromise: Promise<boolean> | null = null
 
-  return normalizedHostname === 'antdv-next.com'
-    || normalizedHostname === 'www.antdv-next.com'
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/\.$/, '')
+}
+
+function isInternationalHost(hostname: string): boolean {
+  return INTERNATIONAL_HOSTNAMES.includes(normalizeHostname(hostname))
+}
+
+function readStorage(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key)
+  }
+  catch {
+    // Storage can throw when cookies are blocked; detection must not break the page.
+    return null
+  }
+}
+
+function writeStorage(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value)
+  }
+  catch {
+    // Ignore quota / privacy-mode failures, the prompt simply shows up again.
+  }
+}
+
+/** `localStorage.DEBUG = 'antdv-next'` forces the flow on, including on localhost. */
+function isDebugForced(): boolean {
+  return readStorage('DEBUG') === GEO_REDIRECT_DEBUG_VALUE
+}
+
+/** `?cn-redirect=off` opts a single visit out, e.g. when linking the global site on purpose. */
+function isDisabledBySearch(search: string): boolean {
+  return new URLSearchParams(search).get(GEO_REDIRECT_DISABLED_SEARCH) === 'off'
+}
+
+function isRedirectableHost(hostname: string): boolean {
+  // Only the two canonical international hosts are redirected, so preview
+  // deployments (surge / vercel / netlify / pages.dev) and localhost stay untouched.
+  return isInternationalHost(hostname) || isDebugForced()
+}
+
+function getLanguageTags(): string[] {
+  const { languages, language } = window.navigator
+
+  return (languages?.length ? [...languages] : [language])
+    .filter(Boolean)
+    .map(tag => tag.toLowerCase())
+}
+
+function getTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone ?? ''
+  }
+  catch {
+    return ''
+  }
+}
+
+function isCnDocPathname(pathname: string): boolean {
+  return /-cn\/?$/.test(pathname)
+}
+
+/**
+ * Cheap local heuristics, scored so a single weak hint never triggers a prompt
+ * on its own. A hard veto wins over any positive signal.
+ */
+function getLocalSignalScore(pathname: string): number {
+  const languageTags = getLanguageTags()
+  const timeZone = getTimeZone()
+
+  const vetoed = NON_MAINLAND_TIME_ZONES.includes(timeZone)
+    || languageTags.some(tag => tag.startsWith('zh-')
+      && NON_MAINLAND_LANGUAGE_REGIONS.some(region => tag.includes(region)))
+
+  if (vetoed) {
+    return 0
+  }
+
+  let score = 0
+
+  if (languageTags.some(tag => tag === 'zh-cn' || tag.startsWith('zh-hans'))) {
+    score += 2
+  }
+  else if (languageTags.some(tag => tag === 'zh' || tag.startsWith('zh-'))) {
+    score += 1
+  }
+
+  if (MAINLAND_TIME_ZONES.includes(timeZone)) {
+    score += 2
+  }
+
+  if (isCnDocPathname(pathname)) {
+    score += 1
+  }
+
+  return score
 }
 
 function isChinaMainlandVisit(from: string | undefined): boolean {
@@ -29,7 +155,62 @@ function isChinaMainlandVisit(from: string | undefined): boolean {
     return false
   }
 
+  if (NON_MAINLAND_IP_REGIONS.some(region => from.includes(region))) {
+    return false
+  }
+
   return from === '中国' || from.startsWith('中国/')
+}
+
+/** Secondary confirmation, only used when the local signals are inconclusive. */
+async function lookupChinaMainland(): Promise<boolean> {
+  const controller = new AbortController()
+  const timeoutId = window.setTimeout(() => controller.abort(), GEO_IP_TIMEOUT)
+
+  try {
+    const response = await fetch(GEO_IP_API_URL, { signal: controller.signal })
+
+    if (!response.ok) {
+      return false
+    }
+
+    const result = await response.json() as IpAddrResponse
+
+    return isChinaMainlandVisit(result.data?.from)
+  }
+  catch {
+    // Ignore network and CORS failures to avoid blocking normal page usage.
+    return false
+  }
+  finally {
+    window.clearTimeout(timeoutId)
+  }
+}
+
+/**
+ * Never send visitors to a channel that cannot answer. An image request needs no
+ * CORS headers, so this works even though the two sites are different origins.
+ */
+function probeCnSiteReachable(): Promise<boolean> {
+  cnSiteReachablePromise ??= new Promise<boolean>((resolve) => {
+    const image = new Image()
+    let settled = false
+
+    const settle = (reachable: boolean) => {
+      if (!settled) {
+        settled = true
+        resolve(reachable)
+      }
+    }
+
+    image.onload = () => settle(true)
+    image.onerror = () => settle(false)
+    image.src = CN_SITE_PROBE_URL
+
+    window.setTimeout(() => settle(false), CN_SITE_PROBE_TIMEOUT)
+  })
+
+  return cnSiteReachablePromise
 }
 
 export function getGeoRedirectPreference(): GeoRedirectPreference | null {
@@ -37,9 +218,35 @@ export function getGeoRedirectPreference(): GeoRedirectPreference | null {
     return null
   }
 
-  const preference = window.localStorage.getItem(GEO_REDIRECT_PREFERENCE_KEY)
+  const raw = readStorage(GEO_REDIRECT_PREFERENCE_KEY)
 
-  return preference === 'accepted' || preference === 'rejected' ? preference : null
+  if (!raw) {
+    return null
+  }
+
+  // Plain strings are what earlier versions stored, keep honouring them.
+  if (raw === 'accepted' || raw === 'rejected') {
+    return raw
+  }
+
+  let stored: StoredPreference | null = null
+
+  try {
+    stored = JSON.parse(raw) as StoredPreference
+  }
+  catch {
+    return null
+  }
+
+  if (stored?.value !== 'accepted' && stored?.value !== 'rejected') {
+    return null
+  }
+
+  if (stored.value === 'rejected' && Date.now() - stored.time > GEO_REDIRECT_REJECTED_TTL) {
+    return null
+  }
+
+  return stored.value
 }
 
 export function setGeoRedirectPreference(preference: GeoRedirectPreference): void {
@@ -47,7 +254,10 @@ export function setGeoRedirectPreference(preference: GeoRedirectPreference): voi
     return
   }
 
-  window.localStorage.setItem(GEO_REDIRECT_PREFERENCE_KEY, preference)
+  writeStorage(
+    GEO_REDIRECT_PREFERENCE_KEY,
+    JSON.stringify({ value: preference, time: Date.now() } satisfies StoredPreference),
+  )
 }
 
 export function buildCnRedirectUrl(): string | null {
@@ -57,7 +267,7 @@ export function buildCnRedirectUrl(): string | null {
 
   const { location } = window
 
-  if (!isComHost(location.hostname) || location.pathname.startsWith('/~demos')) {
+  if (!isRedirectableHost(location.hostname) || location.pathname.startsWith('/~demos')) {
     return null
   }
 
@@ -82,43 +292,32 @@ export async function getChinaMainlandRedirectDecision(): Promise<GeoRedirectDec
     return 'skip'
   }
 
-  const targetUrl = buildCnRedirectUrl()
-
-  if (!targetUrl) {
+  if (isDisabledBySearch(window.location.search) || !buildCnRedirectUrl()) {
     return 'skip'
   }
 
   const preference = getGeoRedirectPreference()
 
-  if (preference === 'accepted') {
-    return 'redirect'
-  }
-
   if (preference === 'rejected') {
     return 'skip'
   }
 
-  const controller = new AbortController()
-  const timeoutId = window.setTimeout(() => controller.abort(), GEO_IP_TIMEOUT)
-
-  try {
-    const response = await fetch(GEO_IP_API_URL, {
-      signal: controller.signal,
-    })
-
-    if (!response.ok) {
-      return 'skip'
-    }
-
-    const result = await response.json() as IpAddrResponse
-
-    return isChinaMainlandVisit(result.data?.from) ? 'prompt' : 'skip'
+  if (preference === 'accepted') {
+    return await probeCnSiteReachable() ? 'redirect' : 'skip'
   }
-  catch {
-    // Ignore network and CORS failures to avoid blocking normal page usage.
+
+  const score = isDebugForced()
+    ? LOCAL_SIGNAL_CONFIDENT_SCORE
+    : getLocalSignalScore(window.location.pathname)
+
+  // No local hint at all: stay silent and spend no request on the IP service.
+  if (score <= 0) {
     return 'skip'
   }
-  finally {
-    window.clearTimeout(timeoutId)
+
+  if (score < LOCAL_SIGNAL_CONFIDENT_SCORE && !await lookupChinaMainland()) {
+    return 'skip'
   }
+
+  return await probeCnSiteReachable() ? 'prompt' : 'skip'
 }


### PR DESCRIPTION
[中文版模板 / Chinese template](./.github/PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> None — follow-up hardening of the `antdv-next.com` → `www.antdv-next.cn` switch prompt.

### 💡 Background and Solution

`docs/src/utils/geo-redirect.ts` decided whether a visitor is in mainland China by calling a single third-party IP service (`v4_dx.boce.com:44433/ipaddr`) on **every** page load, and returned `skip` whenever that call failed. That means overseas visitors paid for a cross-origin request they never needed, mainland visitors got nothing at all whenever the service was slow, blocked or down, and `from.startsWith('中国/')` also matched `中国/香港`, `中国/台湾` and `中国/澳门`.

Following how the Ant Design site handles its China mirror hint (`.dumi/scripts/mirror-notify.js`) — a stack of cheap local conditions plus a reachability probe before pointing anyone at the mirror — the detection is now layered:

1. **Guards** (unchanged intent, made explicit): only the two canonical hosts `antdv-next.com` / `www.antdv-next.com` are considered, so localhost and preview deploys (surge / vercel / netlify / pages.dev) are skipped for free; `/~demos` iframes stay untouched.
2. **Local signals, scored** — `navigator.languages` (`zh-CN` / `zh-Hans` = 2, other `zh-*` = 1), IANA time zone (`Asia/Shanghai`, `Asia/Urumqi`, … = 2), and a `-cn` pathname (= 1). A score of 3+ is confident enough on its own, so **most visitors now trigger zero network requests**.
3. **Regional veto** — `Asia/Hong_Kong` / `Asia/Macau` / `Asia/Taipei` time zones, `zh-HK` / `zh-MO` / `zh-TW` / `zh-Hant` / `zh-SG` language tags and `中国/香港`-style IP regions cancel detection outright.
4. **IP lookup as a tie-breaker only** — still the same endpoint with a 1.2s abort, but reached only when the local score is 1–2 (e.g. an `en-US` browser on `Asia/Shanghai`).
5. **Reachability probe** — an image request against `https://www.antdv-next.cn/antdv-next.png` (1.5s timeout, no CORS needed, cached per session) runs before prompting *and* before honouring a stored `accepted`, so a visitor is never dropped onto a channel that cannot answer.
6. **Robustness / escape hatches** — every `localStorage` access is wrapped in `try/catch` (blocked-cookie mode no longer throws), a `rejected` choice expires after 30 days instead of being permanent (old plain-string values are still honoured), `?cn-redirect=off` disables the flow for one visit, and `localStorage.DEBUG = 'antdv-next'` forces it on, including on localhost.

The exported API (`getChinaMainlandRedirectDecision`, `redirectToCnSite`, `buildCnRedirectUrl`, `get`/`setGeoRedirectPreference`) is unchanged, so `docs/src/App.vue` needs no edits.

Verified by driving `getChinaMainlandRedirectDecision()` against stubbed `window` / `Intl` / `Image` / `fetch` scenarios:

| Scenario | Decision |
| --- | --- |
| `zh-CN` + `Asia/Shanghai` on `/components/button-cn` | `prompt` (no IP request) |
| `en-US` + `America/New_York` | `skip` (no IP request) |
| `zh-TW` + `Asia/Taipei`, `zh-HK` + `Asia/Hong_Kong` | `skip` |
| `en-US` + `Asia/Shanghai`, IP says `中国/上海/电信` | `prompt` |
| `zh` + `America/Los_Angeles`, IP says `美国/加州` or `中国/香港` | `skip` |
| mainland visitor, CN channel unreachable | `skip` |
| localhost / `*.vercel.app` / `?cn-redirect=off` / `/~demos` | `skip` |
| stored `accepted` | `redirect` |
| `rejected` 31 days ago | prompt eligible again |

`eslint` passes on the changed file and `vue-tsc` reports no new errors (the 149 remaining docs errors are pre-existing on `main`).

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Site: mainland China detection for the CN channel prompt now relies on browser language, time zone and pathname first, only falls back to the IP lookup when inconclusive, excludes Hong Kong / Macao / Taiwan visitors, and verifies the CN channel is reachable before switching. |
| 🇨🇳 Chinese | 官网：国内通道提示的地域检测改为优先使用浏览器语言、时区与路径判断，仅在信号不明确时回退到 IP 查询，排除中国香港 / 澳门 / 台湾访问者，并在跳转前先探测国内通道可用性。 |