### PR TITLE
feat(form): support render-function rule messages

### DIFF
--- a/docs/src/pages/components/form/demo/message-render.vue
+++ b/docs/src/pages/components/form/demo/message-render.vue
@@ -1,0 +1,57 @@
+<docs lang="zh-CN">
+`message` 传入渲染函数时，错误提示在渲染时才求值。切换语言后，已经显示的校验信息会自动更新，且不会重新触发校验。
+</docs>
+
+<docs lang="en-US">
+When `message` is a render function, the error text is evaluated at render time. Switching the locale updates messages that are already displayed, without re-running validation.
+</docs>
+
+<script setup lang="ts">
+import type { Rule } from 'antdv-next'
+import { reactive, ref } from 'vue'
+
+const locale = ref<'en' | 'zh'>('en')
+
+const messages = {
+  username: { en: 'Please input your username', zh: '请输入用户名' },
+  email: { en: 'Please input a valid email', zh: '请输入合法的邮箱' },
+} as const
+
+const model = reactive({
+  username: '',
+  email: '',
+})
+
+const usernameRules: Rule[] = [
+  { required: true, message: () => messages.username[locale.value] },
+]
+const emailRules: Rule[] = [
+  { required: true, type: 'email', message: () => messages.email[locale.value] },
+]
+</script>
+
+<template>
+  <a-space direction="vertical" style="width: 100%">
+    <a-radio-group v-model:value="locale">
+      <a-radio value="en">
+        English
+      </a-radio>
+      <a-radio value="zh">
+        中文
+      </a-radio>
+    </a-radio-group>
+    <a-form layout="vertical" :model="model" style="max-width: 600px">
+      <a-form-item name="username" label="Username" :rules="usernameRules">
+        <a-input v-model:value="model.username" placeholder="username" />
+      </a-form-item>
+      <a-form-item name="email" label="Email" :rules="emailRules">
+        <a-input v-model:value="model.email" placeholder="email" />
+      </a-form-item>
+      <a-form-item :label="null">
+        <a-button type="primary" html-type="submit">
+          Submit
+        </a-button>
+      </a-form-item>
+    </a-form>
+  </a-space>
+</template>

--- a/docs/src/pages/components/form/index.en-US.md
+++ b/docs/src/pages/components/form/index.en-US.md
@@ -31,6 +31,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*ylFATY6w-ygAAA
   <demo src="./demo/useWatch.vue">Watch Hooks</demo>
   <demo src="./demo/validate-trigger.vue">Validate Trigger</demo>
   <demo src="./demo/validate-only.vue">Validate Only</demo>
+  <demo src="./demo/message-render.vue">Reactive Message</demo>
   <demo src="./demo/form-zod.vue">Validate with zod</demo>
   <demo src="./demo/form-item-path.vue">Path Prefix</demo>
   <demo src="./demo/dynamic-form-item.vue">Dynamic Form Item</demo>
@@ -217,7 +218,7 @@ interface RuleObject {
   enum?: any[]
   len?: number
   max?: number
-  message?: string | Component
+  message?: string | Component | (() => VueNode)
   min?: number
   pattern?: RegExp
   required?: boolean
@@ -240,6 +241,7 @@ Notes:
 - `Form.Item.rules` is typed as `Rule[]`
 - `validateTrigger` has higher priority than `trigger`
 - When `type: 'array'` is used, `defaultField` can define rules for array items
+- `message` accepts a render function (e.g. `() => t('required')`): it is kept as-is through validation and only invoked while rendering the error, so any reactive state it reads (locale, i18n, ...) updates the displayed message without re-validating. Function messages skip `${label}`-style template interpolation
 
 ### validateMessages
 

--- a/docs/src/pages/components/form/index.zh-CN.md
+++ b/docs/src/pages/components/form/index.zh-CN.md
@@ -32,6 +32,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*ylFATY6w-ygAAA
   <demo src="./demo/useWatch.vue">监听字段</demo>
   <demo src="./demo/validate-trigger.vue">校验触发时机</demo>
   <demo src="./demo/validate-only.vue">仅校验</demo>
+  <demo src="./demo/message-render.vue">响应式校验信息</demo>
   <demo src="./demo/form-zod.vue">接入 zod 校验</demo>
   <demo src="./demo/form-item-path.vue">路径前缀</demo>
   <demo src="./demo/dynamic-form-item.vue">动态表单项</demo>
@@ -218,7 +219,7 @@ interface RuleObject {
   enum?: any[]
   len?: number
   max?: number
-  message?: string | Component
+  message?: string | Component | (() => VueNode)
   min?: number
   pattern?: RegExp
   required?: boolean
@@ -241,6 +242,7 @@ type Rule = RuleObject | RuleRender
 - `Form.Item.rules` 的类型为 `Rule[]`
 - `validateTrigger` 优先级高于 `trigger`
 - `type: 'array'` 时可通过 `defaultField` 为数组元素继续声明规则
+- `message` 支持渲染函数（如 `() => t('required')`）：校验时原样保留，渲染错误时才调用，因此函数内读取的响应式状态（locale、i18n 等）变化时，已显示的提示会自动更新，无需重新校验。注意函数形式不参与 `${label}` 等模板变量插值
 
 #### validateMessages {#validatemessages}
 

--- a/packages/antdv-next/src/form/ErrorList.tsx
+++ b/packages/antdv-next/src/form/ErrorList.tsx
@@ -156,7 +156,7 @@ const ErrorList = defineComponent<
                       )}
                       style={{ ...props.helpItemStyle, ...itemStyle }}
                     >
