### PR TITLE
fix(table): apply first-row radius when header is hidden (#57035)

### DIFF
--- a/packages/antdv-next/src/table/InternalTable.tsx
+++ b/packages/antdv-next/src/table/InternalTable.tsx
@@ -835,21 +835,22 @@ const InternalTable = defineComponent<
 
       const mergedStyle = { ...mergedStyles.value.root, ...style }
 
+      const title = resolvePanelRender(slots, props, 'title')
+      const footer = resolvePanelRender(slots, props, 'footer')
+      const summary = resolvePanelRender(slots, props, 'summary')
+
       const tableClassName = clsx(
         {
           [`${prefixCls.value}-medium`]: mergedSize.value === 'middle' || mergedSize.value === 'medium',
           [`${prefixCls.value}-small`]: mergedSize.value === 'small',
           [`${prefixCls.value}-bordered`]: props.bordered,
           [`${prefixCls.value}-empty`]: rawData.value.length === 0,
+          [`${prefixCls.value}-no-header`]: !title && props.showHeader === false,
         },
         cssVarCls.value,
         rootCls.value,
         hashId.value,
       )
-
-      const title = resolvePanelRender(slots, props, 'title')
-      const footer = resolvePanelRender(slots, props, 'footer')
-      const summary = resolvePanelRender(slots, props, 'summary')
 
       const TableComp = TableComponent.value as any
       const virtualProps = mergedVirtual.value ? { listItemHeight: listItemHeight.value } : {}

--- a/packages/antdv-next/src/table/style/radius.ts
+++ b/packages/antdv-next/src/table/style/radius.ts
@@ -30,6 +30,17 @@ const genRadiusStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           },
         },
 
+        [`&${componentCls}-bordered${componentCls}-no-header`]: {
+          [`> ${componentCls}-container`]: {
+            [`> ${componentCls}-content, > ${componentCls}-body`]: {
+              '> table > tbody > tr:first-child': {
+                '> *:first-child': { borderStartStartRadius: tableRadius },
+                '> *:last-child': { borderStartEndRadius: tableRadius },
+              },
+            },
+          },
+        },
+
         '&-container': {
           borderStartStartRadius: tableRadius,
           borderStartEndRadius: tableRadius,

--- a/packages/antdv-next/src/table/tests/Table.test.tsx
+++ b/packages/antdv-next/src/table/tests/Table.test.tsx
@@ -466,6 +466,19 @@ describe('table', () => {
     expect(wrapper.find('thead').exists()).toBe(false)
   })
 
+  it('should add no-header class only when header and title are absent', async () => {
+    const wrapper = mount(Table, {
+      props: { columns, dataSource: data, pagination: false, bordered: true, showHeader: false },
+    })
+    expect(wrapper.find('.ant-table').classes()).toContain('ant-table-no-header')
+
+    await wrapper.setProps({ showHeader: true })
+    expect(wrapper.find('.ant-table').classes()).not.toContain('ant-table-no-header')
+
+    await wrapper.setProps({ showHeader: false, title: () => 'Title' })
+    expect(wrapper.find('.ant-table').classes()).not.toContain('ant-table-no-header')
+  })
+
   // ========================= Snapshot =========================
   it('should match snapshot', () => {
     const wrapper = mount(Table, {


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/57035
上游 commit: `90ebf247a82aecaee21e49fa98078f5abf200dc7`
优先级: 🟠 P1

### 变更摘要
InternalTable + style/radius.ts：隐藏表头时首行圆角