### PR TITLE
fix(form): stop deriving validation rules from FormItem required

### DIFF
--- a/packages/antdv-next/src/form/FormItem/index.tsx
+++ b/packages/antdv-next/src/form/FormItem/index.tsx
@@ -159,7 +159,7 @@ const InternalFormItem = defineComponent<
       }
       if (props.required !== undefined) {
         // 继承已有规则中的 type，避免 InputNumber 等组件的类型验证冲突
-        let ruleType = (collectedRules.find(r => (r as RuleObject).type) as any)?.type
+        let ruleType = (collectedRules.some(r => (r as RuleObject).type) as any)?.type
         // 如果没有已定义的 type，则根据当前值的类型推断
         if (!ruleType) {
           const currentValue = hasName.value

--- a/packages/antdv-next/src/form/FormItem/index.tsx
+++ b/packages/antdv-next/src/form/FormItem/index.tsx
@@ -157,33 +157,6 @@ const InternalFormItem = defineComponent<
       if (props.rules) {
         collectedRules.push(...props.rules)
       }
-      if (props.required !== undefined) {
-        // 继承已有规则中的 type，避免 InputNumber 等组件的类型验证冲突
-        let ruleType = (collectedRules.some(r => (r as RuleObject).type) as any)?.type
-        // 如果没有已定义的 type，则根据当前值的类型推断
-        if (!ruleType) {
-          const currentValue = hasName.value
-            ? (formContext.value?.getFieldValue?.(namePath.value) ?? getValue(formContext.value?.model ?? {}, namePath.value))
-            : undefined
-          if (typeof currentValue === 'number') {
-            ruleType = 'number'
-          }
-          else if (typeof currentValue === 'boolean') {
-            ruleType = 'boolean'
-          }
-          else if (Array.isArray(currentValue)) {
-            ruleType = 'array'
-          }
-        }
-        const requiredRule: RuleObject = {
-          required: !!props.required,
-          ...(ruleType ? { type: ruleType } : {}),
-        }
-        if (mergedValidateTrigger.value !== undefined) {
-          requiredRule.validateTrigger = (mergedValidateTrigger.value || []) as any
-        }
-        collectedRules.push(requiredRule)
-      }
       return collectedRules as RuleObject[]
     })
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #705 

### 💡 Background and Solution

在 antd 中，formItem 的 required 只是决定输入框前面 * 的显示。如果 required 影响校验，则会在类型推断的时候向 collectedRules 推入多条校验规则，因此导致重复校验。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |avoid duplicate type validation for required FormItem|
| 🇨🇳 Chinese |避免表单必填时进行重复的类型校验|   
