### PR TITLE
fix: localize Modal and Notification close button names (#58957)

### DIFF
--- a/packages/antdv-next/src/_util/hooks/useClosable.tsx
+++ b/packages/antdv-next/src/_util/hooks/useClosable.tsx
@@ -157,7 +157,10 @@ export default function useClosable(
             ...ariaOrDataProps,
           })
         : (<span aria-label={contextLocale?.value?.close} {...ariaOrDataProps}>{mergedCloseIcon}</span>)
-      return [true, mergedCloseIcon, closeBtnIsDisabled.value, ariaOrDataProps] as const
+      return [true, mergedCloseIcon, closeBtnIsDisabled.value, {
+        'aria-label': contextLocale?.value?.close ?? defaultLocale.global?.close,
+        ...ariaOrDataProps,
+      }] as const
     }
   })
 }
@@ -203,7 +206,7 @@ function computeCloseIcon(
     finalCloseIcon = isVNode(finalCloseIcon)
       ? (
           createVNode(finalCloseIcon, {
-            'aria-label': closeLabel,
+            'aria-label': finalCloseIcon.props?.['aria-label'] ?? closeLabel,
             ...ariaOrDataProps,
           })
         )
@@ -214,7 +217,13 @@ function computeCloseIcon(
         )
   }
 
-  return [finalCloseIcon, ariaOrDataProps]
+  return [
+    finalCloseIcon,
+    {
+      'aria-label': closeLabel,
+      ...ariaOrDataProps,
+    },
+  ]
 }
 
 function mergeClosableConfigs(

--- a/packages/antdv-next/src/_util/tests/useClosable.test.tsx
+++ b/packages/antdv-next/src/_util/tests/useClosable.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { computed } from 'vue'
+import { computeClosable } from '../hooks/useClosable'
+import { mount } from '/@tests/utils'
+
+describe('useClosable', () => {
+  it('should localize the close control without overriding a custom icon label', () => {
+    const [, closeIcon, , ariaProps] = computeClosable(
+      computed(() => ({
+        closable: true,
+        closeIcon: <span aria-label="Custom icon" />,
+      })),
+      computed(() => null),
+      undefined,
+      'Localized close',
+    )
+
+    expect(ariaProps).toEqual({ 'aria-label': 'Localized close' })
+
+    const wrapper = mount({ render: () => closeIcon })
+    expect(wrapper.find('span').attributes('aria-label')).toBe('Custom icon')
+
+    const [, , , customAriaProps] = computeClosable(
+      computed(() => ({ closable: { 'aria-label': 'Custom close' } })),
+      computed(() => null),
+      undefined,
+      'Localized close',
+    )
+    expect(customAriaProps).toEqual({ 'aria-label': 'Custom close' })
+  })
+})

--- a/packages/antdv-next/src/modal/tests/Modal.test.tsx
+++ b/packages/antdv-next/src/modal/tests/Modal.test.tsx
@@ -4,6 +4,7 @@ import Modal from '..'
 import App from '../../app'
 import ConfigProvider from '../../config-provider'
 import zhCN from '../../locale/zh_CN'
+import zhTW from '../../locale/zh_TW'
 import Popover from '../../popover'
 import { mount, waitFakeTimer } from '/@tests/utils'
 
@@ -338,6 +339,27 @@ describe('modal integration', () => {
     const content = document.getElementById('force-render-content')
     expect(content).not.toBeNull()
     expect(content!.textContent).toBe('Hello')
+
+    wrapper.unmount()
+  })
+
+  it('should localize the close button accessible name', async () => {
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          return () => (
+            <ConfigProvider locale={zhTW}>
+              <Modal open />
+            </ConfigProvider>
+          )
+        },
+      }),
+      { attachTo: document.body },
+    )
+
+    await waitFakeTimer(20, 10)
+
+    expect(document.body.querySelector('.ant-modal-close')?.getAttribute('aria-label')).toBe('關閉')
 
     wrapper.unmount()
   })

