### PR TITLE
fix(anchor): avoid duplicate onChange with getCurrentAnchor (#58834)

### DIFF
--- a/packages/antdv-next/src/anchor/Anchor.tsx
+++ b/packages/antdv-next/src/anchor/Anchor.tsx
@@ -9,7 +9,7 @@ import { classNames } from '@v-c/util'
 import canUseDom from '@v-c/util/dist/Dom/canUseDom'
 import { filterEmpty } from '@v-c/util/dist/props-util'
 import scrollIntoView from 'scroll-into-view-if-needed'
-import { computed, defineComponent, nextTick, ref, shallowRef, watch } from 'vue'
+import { computed, defineComponent, nextTick, ref, shallowRef, watch, watchEffect } from 'vue'
 import getScroll from '../_util/getScroll'
 import {
   useMergeSemantic,
@@ -329,17 +329,13 @@ const Anchor = defineComponent<
       },
     )
 
-    watch(
-      () => props.getCurrentAnchor,
-      () => {
-        if (typeof props.getCurrentAnchor === 'function') {
-          setCurrentActiveLink(rawActiveLink.value || '')
-        }
-      },
-      {
-        immediate: true,
-      },
-    )
+    // Keep watchEffect so reactive values read inside a stable `getCurrentAnchor`
+    // callback stay tracked; pass the raw link to avoid remapping mapped results.
+    watchEffect(() => {
+      if (typeof props.getCurrentAnchor === 'function') {
+        setCurrentActiveLink(rawActiveLink.value || '')
+      }
+    })
     watch(
       [() => props.direction, () => props.getCurrentAnchor, dependencyListItem, activeLink],
       async () => {

--- a/packages/antdv-next/src/anchor/Anchor.tsx
+++ b/packages/antdv-next/src/anchor/Anchor.tsx
@@ -9,7 +9,7 @@ import { classNames } from '@v-c/util'
 import canUseDom from '@v-c/util/dist/Dom/canUseDom'
 import { filterEmpty } from '@v-c/util/dist/props-util'
 import scrollIntoView from 'scroll-into-view-if-needed'
-import { computed, defineComponent, nextTick, ref, shallowRef, watch, watchEffect } from 'vue'
+import { computed, defineComponent, nextTick, ref, shallowRef, watch } from 'vue'
 import getScroll from '../_util/getScroll'
 import {
   useMergeSemantic,
@@ -143,6 +143,7 @@ const Anchor = defineComponent<
         _activeLink.value = val
       },
     })
+    const rawActiveLink = shallowRef(activeLink.value)
 
     const wrapperRef = shallowRef<HTMLElement>()
     const spanLinkNode = shallowRef<HTMLSpanElement>()
@@ -216,18 +217,22 @@ const Anchor = defineComponent<
       return ''
     }
 
