### PR TITLE
fix(locale): correct Form min placeholders (#58965)

### DIFF
--- a/packages/antdv-next/src/locale/is_IS.ts
+++ b/packages/antdv-next/src/locale/is_IS.ts
@@ -109,7 +109,7 @@ const localeValues: Locale = {
       },
       number: {
         len: '${label} verður að vera jafngildi ${len}',
-        min: 'Lágmarksgildi ${label} er ${mín}',
+        min: 'Lágmarksgildi ${label} er ${min}',
         max: 'Hámarksgildi ${label} er ${max}',
         range: '${label} verður að vera á milli ${min}-${max}',
       },

--- a/packages/antdv-next/src/locale/mn_MN.ts
+++ b/packages/antdv-next/src/locale/mn_MN.ts
@@ -125,7 +125,7 @@ const localeValues: Locale = {
       },
       array: {
         len: '${len} ${label} байх ёстой',
-        min: 'Дор хаяж ${мин} ${label}',
+        min: 'Дор хаяж ${min} ${label}',
         max: 'Хамгийн ихдээ ${max} ${label}',
         range: '${label}-н хэмжээ ${min}-${max} хооронд байх ёстой',
       },


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58965
上游 commit: `8b4c97310fa2d2bf3a7f2eb9f5ce5146706bbb3b`
优先级: 🟢 P3

### 变更摘要
is_IS/mn_MN 两个语言包的 Form min 文案修正