### PR TITLE
fix(menu): prevent tooltip flash when collapsing while hovered (#58865)

### DIFF
--- a/packages/antdv-next/src/menu/MenuItem.tsx
+++ b/packages/antdv-next/src/menu/MenuItem.tsx
@@ -6,7 +6,7 @@ import { Item } from '@v-c/menu'
 import { clsx } from '@v-c/util'
 import { filterEmpty, getAttrStyleAndClass } from '@v-c/util/dist/props-util'
 import { omit } from 'es-toolkit/compat'
-import { createVNode, defineComponent, isVNode } from 'vue'
+import { computed, createVNode, defineComponent, isVNode, shallowRef, watch } from 'vue'
 import { pureAttrs } from '../_util/hooks'
 import { getSlotPropsFnRun } from '../_util/tools.ts'
 import { useSiderCtx } from '../layout/Sider.tsx'
@@ -47,6 +47,17 @@ const MenuItem = defineComponent<
   (props, { slots, attrs }) => {
     const menuContext = useMenuContext()
     const { siderCollapsed } = useSiderCtx()
+
+    const mergedCollapsed = computed(() => !!(siderCollapsed?.value || menuContext.value.inlineCollapsed))
+
+    // Controlled tooltip state to prevent flash during collapse/expand transitions
+    // ref: https://github.com/ant-design/ant-design/issues/56528
+    const tooltipOpen = shallowRef(false)
+
+    watch(mergedCollapsed, () => {
+      tooltipOpen.value = false
+    })
+
     return () => {
       const extra = getSlotPropsFnRun(slots, props, 'extra')
       const icon = getSlotPropsFnRun(slots, props, 'icon')
@@ -92,11 +103,19 @@ const MenuItem = defineComponent<
 
       const tooltipProps: TooltipProps = { title: tooltipTitle }
 
-      if (!siderCollapsed?.value && !isInlineCollapsed) {
+      if (!mergedCollapsed.value) {
         tooltipProps.title = null
         // Reset `open` to fix control mode tooltip display not correct
         // ref: https://github.com/ant-design/ant-design/issues/16742
         tooltipProps.open = false
+      }
+      else {
+        // When collapsed, use controlled state to prevent flash during transitions
+        // ref: https://github.com/ant-design/ant-design/issues/56528
+        tooltipProps.open = tooltipOpen.value
+        tooltipProps.onOpenChange = (open) => {
+          tooltipOpen.value = open
+        }
       }
       const childrenLength = children.length
       let returnNode = (

--- a/packages/antdv-next/src/menu/tests/index.test.tsx
+++ b/packages/antdv-next/src/menu/tests/index.test.tsx
@@ -1,11 +1,11 @@
 import type { MenuProps } from '..'
 import { MailOutlined } from '@antdv-next/icons'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 import Menu, { MenuItem, MenuItemGroup, SubMenu } from '..'
 import ConfigProvider from '../../config-provider'
 import { mountTest, rtlTest } from '/@tests/shared'
-import { mount } from '/@tests/utils'
+import { mount, waitFakeTimer } from '/@tests/utils'
 
 const items: NonNullable<MenuProps['items']> = [
   {
@@ -250,6 +250,47 @@ describe('menu', () => {
     expect(wrapper.find('.menu-prop-icon').exists()).toBe(true)
     expect(wrapper.find('.ant-menu-item-extra').exists()).toBe(true)
     expect(wrapper.find('.ant-menu-item-icon').exists()).toBe(true)
+  })
+
+  // https://github.com/ant-design/ant-design/issues/56528
+  it('should not flash Tooltip when collapsing while hovered', async () => {
+    vi.useFakeTimers()
+    try {
+      const inlineCollapsed = ref(false)
+      const wrapper = mount(() => (
+        <Menu
+          mode="inline"
+          inlineCollapsed={inlineCollapsed.value}
+          items={[{ key: '1', label: 'Home', title: 'Home' }]}
+        />
+      ), { attachTo: document.body })
+
+      const item = wrapper.find('li.ant-menu-item')
+      await item.trigger('mouseenter')
+      await waitFakeTimer()
+      expect(document.querySelector('.ant-tooltip-container')).toBeFalsy()
+
+      inlineCollapsed.value = true
+      await nextTick()
+      await waitFakeTimer()
+
+      // Fresh Tooltip mounts closed; stale hover from expanded state should not open it.
+      expect(document.querySelector('.ant-tooltip-open')).toBeFalsy()
+      expect(
+        document.querySelector('.ant-tooltip:not(.ant-tooltip-hidden) .ant-tooltip-container'),
+      ).toBeFalsy()
+
+      // A fresh hover after collapsing should still open the tooltip via controlled state.
+      await wrapper.find('li.ant-menu-item').trigger('mouseenter')
+      await waitFakeTimer()
+      expect(document.querySelector('.ant-tooltip:not(.ant-tooltip-hidden)')).toBeTruthy()
+
+      wrapper.unmount()
+    }
+    finally {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
   })
 
   it('aligns inline-collapsed icon when collapsedIconSize is customized', async () => {


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58865
上游 commit: `c9aa0cdb503636444bd5440e11fab4ce28b7ba8f`
优先级: 🟡 P2

### 变更摘要
MenuItem.tsx：hover 状态下收起菜单时 tooltip 闪烁