### PR TITLE
fix(form): preserve Form labelCol offset in vertical layout (#58981)

### DIFF
--- a/packages/antdv-next/src/form/style/index.ts
+++ b/packages/antdv-next/src/form/style/index.ts
@@ -425,9 +425,8 @@ const genFormItemStyle: GenerateStyle<FormToken, CSSObject> = (token) => {
   }
 }
 
-const makeVerticalLayoutLabel: GenerateStyle<FormToken, CSSObject> = token => ({
+const makeVerticalLayoutLabelBase: GenerateStyle<FormToken, CSSObject> = token => ({
   padding: token.verticalLabelPadding,
-  margin: token.verticalLabelMargin,
   whiteSpace: 'initial',
   textAlign: 'start',
 
@@ -440,6 +439,20 @@ const makeVerticalLayoutLabel: GenerateStyle<FormToken, CSSObject> = token => ({
     },
   },
 })
+
+const makeVerticalLayoutLabel: GenerateStyle<FormToken, CSSObject> = token => ({
+  ...makeVerticalLayoutLabelBase(token),
+  margin: token.verticalLabelMargin,
+})
+
+const makeVerticalLayoutLabelWithOffset: GenerateStyle<FormToken, CSSObject> = (token) => {
+  const [formVarName] = genCssVar(token.antCls, 'form')
+
+  return {
+    ...makeVerticalLayoutLabelBase(token),
+    [formVarName('item-label-margin')]: token.verticalLabelMargin,
+  }
+}
 
 const genHorizontalStyle: GenerateStyle<FormToken, CSSObject> = (token) => {
   const { antCls, formItemCls } = token
@@ -466,8 +479,9 @@ const genHorizontalStyle: GenerateStyle<FormToken, CSSObject> = (token) => {
           minWidth: 'unset',
         },
       },
-      [`${antCls}-col-24${formItemCls}-label,
-        ${antCls}-col-xl-24${formItemCls}-label`]: makeVerticalLayoutLabel(token),
+      [`> ${formItemCls}-row > ${antCls}-col-24${formItemCls}-label,
+        > ${formItemCls}-row > ${antCls}-col-xl-24${formItemCls}-label`]:
+        makeVerticalLayoutLabel(token),
     },
   }
 }
