### PR TITLE
fix(upload): use localized names for Upload actions (#58953)

### DIFF
--- a/packages/antdv-next/src/upload/UploadList/ListItem.tsx
+++ b/packages/antdv-next/src/upload/UploadList/ListItem.tsx
@@ -248,6 +248,7 @@ const ListItem = defineComponent<
                 rel="noopener noreferrer"
                 onClick={e => onPreview(file, e)}
                 title={locale.previewFile}
+                aria-label={locale.previewFile || undefined}
               >
                 {typeof customPreviewIcon === 'function'
                   ? customPreviewIcon(file)

--- a/packages/antdv-next/src/upload/UploadList/index.tsx
+++ b/packages/antdv-next/src/upload/UploadList/index.tsx
@@ -145,7 +145,8 @@ const UploadList = defineComponent<
             size="small"
             {
               ...{
-                title,
+                'title': title,
+                'aria-label': title || undefined,
               }
             }
             class={`${actionPrefixCls}-list-item-action`}
@@ -162,7 +163,8 @@ const UploadList = defineComponent<
           size="small"
           {
             ...{
-              title,
+              'title': title,
+              'aria-label': title || undefined,
             }
           }
           class={`${actionPrefixCls}-list-item-action`}

--- a/packages/antdv-next/src/upload/tests/__snapshots__/uploadlist.test.tsx.snap
+++ b/packages/antdv-next/src/upload/tests/__snapshots__/uploadlist.test.tsx.snap
@@ -85,6 +85,7 @@ exports[`upload List > should be uploading when upload a file 1`] = `
         >
           <!---->
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"

--- a/packages/antdv-next/src/upload/tests/accessibility.test.tsx
+++ b/packages/antdv-next/src/upload/tests/accessibility.test.tsx
@@ -1,0 +1,83 @@
+import type { UploadProps } from '../interface'
+
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import Upload from '..'
+import ConfigProvider from '../../config-provider'
+import zhTW from '../../locale/zh_TW'
+import { setup, teardown } from './mock'
+
+const fileList: UploadProps['fileList'] = [
+  {
+    uid: 'report',
+    name: 'report.pdf',
+    status: 'done',
+    url: '/report.pdf',
+  },
+]
+
+describe('upload accessibility', () => {
+  beforeEach(() => setup())
+  afterEach(() => teardown())
+
+  it('uses the merged locale for default file actions', () => {
+    const wrapper = mount({
+      render: () => (
+        <Upload
+          fileList={fileList}
+          listType="picture-card"
+          locale={{ removeFile: 'Localized remove' }}
+          showUploadList={{ showDownloadIcon: true }}
+        />
+      ),
+    })
+
+    expect(wrapper.find('a[title="Preview file"]').attributes('aria-label')).toBe('Preview file')
+    expect(wrapper.find('button[title="Download file"]').attributes('aria-label')).toBe('Download file')
+    expect(wrapper.find('button[title="Localized remove"]').attributes('aria-label')).toBe('Localized remove')
+  })
+
+  it('keeps localized action names when custom icons have their own names', () => {
+    const wrapper = mount({
+      render: () => (
+        <ConfigProvider locale={zhTW}>
+          <Upload
+            fileList={fileList}
+            listType="picture-card"
+            showUploadList={{
+              showDownloadIcon: true,
+              removeIcon: () => <span role="img" aria-label="Remove icon" />,
+              previewIcon: () => <span role="img" aria-label="Preview icon" />,
+              downloadIcon: () => <span role="img" aria-label="Download icon" />,
+            }}
+          />
+        </ConfigProvider>
+      ),
+    })
+
+    expect(wrapper.find('button[aria-label="移除檔案"]').attributes('title')).toBe('移除檔案')
+    expect(wrapper.find('a[aria-label="預覽檔案"]').attributes('title')).toBe('預覽檔案')
+    expect(wrapper.find('button[aria-label="下載檔案"]').attributes('title')).toBe('下載檔案')
+  })
+
+  it('keeps the icon fallback when an action locale is empty', () => {
+    const wrapper = mount({
+      render: () => (
+        <Upload
+          fileList={fileList}
+          listType="picture-card"
+          locale={{ removeFile: '', previewFile: '' }}
+        />
+      ),
+    })
+
+    const removeButton = wrapper.find('.ant-upload-list-item-actions button')
+    const previewLink = wrapper.find('.ant-upload-list-item-actions a')
+    expect(removeButton.exists()).toBe(true)
+    expect(previewLink.exists()).toBe(true)
+    expect(removeButton.attributes('aria-label')).toBeUndefined()
+    expect(previewLink.attributes('aria-label')).toBeUndefined()
+    expect(removeButton.find('.anticon-delete').exists()).toBe(true)
+    expect(previewLink.find('.anticon-eye').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58953
上游 commit: `6455d91fabd6e58f3e89014105640e8ceb9ff502`
优先级: 🟡 P2

### 变更摘要
UploadList/ListItem：操作按钮使用 locale 文案（a11y）