### PR TITLE
fix(color-picker): keep color selection draggable after clearing (#58995)

### DIFF
--- a/packages/antdv-next/src/color-picker/style/index.ts
+++ b/packages/antdv-next/src/color-picker/style/index.ts
@@ -104,6 +104,7 @@ function genClearStyle(token: ColorPickerToken, size: number, extraStyle?: CSSOb
       position: 'relative',
       overflow: 'hidden',
       cursor: 'inherit',
+      userSelect: 'none',
       transition: `all ${token.motionDurationFast}`,
 
       ...extraStyle,


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58995
上游 commit: `be31004816cb8806f433909e79b9d6bf4b89b1af`
优先级: 🟡 P2

### 变更摘要
color-picker/style/index.ts 纯样式修复