@@ -515,7 +529,8 @@ const makeVerticalLayout: GenerateStyle<FormToken, CSSObject> = (token) => {
   const { componentCls, formItemCls, rootPrefixCls } = token
 
   return {
-    [`${formItemCls} ${formItemCls}-label`]: makeVerticalLayoutLabel(token),
+    [`${formItemCls}:not(${formItemCls}-vertical) > ${formItemCls}-row > ${formItemCls}-label`]:
+      makeVerticalLayoutLabel(token),
     // ref: https://github.com/ant-design/ant-design/issues/45122
     [`${componentCls}:not(${componentCls}-inline)`]: {
       [formItemCls]: {
@@ -537,8 +552,17 @@ const makeVerticalLayout: GenerateStyle<FormToken, CSSObject> = (token) => {
 
 const genVerticalStyle: GenerateStyle<FormToken, CSSObject> = (token) => {
   const { componentCls, formItemCls, antCls, verticalLabelHeight } = token
+  const [formVarName, formVarRef] = genCssVar(antCls, 'form')
 
   return {
+    [formItemCls]: {
+      [formVarName('item-label-margin')]: 'initial',
+    },
+
+    [`${formItemCls}-label`]: {
+      margin: formVarRef('item-label-margin'),
+    },
+
     [`${formItemCls}-vertical`]: {
       [`${formItemCls}-row`]: {
         flexDirection: 'column',
@@ -551,17 +575,19 @@ const genVerticalStyle: GenerateStyle<FormToken, CSSObject> = (token) => {
       [`${formItemCls}-control`]: {
         width: '100%',
       },
-      [`${formItemCls}-label,
-        ${antCls}-col-24${formItemCls}-label,
-        ${antCls}-col-xl-24${formItemCls}-label`]: makeVerticalLayoutLabel(token),
+      [`> ${formItemCls}-row > ${formItemCls}-label,
+        > ${formItemCls}-row > ${antCls}-col-24${formItemCls}-label,
+        > ${formItemCls}-row > ${antCls}-col-xl-24${formItemCls}-label`]:
+        makeVerticalLayoutLabelWithOffset(token),
     },
 
     [`@media (max-width: ${unit(token.screenXSMax)})`]: [
       makeVerticalLayout(token),
       {
         [componentCls]: {
-          [`${formItemCls}:not(${formItemCls}-horizontal)`]: {
-            [`${antCls}-col-xs-24${formItemCls}-label`]: makeVerticalLayoutLabel(token),
+          [`${formItemCls}:not(${formItemCls}-horizontal):not(${formItemCls}-vertical)`]: {
+            [`> ${formItemCls}-row > ${antCls}-col-xs-24${formItemCls}-label`]:
+              makeVerticalLayoutLabel(token),
           },
         },
       },
@@ -569,24 +595,27 @@ const genVerticalStyle: GenerateStyle<FormToken, CSSObject> = (token) => {
 
     [`@media (max-width: ${unit(token.screenSMMax)})`]: {
       [componentCls]: {
-        [`${formItemCls}:not(${formItemCls}-horizontal)`]: {
-          [`${antCls}-col-sm-24${formItemCls}-label`]: makeVerticalLayoutLabel(token),
+        [`${formItemCls}:not(${formItemCls}-horizontal):not(${formItemCls}-vertical)`]: {
+          [`> ${formItemCls}-row > ${antCls}-col-sm-24${formItemCls}-label`]:
+            makeVerticalLayoutLabel(token),
         },
       },
     },
 
     [`@media (max-width: ${unit(token.screenMDMax)})`]: {
       [componentCls]: {
-        [`${formItemCls}:not(${formItemCls}-horizontal)`]: {
-          [`${antCls}-col-md-24${formItemCls}-label`]: makeVerticalLayoutLabel(token),
+        [`${formItemCls}:not(${formItemCls}-horizontal):not(${formItemCls}-vertical)`]: {
+          [`> ${formItemCls}-row > ${antCls}-col-md-24${formItemCls}-label`]:
+            makeVerticalLayoutLabel(token),
         },
       },
     },
 
     [`@media (max-width: ${unit(token.screenLGMax)})`]: {
       [componentCls]: {
-        [`${formItemCls}:not(${formItemCls}-horizontal)`]: {
-          [`${antCls}-col-lg-24${formItemCls}-label`]: makeVerticalLayoutLabel(token),
+        [`${formItemCls}:not(${formItemCls}-horizontal):not(${formItemCls}-vertical)`]: {
+          [`> ${formItemCls}-row > ${antCls}-col-lg-24${formItemCls}-label`]:
+            makeVerticalLayoutLabel(token),
         },
       },
     },

--- a/packages/antdv-next/src/form/tests/vertical-label-offset.test.tsx
+++ b/packages/antdv-next/src/form/tests/vertical-label-offset.test.tsx
@@ -1,0 +1,85 @@
+import { createCache, extractStyle, StyleProvider } from '@antdv-next/cssinjs'
+import { describe, expect, it } from 'vitest'
+import { createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import Form, { FormItem } from '..'
+import ConfigProvider from '../../config-provider'
+import { mount } from '/@tests/utils'
+
+// https://github.com/ant-design/ant-design/pull/58981
+// https://github.com/ant-design/ant-design/issues/51630
+describe('form vertical layout labelCol offset', () => {
+  it('should preserve labelCol offset classes in vertical layout', () => {
+    const wrapper = mount(() => (
+      <Form layout="vertical" labelCol={{ span: 24, offset: 6, sm: { span: 24, offset: 3 } }}>
+        <FormItem label="Form offset">
+          <input />
+        </FormItem>
+        <FormItem label="Item offset" labelCol={{ offset: 4, md: { offset: 0 } }}>
+          <input />
+        </FormItem>
+      </Form>
+    ))
+
+    const labels = wrapper.findAll('.ant-form-item-label')
+    expect(labels[0].classes()).toEqual(
+      expect.arrayContaining(['ant-col-24', 'ant-col-offset-6', 'ant-col-sm-24', 'ant-col-sm-offset-3']),
+    )
+    expect(labels[1].classes()).toEqual(
+      expect.arrayContaining(['ant-col-offset-4', 'ant-col-md-offset-0']),
+    )
+  })
+
+  it('should preserve label offset margin in vertical layout', async () => {
+    const cache = createCache()
+    const app = createSSRApp({
+      render: () =>
+        h(ConfigProvider, {
+          theme: {
+            hashed: false,
+            components: { Form: { verticalLabelMargin: '1px 2px 3px 4px' } },
+          },
+        }, {
+          default: () =>
+            h(StyleProvider, { cache, mock: 'server' }, {
+              default: () =>
+                h(Form, {
+                  layout: 'vertical',
+                  labelCol: { span: 24, offset: 6, sm: { span: 24, offset: 3 } },
+                }, {
+                  default: () => [
+                    h(FormItem, { label: 'Form offset' }, { default: () => h('input') }),
+                    h(FormItem, { label: 'Item offset', labelCol: { offset: 4, md: { offset: 0 } } }, {
+                      default: () => h('input'),
+                    }),
+                  ],
+                }),
+            }),
+        }),
+    })
+
+    await renderToString(app)
+
+    const styleText = extractStyle(cache, { plain: true })
+
+    // Vertical label keeps its margin through a CSS variable so Grid offset
+    // (margin-inline-start) can still win over the shorthand.
+    const labelMarginRule = '.ant-form-item-label{margin:var(--ant-form-item-label-margin);}'
+    expect(styleText).toContain('--ant-form-vertical-label-margin:1px 2px 3px 4px;')
+    expect(styleText).toContain('--ant-form-item-label-margin:initial;')
+    expect(styleText).toContain('--ant-form-item-label-margin:var(--ant-form-vertical-label-margin);')
+    expect(styleText).toContain(labelMarginRule)
+
+    // The single-class Form rule has the same specificity as the Grid offset.
+    // Grid styles are emitted later, so margin-inline-start wins while the other margins remain.
+    const gridMarginRules = [
+      '.ant-col-offset-6{margin-inline-start:25%;}',
+      '.ant-col-sm-offset-3{margin-inline-start:12.5%;}',
+      '.ant-col-md-offset-0{margin-inline-start:0;}',
+    ]
+    gridMarginRules.forEach((rule) => {
+      expect(styleText).toContain(rule)
+      expect(styleText.indexOf(labelMarginRule)).toBeLessThan(styleText.indexOf(rule))
+    })
+  })
+})


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58981
上游 commit: `5957ad9b11441b79f1259becab1584e9c107f489`
优先级: 🟠 P1

### 变更摘要
form/style/index.ts：vertical 布局下保留 labelCol offset