-    const setCurrentActiveLink = (link: string) => {
-      // FIXME: Seems a bug since this compare is not equals
-      // `activeLinkRef` is parsed value which will always trigger `onChange` event.
-      if (activeLinkRef.value === link) {
-        return
-      }
+    const setCurrentActiveLink = (link: string, forceTriggerChange = false) => {
+      rawActiveLink.value = link
+
       // https://github.com/ant-design/ant-design/issues/30584
       const getCurrentAnchor = props.getCurrentAnchor
       const newLink = typeof getCurrentAnchor === 'function' ? getCurrentAnchor(link) : link
+      const isSameLink = activeLinkRef.value === newLink
 
-      activeLink.value = newLink
-      activeLinkRef.value = newLink
+      if (isSameLink && !forceTriggerChange) {
+        return
+      }
+
+      if (!isSameLink) {
+        activeLink.value = newLink
+        activeLinkRef.value = newLink
+      }
 
       // onChange should respect the original link (which may caused by
       // window scroll or user click), not the new link
@@ -247,7 +252,8 @@ const Anchor = defineComponent<
     }
     const handleScrollTo = (link: string, linkTargetOffset?: number) => {
       const { offsetTop, targetOffset } = props
-      setCurrentActiveLink(link)
+      const previousRawActiveLink = rawActiveLink.value
+      setCurrentActiveLink(link, previousRawActiveLink !== link)
       const sharpLinkMatch = sharpMatcherRegex.exec(link)
       if (!sharpLinkMatch) {
         return
@@ -323,11 +329,17 @@ const Anchor = defineComponent<
       },
     )
 
-    watchEffect(() => {
-      if (typeof props.getCurrentAnchor === 'function') {
-        setCurrentActiveLink(props?.getCurrentAnchor(activeLinkRef.value || ''))
-      }
-    })
+    watch(
+      () => props.getCurrentAnchor,
+      () => {
+        if (typeof props.getCurrentAnchor === 'function') {
+          setCurrentActiveLink(rawActiveLink.value || '')
+        }
+      },
+      {
+        immediate: true,
+      },
+    )
     watch(
       [() => props.direction, () => props.getCurrentAnchor, dependencyListItem, activeLink],
       async () => {

--- a/packages/antdv-next/src/anchor/tests/Anchor.test.tsx
+++ b/packages/antdv-next/src/anchor/tests/Anchor.test.tsx
@@ -543,6 +543,63 @@ describe('anchor Render', () => {
       wrapper.unmount()
     })
 
+    it('should trigger onChange when a raw link matches the mapped active link', async () => {
+      const hash1 = getHashUrl()
+      const hash2 = getHashUrl()
+      const onChange = vi.fn()
+      const wrapper = mount(Anchor, {
+        props: {
+          affix: false,
+          onChange,
+          getCurrentAnchor: (link: string) => (link === `#${hash1}` ? `#${hash2}` : link),
+          items: [
+            { key: hash1, href: `#${hash1}`, title: hash1 },
+            { key: hash2, href: `#${hash2}`, title: hash2 },
+          ],
+        },
+        attachTo: document.body,
+      })
+
+      await waitFakeTimer()
+      await wrapper.find(`a[href="#${hash1}"]`).trigger('click')
+      expect(wrapper.element.querySelector(`.ant-anchor-link-title-active`)?.textContent).toBe(hash2)
+      expect(onChange).toHaveBeenLastCalledWith(`#${hash1}`)
+      onChange.mockClear()
+      await wrapper.find(`a[href="#${hash2}"]`).trigger('click')
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith(`#${hash2}`)
+      wrapper.unmount()
+    })
+
+    it('should not trigger onChange repeatedly when scrolling with getCurrentAnchor', async () => {
+      const hash1 = getHashUrl()
+      const hash2 = getHashUrl()
+      const onChange = vi.fn()
+      const getCurrentAnchor = vi.fn(() => `#${hash2}`)
+      const wrapper = mount(Anchor, {
+        props: {
+          affix: false,
+          onChange,
+          getCurrentAnchor,
+          items: [
+            { key: hash1, href: `#${hash1}`, title: hash1 },
+            { key: hash2, href: `#${hash2}`, title: hash2 },
+          ],
+        },
+        attachTo: document.body,
+      })
+
+      await waitFakeTimer()
+      onChange.mockClear()
+      getCurrentAnchor.mockClear()
+      window.dispatchEvent(new Event('scroll'))
+      window.dispatchEvent(new Event('scroll'))
+      await waitFakeTimer()
+      expect(getCurrentAnchor).toHaveBeenCalledTimes(2)
+      expect(onChange).not.toHaveBeenCalled()
+      wrapper.unmount()
+    })
+
     it('getCurrentAnchor have default link as argument', async () => {
       const hash1 = getHashUrl()
       const hash2 = getHashUrl()
@@ -598,6 +655,53 @@ describe('anchor Render', () => {
       await waitFakeTimer()
       expect(wrapper.element.querySelector(`.ant-anchor-link-title-active`)?.textContent).toBe(hash1)
       await wrapper.setProps({ current: hash2 })
+      await waitFakeTimer()
+      expect(wrapper.element.querySelector(`.ant-anchor-link-title-active`)?.textContent).toBe(hash2)
+      wrapper.unmount()
+    })
+
+    it('should apply getCurrentAnchor once when it changes', async () => {
+      const hash1 = getHashUrl()
+      const hash2 = getHashUrl()
+      const hash3 = getHashUrl()
+      const Demo = defineComponent<{ mappedLink: string }>({
+        props: {
+          mappedLink: {
+            type: String,
+            required: true,
+          },
+        },
+        setup(props) {
+          return () => (
+            <Anchor
+              affix={false}
+              getCurrentAnchor={(link) => {
+                if (link === `#${hash1}`) {
+                  return `#${hash2}`
+                }
+                if (link === `#${hash2}`) {
+                  return `#${props.mappedLink}`
+                }
+                return link
+              }}
+              items={[
+                { key: hash1, href: `#${hash1}`, title: hash1 },
+                { key: hash2, href: `#${hash2}`, title: hash2 },
+                { key: hash3, href: `#${hash3}`, title: hash3 },
+              ]}
+            />
+          )
+        },
+      })
+      const wrapper = mount(Demo, {
+        props: { mappedLink: hash2 },
+        attachTo: document.body,
+      })
+      await waitFakeTimer()
+      await wrapper.find(`a[href="#${hash1}"]`).trigger('click')
+      expect(wrapper.element.querySelector(`.ant-anchor-link-title-active`)?.textContent).toBe(hash2)
+
+      await wrapper.setProps({ mappedLink: hash3 })
       await waitFakeTimer()
       expect(wrapper.element.querySelector(`.ant-anchor-link-title-active`)?.textContent).toBe(hash2)
       wrapper.unmount()


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58834
上游 commit: `11a07c086ab266e425346cd8663d5d475a94ba5b`
优先级: 🟡 P2

### 变更摘要
Anchor.tsx：使用 getCurrentAnchor 时避免重复 onChange