### PR TITLE
fix(radio): trigger option onChange when using options in radio-group

### DIFF
--- a/packages/antdv-next/src/radio/group.tsx
+++ b/packages/antdv-next/src/radio/group.tsx
@@ -141,6 +141,11 @@ const RadioGroup = defineComponent<
               class={option.class}
               id={option.id}
               required={option.required}
+              {
+                ...{
+                  onChange: option.onChange,
+                }
+              }
             >
               {_label}
             </Radio>

--- a/packages/antdv-next/src/radio/tests/Radio.test.tsx
+++ b/packages/antdv-next/src/radio/tests/Radio.test.tsx
@@ -752,6 +752,23 @@ describe('radio group', () => {
     expect(onChange).toHaveBeenCalledTimes(1)
   })
 
+  // ===================== option onChange with options =====================
+
+  it('should trigger option onChange when using options', async () => {
+    const onOptionChange = vi.fn()
+    const wrapper = mount(RadioGroup, {
+      props: {
+        options: [
+          { label: 'Bamboo', value: 'Bamboo' },
+          { label: 'Light', value: 'Light', onChange: onOptionChange },
+        ],
+      },
+    })
+    const inputs = wrapper.findAll('input')
+    await inputs[1].trigger('change')
+    expect(onOptionChange).toHaveBeenCalledTimes(1)
+  })
+
   // ===================== Snapshot =====================
 
   it('should match snapshot with options', () => {


### PR DESCRIPTION
Fixes radio-group not firing each option's onChange when rendered via the options prop. Mirrors the checkbox-group behavior so option.onChange is invoked on selection.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/antdv-next/antdv-next/blob/main/.github/PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://www.antdv-next.com/components/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | trigger option onChange when using options in radio-group |
| 🇨🇳 Chinese | radio-group 的 options 中的 onChange 现在会在选中时被触发 |
