### PR TITLE
fix(select): keep customize input aligned on clear hover (#58932)

### DIFF
--- a/.sync-checklist-ant-design-58932.md
+++ b/.sync-checklist-ant-design-58932.md
@@ -11,27 +11,27 @@
 select/style/index.ts 样式修复 + auto-complete 新增 customize-clear-debug demo 与文档
 
 ### 🔍 Pre-sync 分析
-- [ ] 阅读上游 PR 完整内容和 review 评论
-- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
-- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
-- [ ] 检查是否有相关联的其他 PR 需要一起同步
+- [x] 阅读上游 PR 完整内容和 review 评论
+- [x] 确认 antdv-next 中是否存在相同问题/缺失相同功能
+- [x] 查看上游变更的文件列表，评估 Vue3 适配工作量
+- [x] 检查是否有相关联的其他 PR 需要一起同步
 
 ### 🛠️ 实现步骤
-- [ ] 实现对应的 fix（参考上游代码逻辑）
-- [ ] 处理 React→Vue3 差异（见下方注意事项）
-- [ ] 编写/更新单元测试（根目录运行 vitest）
-- [ ] 更新组件文档（若有 API 变更）
-- [ ] 本地运行测试套件确认无回归
+- [x] 实现对应的 fix（参考上游代码逻辑）
+- [x] 处理 React→Vue3 差异（见下方注意事项）
+- [x] 编写/更新单元测试（根目录运行 vitest）
+- [x] 更新组件文档（若有 API 变更）
+- [x] 本地运行测试套件确认无回归
 
 ### ⚠️ React→Vue3 差异注意事项
-- [ ] `children` / `ReactNode` → `slots` / `VueNode`
+- [x] `children` / `ReactNode` → `slots` / `VueNode`
 - [ ] `React.forwardRef` → `defineExpose` / `ref`
 - [ ] `useEffect` → `watchEffect` / `onMounted`
-- [ ] `className` → `attrs.class`；`rootClassName` → `rootClass`；`classNames` → `classes`
+- [x] `className` → `attrs.class`；`rootClassName` → `rootClass`；`classNames` → `classes`
 - [ ] `on*` props → emits 声明
 - [ ] Context API → `provide` / `inject`
 
 ### 📦 提交与发布
-- [ ] 提交信息格式：`fix(<scope>): xxx (#58932)`
+- [x] 提交信息格式：`fix(<scope>): xxx (#58932)`
 - [ ] PR 描述中链接上游 PR
 - [ ] CI 全部通过

--- a/.sync-checklist-ant-design-58932.md
+++ b/.sync-checklist-ant-design-58932.md
@@ -1,0 +1,37 @@
+## ✅ 同步任务：#58932 - fix(Select): keep customize input aligned on clear hover
+
+**优先级**: 🟠 P1
+**类型**: fix
+**上游 PR**: https://github.com/ant-design/ant-design/pull/58932
+**上游 Commit**: `355b8ad8d19b818f1493a8ae092bb5b14587b5a5`
+**涉及组件**: Select,AutoComplete
+**同步难度**: Low
+
+### 📖 变更摘要
+select/style/index.ts 样式修复 + auto-complete 新增 customize-clear-debug demo 与文档
+
+### 🔍 Pre-sync 分析
+- [ ] 阅读上游 PR 完整内容和 review 评论
+- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
+- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
+- [ ] 检查是否有相关联的其他 PR 需要一起同步
+
+### 🛠️ 实现步骤
+- [ ] 实现对应的 fix（参考上游代码逻辑）
+- [ ] 处理 React→Vue3 差异（见下方注意事项）
+- [ ] 编写/更新单元测试（根目录运行 vitest）
+- [ ] 更新组件文档（若有 API 变更）
+- [ ] 本地运行测试套件确认无回归
+
+### ⚠️ React→Vue3 差异注意事项
+- [ ] `children` / `ReactNode` → `slots` / `VueNode`
+- [ ] `React.forwardRef` → `defineExpose` / `ref`
+- [ ] `useEffect` → `watchEffect` / `onMounted`
+- [ ] `className` → `attrs.class`；`rootClassName` → `rootClass`；`classNames` → `classes`
+- [ ] `on*` props → emits 声明
+- [ ] Context API → `provide` / `inject`
+
+### 📦 提交与发布
+- [ ] 提交信息格式：`fix(<scope>): xxx (#58932)`
+- [ ] PR 描述中链接上游 PR
+- [ ] CI 全部通过

--- a/docs/src/pages/components/auto-complete/demo/customize-clear-debug.vue
+++ b/docs/src/pages/components/auto-complete/demo/customize-clear-debug.vue
@@ -1,0 +1,22 @@
+<docs lang="zh-CN">
+自定义输入组件配合 `allowClear` 时的悬浮态 Debug。
+</docs>
+
+<docs lang="en-US">
+Custom input with `allowClear` on hover debug.
+</docs>
+
+<script setup lang="ts">
+const options = [{ value: 'Burnaby' }, { value: 'Seattle' }, { value: 'Los Angeles' }]
+</script>
+
+<template>
+  <a-flex vertical :gap="24" style="width: 300px">
+    <a-auto-complete allow-clear default-value="Burnaby" :options="options">
+      <a-input />
+    </a-auto-complete>
+    <a-auto-complete allow-clear default-value="Burnaby" :options="options">
+      <a-textarea />
+    </a-auto-complete>
+  </a-flex>
+</template>

--- a/docs/src/pages/components/auto-complete/index.en-US.md
+++ b/docs/src/pages/components/auto-complete/index.en-US.md
@@ -34,6 +34,7 @@ The differences with Select are:
   <demo src="./demo/variant.vue">Variants</demo>
   <demo src="./demo/allowClear.vue">Customize clear button</demo>
   <demo src="./demo/style-class.vue">Custom semantic dom styling</demo>
+  <demo src="./demo/customize-clear-debug.vue" debug>Custom input with allowClear debug</demo>
   <demo src="./demo/disabled-custom-debug.vue" debug>Disabled custom input debug</demo>
   <demo src="./demo/filled-custom-debug.vue" debug>Filled custom input debug</demo>
   <demo src="./demo/disabled-in-form-debug.vue" debug>Disabled text colour in Form debug</demo>

--- a/docs/src/pages/components/auto-complete/index.zh-CN.md
+++ b/docs/src/pages/components/auto-complete/index.zh-CN.md
@@ -35,6 +35,7 @@ demo:
   <demo src="./demo/variant.vue">多种形态</demo>
   <demo src="./demo/allowClear.vue">自定义清除按钮</demo>
   <demo src="./demo/style-class.vue">自定义语义结构的样式和类</demo>
+  <demo src="./demo/customize-clear-debug.vue" debug>自定义输入组件配合清除按钮 Debug</demo>
   <demo src="./demo/disabled-custom-debug.vue" debug>禁用自定义输入 Debug</demo>
   <demo src="./demo/filled-custom-debug.vue" debug>填充形态自定义输入 Debug</demo>
   <demo src="./demo/disabled-in-form-debug.vue" debug>禁用文字颜色在 Form 中 Debug</demo>

--- a/packages/antdv-next/src/auto-complete/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/auto-complete/tests/__snapshots__/demo.test.tsx.snap
@@ -1700,6 +1700,122 @@ exports[`auto-complete demo > renders custom correctly 1`] = `
 </div>
 `;
 
+exports[`auto-complete demo > renders customize-clear-debug correctly 1`] = `
+<div
+  class="ant-flex css-var-root ant-flex-align-stretch ant-flex-vertical"
+  style="gap: 24px; width: 300px;"
+>
+  <!---->
+  <div
+    class="ant-select ant-select-outlined ant-select-auto-complete ant-select-customize css-var-root ant-select-css-var ant-select-single ant-select-allow-clear ant-select-customize-input ant-select-show-search"
+  >
+    <!---->
+    <div
+      class="ant-select-content ant-select-content-has-value ant-select-content-has-search-value"
+      title="Burnaby"
+    >
+      <!---->
+      <input
+        aria-autocomplete="list"
+        aria-controls="test-id_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="test-id_list"
+        autocomplete="new-password"
+        class="ant-input ant-input-outlined ant-select-input css-var-root ant-input-css-var"
+        id="test-id"
+        role="combobox"
+        type="text"
+        value="Burnaby"
+      />
+    </div>
+    <!---->
+    <button
+      aria-label="Clear"
+      class="ant-select-clear"
+      type="button"
+    >
+      <span
+        aria-label="close-circle"
+        class="anticon anticon-close-circle"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close-circle"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+    <!---->
+  </div>
+  <!---->
+  <!---->
+  <div
+    class="ant-select ant-select-outlined ant-select-auto-complete ant-select-customize css-var-root ant-select-css-var ant-select-single ant-select-allow-clear ant-select-customize-input ant-select-show-search"
+  >
+    <!---->
+    <div
+      class="ant-select-content ant-select-content-has-value ant-select-content-has-search-value"
+      title="Burnaby"
+    >
+      <!---->
+      <textarea
+        aria-autocomplete="list"
+        aria-controls="test-id_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="test-id_list"
+        autocomplete="new-password"
+        class="ant-input ant-input-outlined css-var-root ant-input-css-var ant-select-input"
+        id="test-id"
+        role="combobox"
+        type="text"
+        value="Burnaby"
+      />
+    </div>
+    <!---->
+    <button
+      aria-label="Clear"
+      class="ant-select-clear"
+      type="button"
+    >
+      <span
+        aria-label="close-circle"
+        class="anticon anticon-close-circle"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close-circle"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+    <!---->
+  </div>
+  <!---->
+</div>
+`;
+
 exports[`auto-complete demo > renders disabled-custom-debug correctly 1`] = `
 <div
   class="ant-flex css-var-root ant-flex-wrap-wrap"

--- a/packages/antdv-next/src/select/style/index.ts
+++ b/packages/antdv-next/src/select/style/index.ts
@@ -27,7 +27,7 @@ const genBaseStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
       opacity: 0,
       pointerEvents: 'none',
     },
-    [`&${componentCls}-allow-clear:not(${componentCls}-show-arrow) ${componentCls}-content`]: {
+    [`&${componentCls}-allow-clear:not(${componentCls}-show-arrow):not(${componentCls}-customize) ${componentCls}-content`]: {
       marginInlineEnd: token.showArrowPaddingInlineEnd,
     },
   }


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58932
上游 commit: `355b8ad8d19b818f1493a8ae092bb5b14587b5a5`
优先级: 🟠 P1

### 变更摘要
select/style/index.ts 样式修复 + auto-complete 新增 customize-clear-debug demo 与文档

> Checklist 见分支根目录 `.sync-checklist-ant-design-58932.md`