-                      {error}
+                      {typeof error === 'function' ? error() : error}
                     </div>
                   )
                 })}

--- a/packages/antdv-next/src/form/tests/__snapshots__/demo.test.ts.snap
+++ b/packages/antdv-next/src/form/tests/__snapshots__/demo.test.ts.snap
@@ -9694,6 +9694,255 @@ exports[`form demo > renders login correctly 1`] = `
 </form>
 `;
 
+exports[`form demo > renders message-render correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+  style="width: 100%;"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-root ant-radio-css-var"
+    >
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-root ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked ant-wave-target"
+          name="v-0"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            type="radio"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+           English 
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-root ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target ant-wave-target"
+          name="v-0"
+        >
+          <input
+            class="ant-radio-input"
+            type="radio"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+           中文 
+        </span>
+      </label>
+    </div>
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <form
+      class="ant-form ant-form-vertical css-var-root ant-form-css-var"
+      style="max-width: 600px;"
+    >
+      <div
+        class="ant-form-item css-var-root ant-form-css-var ant-form-item-vertical"
+      >
+        <div
+          class="ant-row css-var-root ant-form-item-row"
+        >
+          <div
+            class="ant-col css-var-root ant-form-item-label"
+          >
+            <label
+              class="ant-form-item-required"
+              for="username"
+              title="Username"
+            >
+              Username
+            </label>
+          </div>
+          <div
+            class="ant-col css-var-root ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <input
+                  aria-required="true"
+                  class="ant-input ant-input-outlined css-var-root ant-input-css-var"
+                  id="username"
+                  placeholder="username"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="ant-form-item-additional"
+            >
+              <transition-stub
+                appear="true"
+                css="true"
+                enteractiveclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare "
+                enterfromclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare ant-form-show-help-enter-start"
+                entertoclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-active ant-form-show-help-enter-active"
+                leaveactiveclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+                leavefromclass="ant-form-show-help ant-form-show-help-leave"
+                leavetoclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+                name="ant-form-show-help"
+                persisted="false"
+              >
+                <!---->
+              </transition-stub>
+              <!---->
+            </div>
+          </div>
+          <!---->
+        </div>
+        <!---->
+      </div>
+      <div
+        class="ant-form-item css-var-root ant-form-css-var ant-form-item-vertical"
+      >
+        <div
+          class="ant-row css-var-root ant-form-item-row"
+        >
+          <div
+            class="ant-col css-var-root ant-form-item-label"
+          >
+            <label
+              class="ant-form-item-required"
+              for="email"
+              title="Email"
+            >
+              Email
+            </label>
+          </div>
+          <div
+            class="ant-col css-var-root ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <input
+                  aria-required="true"
+                  class="ant-input ant-input-outlined css-var-root ant-input-css-var"
+                  id="email"
+                  placeholder="email"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="ant-form-item-additional"
+            >
+              <transition-stub
+                appear="true"
+                css="true"
+                enteractiveclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare "
+                enterfromclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare ant-form-show-help-enter-start"
+                entertoclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-active ant-form-show-help-enter-active"
+                leaveactiveclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+                leavefromclass="ant-form-show-help ant-form-show-help-leave"
+                leavetoclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+                name="ant-form-show-help"
+                persisted="false"
+              >
+                <!---->
+              </transition-stub>
+              <!---->
+            </div>
+          </div>
+          <!---->
+        </div>
+        <!---->
+      </div>
+      <div
+        class="ant-form-item css-var-root ant-form-css-var ant-form-item-vertical"
+      >
+        <div
+          class="ant-row css-var-root ant-form-item-row"
+        >
+          <!---->
+          <div
+            class="ant-col css-var-root ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <button
+                  class="ant-btn css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+                  type="submit"
+                >
+                  <transition-stub
+                    appear="false"
+                    css="true"
+                    enteractiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare "
+                    enterfromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-prepare ant-btn-loading-icon-motion-enter-prepare ant-btn-loading-icon-motion-enter-start"
+                    entertoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-enter ant-btn-loading-icon-motion-appear ant-btn-loading-icon-motion-appear-active ant-btn-loading-icon-motion-enter-active"
+                    leaveactiveclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+                    leavefromclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave"
+                    leavetoclass="ant-btn-loading-icon-motion ant-btn-loading-icon-motion-leave ant-btn-loading-icon-motion-leave-active"
+                    name="ant-btn-loading-icon-motion"
+                    persisted="false"
+                  >
+                    <!---->
+                  </transition-stub>
+                  <span>
+                     Submit 
+                  </span>
+                  <!---->
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-form-item-additional"
+            >
+              <transition-stub
+                appear="true"
+                css="true"
+                enteractiveclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare "
+                enterfromclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-prepare ant-form-show-help-enter-prepare ant-form-show-help-enter-start"
+                entertoclass="ant-form-show-help ant-form-show-help-enter ant-form-show-help-appear ant-form-show-help-appear-active ant-form-show-help-enter-active"
+                leaveactiveclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+                leavefromclass="ant-form-show-help ant-form-show-help-leave"
+                leavetoclass="ant-form-show-help ant-form-show-help-leave ant-form-show-help-leave-active"
+                name="ant-form-show-help"
+                persisted="false"
+              >
+                <!---->
+              </transition-stub>
+              <!---->
+            </div>
+          </div>
+          <!---->
+        </div>
+        <!---->
+      </div>
+    </form>
+  </div>
+  <!---->
+</div>
+`;
+
 exports[`form demo > renders nest-messages correctly 1`] = `
 <form
   class="ant-form ant-form-horizontal css-var-root ant-form-css-var"

--- a/packages/antdv-next/src/form/tests/message-render.test.tsx
+++ b/packages/antdv-next/src/form/tests/message-render.test.tsx
@@ -1,6 +1,6 @@
 import type { FormInstance } from '..'
 import { describe, expect, it, vi } from 'vitest'
-import { defineComponent, h, nextTick, reactive, ref, shallowRef } from 'vue'
+import { computed, defineComponent, h, nextTick, reactive, ref, shallowRef } from 'vue'
 import Form, { FormItem } from '..'
 import { flushPromises, mount } from '/@tests/utils'
 
@@ -93,6 +93,39 @@ describe('form rule message as render function', () => {
     await flushForm()
 
     expect(wrapper.find('.ant-form-item-explain .custom-message').text()).toBe('Required')
+
+    wrapper.unmount()
+  })
+
+  it('works with form-level rules, including computed ones', async () => {
+    const formRef = shallowRef<FormInstance>()
+    const model = reactive<{ username?: string }>({ username: undefined })
+    const locale = ref<'en' | 'zh'>('en')
+
+    const rules = computed(() => ({
+      username: [{
+        required: true,
+        message: () => (locale.value === 'zh' ? '请输入用户名' : 'Username is required'),
+      }],
+    }))
+
+    const wrapper = mount(defineComponent(() => () => (
+      <Form ref={formRef as any} model={model} rules={rules.value}>
+        <FormItem name="username">
+          <input />
+        </FormItem>
+      </Form>
+    )), { attachTo: document.body })
+
+    await formRef.value!.validateFields().catch(() => {})
+    await flushForm()
+
+    expect(wrapper.find('.ant-form-item-explain').text()).toBe('Username is required')
+
+    locale.value = 'zh'
+    await flushForm()
+
+    expect(wrapper.find('.ant-form-item-explain').text()).toBe('请输入用户名')
 
     wrapper.unmount()
   })

--- a/packages/antdv-next/src/form/tests/message-render.test.tsx
+++ b/packages/antdv-next/src/form/tests/message-render.test.tsx
@@ -1,0 +1,119 @@
+import type { FormInstance } from '..'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick, reactive, ref, shallowRef } from 'vue'
+import Form, { FormItem } from '..'
+import { flushPromises, mount } from '/@tests/utils'
+
+async function flushForm() {
+  await nextTick()
+  await flushPromises()
+  await nextTick()
+}
+
+describe('form rule message as render function', () => {
+  it('renders the function result and updates reactively without re-validating', async () => {
+    const formRef = shallowRef<FormInstance>()
+    const model = reactive<{ name?: string }>({ name: undefined })
+    const locale = ref<'en' | 'zh'>('en')
+    const message = vi.fn(() => (locale.value === 'zh' ? '请输入名称' : 'Name is required'))
+
+    const wrapper = mount(defineComponent(() => () => (
+      <Form ref={formRef as any} model={model}>
+        <FormItem name="name" rules={[{ required: true, message }]}>
+          <input />
+        </FormItem>
+      </Form>
+    )), { attachTo: document.body })
+
+    await formRef.value!.validateFields().catch(() => {})
+    await flushForm()
+
+    expect(wrapper.find('.ant-form-item-explain').text()).toBe('Name is required')
+
+    locale.value = 'zh'
+    await flushForm()
+
+    expect(wrapper.find('.ant-form-item-explain').text()).toBe('请输入名称')
+    expect(wrapper.find('.ant-form-item').classes()).toContain('ant-form-item-has-error')
+
+    wrapper.unmount()
+  })
+
+  it('does not re-run validators when the message re-renders', async () => {
+    const formRef = shallowRef<FormInstance>()
+    const model = reactive<{ name?: string }>({ name: undefined })
+    const locale = ref<'en' | 'zh'>('en')
+    const validator = vi.fn(() => Promise.reject(new Error('fail')))
+
+    const wrapper = mount(defineComponent(() => () => (
+      <Form ref={formRef as any} model={model}>
+        <FormItem
+          name="name"
+          rules={[{
+            validator,
+            message: () => (locale.value === 'zh' ? '校验失败' : 'Validation failed'),
+          }]}
+        >
+          <input />
+        </FormItem>
+      </Form>
+    )), { attachTo: document.body })
+
+    await formRef.value!.validateFields().catch(() => {})
+    await flushForm()
+
+    expect(wrapper.find('.ant-form-item-explain').text()).toBe('Validation failed')
+    expect(validator).toHaveBeenCalledTimes(1)
+
+    locale.value = 'zh'
+    await flushForm()
+
+    expect(wrapper.find('.ant-form-item-explain').text()).toBe('校验失败')
+    expect(validator).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
+  it('supports returning a vnode from the message function', async () => {
+    const formRef = shallowRef<FormInstance>()
+    const model = reactive<{ name?: string }>({ name: undefined })
+
+    const wrapper = mount(defineComponent(() => () => (
+      <Form ref={formRef as any} model={model}>
+        <FormItem
+          name="name"
+          rules={[{ required: true, message: () => h('span', { class: 'custom-message' }, 'Required') }]}
+        >
+          <input />
+        </FormItem>
+      </Form>
+    )), { attachTo: document.body })
+
+    await formRef.value!.validateFields().catch(() => {})
+    await flushForm()
+
+    expect(wrapper.find('.ant-form-item-explain .custom-message').text()).toBe('Required')
+
+    wrapper.unmount()
+  })
+
+  it('keeps plain string and vnode messages working as before', async () => {
+    const formRef = shallowRef<FormInstance>()
+    const model = reactive<{ name?: string }>({ name: undefined })
+
+    const wrapper = mount(defineComponent(() => () => (
+      <Form ref={formRef as any} model={model}>
+        <FormItem name="name" rules={[{ required: true, message: 'plain message' }]}>
+          <input />
+        </FormItem>
+      </Form>
+    )), { attachTo: document.body })
+
+    await formRef.value!.validateFields().catch(() => {})
+    await flushForm()
+
+    expect(wrapper.find('.ant-form-item-explain').text()).toBe('plain message')
+
+    wrapper.unmount()
+  })
+})

--- a/packages/antdv-next/src/form/types.ts
+++ b/packages/antdv-next/src/form/types.ts
@@ -1,4 +1,5 @@
-import type { Component, VNode } from 'vue'
+import type { Component } from 'vue'
+import type { VueNode } from '../_util/type'
 import type { DeepNamePath } from './namePathType'
 
 /**
@@ -6,7 +7,7 @@ import type { DeepNamePath } from './namePathType'
  * only invoked while rendering the error, so any reactive state it reads
  * (locale, i18n `t`, ...) updates the displayed message without re-validating.
  */
-export type RuleMessageRender = () => string | number | VNode
+export type RuleMessageRender = () => VueNode
 
 export type RuleMessage = string | Component | RuleMessageRender
 

--- a/packages/antdv-next/src/form/types.ts
+++ b/packages/antdv-next/src/form/types.ts
@@ -1,5 +1,14 @@
-import type { Component } from 'vue'
+import type { Component, VNode } from 'vue'
 import type { DeepNamePath } from './namePathType'
+
+/**
+ * Render function form of a rule message. Kept as-is through validation and
+ * only invoked while rendering the error, so any reactive state it reads
+ * (locale, i18n `t`, ...) updates the displayed message without re-validating.
+ */
+export type RuleMessageRender = () => string | number | VNode
+
+export type RuleMessage = string | Component | RuleMessageRender
 
 export type ReducerAction = UpdateAction | ValidateAction
 
@@ -68,7 +77,7 @@ export type RuleRender = (form: FormInstance) => RuleObject
 
 export interface ValidatorRule {
   warningOnly?: boolean
-  message?: string | Component
+  message?: RuleMessage
   validator: Validator
 }
 
@@ -79,7 +88,7 @@ interface BaseRule {
   enum?: StoreValue[]
   len?: number
   max?: number
-  message?: string | Component
+  message?: RuleMessage
   min?: number
   pattern?: RegExp
   required?: boolean

--- a/packages/antdv-next/src/form/utils/validateUtil.ts
+++ b/packages/antdv-next/src/form/utils/validateUtil.ts
@@ -30,6 +30,13 @@ function replaceMessage(template: string, kv: Record<string, string>): string {
 
 const CODE_LOGIC_ERROR = 'CODE_LOGIC_ERROR'
 
+// async-validator resolves function messages while validating (its
+// `complementError` calls them), which would freeze a reactive message into a
+// static string. Swap the function for this token before validating and put
+// the function back on the produced errors, so ErrorList can invoke it on
+// each render instead.
+const CODE_FUNCTION_MESSAGE = 'CODE_FUNCTION_MESSAGE'
+
 async function validateRule(
   name: string,
   value: StoreValue,
@@ -48,6 +55,13 @@ async function validateRule(
 
   // https://github.com/ant-design/ant-design/issues/40497#issuecomment-1422282378
   AsyncValidator.warning = () => void 0
+
+  const functionMessage = typeof cloneRule.message === 'function'
+    ? cloneRule.message as () => any
+    : null
+  if (functionMessage) {
+    cloneRule.message = CODE_FUNCTION_MESSAGE
+  }
 
   if (cloneRule.validator) {
     const originValidator = cloneRule.validator
@@ -84,6 +98,10 @@ async function validateRule(
   catch (errObj: any) {
     if (errObj.errors) {
       result = errObj.errors.map(({ message }: any, index: number) => {
+        if (functionMessage && message === CODE_FUNCTION_MESSAGE) {
+          return functionMessage
+        }
+
         const mergedMessage = message === CODE_LOGIC_ERROR ? messages.default : message
 
         return isVNode(mergedMessage)


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Validation messages stay in the old language after a locale switch, because errors are produced at validate time and stored as static strings.

### 💡 Background and Solution

React antd sidesteps this with element messages that re-render through context (`message: <FormattedMessage/>`); the Vue-idiomatic equivalent is a render function, so `rule.message` now also accepts `() => VueNode`:

```ts
const rules: Rule[] = [
  { required: true, message: () => t('form.username.required') },
]
```

**How it works**: async-validator resolves function messages while validating (its `complementError` calls them), which would freeze the message into a static string — the reason naive-ui had to introduce a separate `renderMessage` field. Instead, `validateRule` swaps the function for a placeholder token before handing the rule to async-validator and puts the function back on the produced errors. `ErrorList` invokes it during render, so any reactive state the function reads (locale ref, vue-i18n `t`, pinia, ...) updates the displayed message **in place, without re-running validators** — async validators never re-fire on a locale switch.

Design notes:

- No new API surface: this widens the existing antd `message` field per the repo's VueNode/render-fn conventions, rather than adding a naive-ui-style `renderMessage` or a form-level translator prop (which would conflict with `${}` template interpolation and leak keys into `errors`).
- Function messages skip `${label}`-style template interpolation — they can close over whatever they need.
- `getFieldsError()` surfaces the function as-is, matching how vnode messages already behave.

Covered by 4 new tests (reactive update, no validator re-run, vnode return, string regression); docs updated in both locales plus a `message-render` demo with live locale switching. Full suite from repo root: **4798 passing, 0 failing**.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Form rule `message` accepts a render function, so displayed validation messages update reactively on locale change without re-validating. |
| 🇨🇳 Chinese | Form 规则 `message` 支持渲染函数，切换语言时已显示的校验信息响应式更新，无需重新校验。 |