--- a/packages/antdv-next/src/notification/index.tsx
+++ b/packages/antdv-next/src/notification/index.tsx
@@ -141,6 +141,7 @@ const GlobalHolderWrapper = defineComponent<{ onReady?: (holder: GlobalHolderRef
           prefixCls={global.getRootPrefixCls()}
           iconPrefixCls={global.getIconPrefixCls()}
           theme={global.theme.value as any}
+          locale={globalConfig().locale}
         >
           {holderNode}
         </ConfigProvider>

--- a/packages/antdv-next/src/notification/tests/Notification.test.tsx
+++ b/packages/antdv-next/src/notification/tests/Notification.test.tsx
@@ -1164,6 +1164,36 @@ describe('notification', () => {
 
       wrapper.unmount()
     })
+
+    it('should use the locale around the context holder for the close button', async () => {
+      const { default: ConfigProvider } = await import('../../config-provider')
+      const { default: zhTW } = await import('../../locale/zh_TW')
+      let api!: NotificationInstance
+      const App = defineComponent({
+        setup() {
+          const [notificationApi, contextHolder] = useNotification()
+          api = notificationApi
+          return () => (
+            <ConfigProvider locale={zhTW}>
+              {contextHolder()}
+            </ConfigProvider>
+          )
+        },
+      })
+
+      const wrapper = mount(App, { attachTo: document.body })
+      await waitForNotification()
+
+      api.open({
+        title: 'Notification',
+        duration: 0,
+      })
+      await waitForNotification()
+
+      expect(document.querySelector('.ant-notification-notice-close')?.getAttribute('aria-label')).toBe('關閉')
+
+      wrapper.unmount()
+    })
   })
 
   // ========================= useNotification config =========================

--- a/packages/antdv-next/src/notification/useNotification.tsx
+++ b/packages/antdv-next/src/notification/useNotification.tsx
@@ -21,6 +21,8 @@ import { toPropsRefs } from '../_util/tools.ts'
 import { devUseWarning } from '../_util/warning.ts'
 import { useBaseConfig, useComponentBaseConfig } from '../config-provider/context'
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls'
+import defaultLocale from '../locale/en_US'
+import useLocale from '../locale/useLocale'
 import { useToken } from '../theme/internal.ts'
 import { getCloseIcon, getIconWrapperClassName, resolveIconNode } from './PurePanel.tsx'
 import useStyle from './style'
@@ -42,6 +44,7 @@ interface HolderRef extends NotificationAPI {
   notification?: CPNotificationConfig
   classNames: NotificationSemanticClassNames
   styles: NotificationSemanticStyles
+  closeLabel: string
 }
 
 const Wrapper = defineComponent<{
@@ -81,6 +84,7 @@ const holderDefaultProps = {
 const Holder = defineComponent<HolderProps>(
   (props = holderDefaultProps, { expose }) => {
     const { getPrefixCls, getPopupContainer, notification, direction } = useBaseConfig('notification')
+    const [contextLocale] = useLocale('global', defaultLocale.global)
 
     const { classes: contextClassNames, style: contextStyle, styles: contextStyles } = useComponentBaseConfig('notification', props)
     const { classes, styles } = toPropsRefs(props, 'classes', 'styles')
@@ -144,6 +148,7 @@ const Holder = defineComponent<HolderProps>(
       notification,
       classNames: mergedClassNames,
       styles: mergedStyles,
+      closeLabel: computed(() => contextLocale.value?.close ?? defaultLocale.global?.close ?? 'Close'),
     })
     return () => {
       return holder?.() as any
@@ -184,6 +189,7 @@ export function useInternalNotification(
         notification,
         classNames: originClassNames,
         styles: originStyles,
+        closeLabel,
       } = holderRef.value
       const contextClassName = notification?.class || {}
       const noticePrefixCls = `${prefixCls}-notice`
@@ -221,6 +227,7 @@ export function useInternalNotification(
           closable: true,
           closeIcon: realCloseIcon,
         })),
+        closeLabel,
       )
 
       const mergedClosable = rawClosable


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58957
上游 commit: `0b0edf011ab35f3d7a9ae4d1b525e76d91edac6a`
优先级: 🟡 P2

### 变更摘要
useClosable + notification/useNotification：关闭按钮 aria 文案走 locale