### PR TITLE
fix(transfer): respect locale.remove in one-way mode (#58955)

### DIFF
--- a/packages/antdv-next/src/transfer/ListBody.tsx
+++ b/packages/antdv-next/src/transfer/ListBody.tsx
@@ -96,6 +96,7 @@ const TransferListBody = defineComponent<
         disabled,
         onScroll,
         selectedKeys,
+        remove,
       } = props
       const paginationNode = mergedPagination.value
         ? (
@@ -136,6 +137,7 @@ const TransferListBody = defineComponent<
                 showRemove={showRemove}
                 onClick={onInternalClick}
                 onRemove={onRemove}
+                removeLabel={remove}
                 checked={selectedKeys.includes(item.key)}
                 disabled={disabled}
               />

--- a/packages/antdv-next/src/transfer/ListItem.tsx
+++ b/packages/antdv-next/src/transfer/ListItem.tsx
@@ -23,6 +23,7 @@ interface ListItemProps<RecordType> {
   onRemove?: (item: RecordType) => void
   item: RecordType
   showRemove?: boolean
+  removeLabel?: string
 }
 
 const ListItem = defineComponent<
@@ -43,6 +44,7 @@ const ListItem = defineComponent<
         onClick,
         onRemove,
         showRemove,
+        removeLabel,
       } = props
       const mergedDisabled = disabled || item?.disabled
       const classes = clsx(`${prefixCls}-content-item`, classNames.item, {
@@ -72,7 +74,7 @@ const ListItem = defineComponent<
               type="button"
               disabled={mergedDisabled}
               class={`${prefixCls}-content-item-remove`}
-              aria-label={contextLocale?.value?.remove}
+              aria-label={removeLabel ?? contextLocale?.value?.remove}
               onClick={() => onRemove?.(item)}
             >
               <DeleteOutlined />

--- a/packages/antdv-next/src/transfer/tests/index.test.tsx
+++ b/packages/antdv-next/src/transfer/tests/index.test.tsx
@@ -983,17 +983,21 @@ describe('transfer', () => {
     })
   })
 
-  it('remove by click icon', () => {
+  it('should use the component locale for one-way item removal', () => {
     const onChange = vi.fn()
     const wrapper = mount(Transfer, {
       props: {
         ...listCommonProps,
+        locale: { remove: 'Remove target item' },
         onChange,
         oneWay: true,
       },
     })
 
-    clickElement(wrapper.element.querySelectorAll('.ant-transfer-list-content-item-remove')[0])
+    const removeButton = wrapper.element.querySelector('button[aria-label="Remove target item"]')
+    expect(removeButton).toBeTruthy()
+
+    clickElement(removeButton)
 
     expect(onChange).toHaveBeenCalledWith([], 'left', ['b'])
   })


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58955
上游 commit: `9e4c9c5d73cfb1bd3bccc236bd6018b5c7dd3bd8`
优先级: 🟡 P2

### 变更摘要
ListBody/ListItem：one-way 模式删除按钮使用 locale.remove