### PR TITLE
fix(float-button): keep BackTop progress ring visible (#58982)

### DIFF
--- a/packages/antdv-next/src/float-button/style/button.ts
+++ b/packages/antdv-next/src/float-button/style/button.ts
@@ -9,7 +9,7 @@ const genFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) 
   const { componentCls, floatButtonSize, iconCls, antCls, floatButtonIconSize } = token
 
   const [varName, varRef] = genCssVar(antCls, 'float-btn')
-  const [buttonVarName, buttonVarRef] = genCssVar(antCls, 'btn')
+  const [, buttonVarRef] = genCssVar(antCls, 'btn')
 
   const getProgressBackground = (backgroundColor: string) =>
     [
@@ -80,26 +80,26 @@ const genFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) 
         },
 
         // ========================= Progress =========================
-        [`&${componentCls}-progress`]: {
-          [buttonVarName('border-width')]: unit(token.lineWidthBold),
-          [buttonVarName('border-color')]: 'transparent',
-          [buttonVarName('border-color-hover')]: 'transparent',
-          [buttonVarName('border-color-active')]: 'transparent',
-          [buttonVarName('border-color-disabled')]: 'transparent',
+        [`&${antCls}-btn${componentCls}-progress`]: {
+          borderWidth: unit(token.lineWidthBold),
+          borderColor: 'transparent',
           backgroundImage: getProgressBackground(buttonVarRef('bg-color')),
           backgroundOrigin: 'border-box',
           backgroundClip: 'padding-box, border-box',
 
           [`&:not(:disabled):not(${antCls}-btn-disabled)`]: {
             '&:hover': {
+              borderColor: 'transparent',
               backgroundImage: getProgressBackground(buttonVarRef('bg-color-hover')),
             },
             '&:active': {
+              borderColor: 'transparent',
               backgroundImage: getProgressBackground(buttonVarRef('bg-color-active')),
             },
           },
 
           [`&:disabled, &${antCls}-btn-disabled`]: {
+            borderColor: 'transparent',
             backgroundImage: getProgressBackground(buttonVarRef('bg-color-disabled')),
           },
         },


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58982
上游 commit: `ec7606d059cd96766faf1f05660dd410b39c7a8d`
优先级: 🟡 P2

### 变更摘要
float-button/style/button.ts 纯样式修复