### PR TITLE
docs(list): update with Listy migration guidance (#58985)

### DIFF
--- a/.sync-checklist-ant-design-58985.md
+++ b/.sync-checklist-ant-design-58985.md
@@ -11,10 +11,18 @@
 list 文档增加 Listy 迁移指引
 
 ### 🔍 Pre-sync 分析
-- [ ] 阅读上游 PR 完整内容和 review 评论
-- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
-- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
-- [ ] 检查是否有相关联的其他 PR 需要一起同步
+- [x] 阅读上游 PR 完整内容和 review 评论
+- [x] 确认 antdv-next 中是否存在相同问题/缺失相同功能
+- [x] 查看上游变更的文件列表，评估 Vue3 适配工作量
+- [x] 检查是否有相关联的其他 PR 需要一起同步
+
+### 📌 同步结论：不适用（N/A）
+
+上游 PR 仅修改 `components/list/index.{en-US,zh-CN}.md`，为已废弃的 List 组件文档补充
+「请改用 Listy」的废弃提示与迁移指引 FAQ。antdv-next 从未提供 List 组件，
+`packages/antdv-next/src/` 与 `docs/src/pages/components/` 中均不存在 list，
+Listy（1.5.0 起）即为唯一列表组件，不存在可承载该迁移指引的目标文档，
+无需（也不应）为此新造 List 文档页，故本 PR 无需移植。
 
 ### 🛠️ 实现步骤
 - [ ] 实现对应的 docs（参考上游代码逻辑）

--- a/.sync-checklist-ant-design-58985.md
+++ b/.sync-checklist-ant-design-58985.md
@@ -1,0 +1,37 @@
+## ✅ 同步任务：#58985 - docs(List): update with Listy migration guidance
+
+**优先级**: 🟢 P3
+**类型**: docs
+**上游 PR**: https://github.com/ant-design/ant-design/pull/58985
+**上游 Commit**: `3be9ea04ab3e42dd7156ed03dec30aefccea62c7`
+**涉及组件**: List
+**同步难度**: Low
+
+### 📖 变更摘要
+list 文档增加 Listy 迁移指引
+
+### 🔍 Pre-sync 分析
+- [ ] 阅读上游 PR 完整内容和 review 评论
+- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
+- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
+- [ ] 检查是否有相关联的其他 PR 需要一起同步
+
+### 🛠️ 实现步骤
+- [ ] 实现对应的 docs（参考上游代码逻辑）
+- [ ] 处理 React→Vue3 差异（见下方注意事项）
+- [ ] 编写/更新单元测试（根目录运行 vitest）
+- [ ] 更新组件文档（若有 API 变更）
+- [ ] 本地运行测试套件确认无回归
+
+### ⚠️ React→Vue3 差异注意事项
+- [ ] `children` / `ReactNode` → `slots` / `VueNode`
+- [ ] `React.forwardRef` → `defineExpose` / `ref`
+- [ ] `useEffect` → `watchEffect` / `onMounted`
+- [ ] `className` → `attrs.class`；`rootClassName` → `rootClass`；`classNames` → `classes`
+- [ ] `on*` props → emits 声明
+- [ ] Context API → `provide` / `inject`
+
+### 📦 提交与发布
+- [ ] 提交信息格式：`docs(<scope>): xxx (#58985)`
+- [ ] PR 描述中链接上游 PR
+- [ ] CI 全部通过


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58985
上游 commit: `3be9ea04ab3e42dd7156ed03dec30aefccea62c7`
优先级: 🟢 P3

### 变更摘要
list 文档增加 Listy 迁移指引

> Checklist 见分支根目录 `.sync-checklist-ant-design-58985.md`