### PR TITLE
docs(float-button): unify FloatButton translation (#58996)

### DIFF
--- a/.sync-checklist-ant-design-58996.md
+++ b/.sync-checklist-ant-design-58996.md
@@ -1,0 +1,37 @@
+## ✅ 同步任务：#58996 - docs(float-button): unify FloatButton translation
+
+**优先级**: 🟢 P3
+**类型**: docs
+**上游 PR**: https://github.com/ant-design/ant-design/pull/58996
+**上游 Commit**: `e57c50affe02cd1e84e4cc029a64e96dbf62019f`
+**涉及组件**: FloatButton
+**同步难度**: Low
+
+### 📖 变更摘要
+float-button/index.zh-CN.md 译名统一
+
+### 🔍 Pre-sync 分析
+- [ ] 阅读上游 PR 完整内容和 review 评论
+- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
+- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
+- [ ] 检查是否有相关联的其他 PR 需要一起同步
+
+### 🛠️ 实现步骤
+- [ ] 实现对应的 docs（参考上游代码逻辑）
+- [ ] 处理 React→Vue3 差异（见下方注意事项）
+- [ ] 编写/更新单元测试（根目录运行 vitest）
+- [ ] 更新组件文档（若有 API 变更）
+- [ ] 本地运行测试套件确认无回归
+
+### ⚠️ React→Vue3 差异注意事项
+- [ ] `children` / `ReactNode` → `slots` / `VueNode`
+- [ ] `React.forwardRef` → `defineExpose` / `ref`
+- [ ] `useEffect` → `watchEffect` / `onMounted`
+- [ ] `className` → `attrs.class`；`rootClassName` → `rootClass`；`classNames` → `classes`
+- [ ] `on*` props → emits 声明
+- [ ] Context API → `provide` / `inject`
+
+### 📦 提交与发布
+- [ ] 提交信息格式：`docs(<scope>): xxx (#58996)`
+- [ ] PR 描述中链接上游 PR
+- [ ] CI 全部通过

--- a/.sync-checklist-ant-design-58996.md
+++ b/.sync-checklist-ant-design-58996.md
@@ -11,17 +11,17 @@
 float-button/index.zh-CN.md 译名统一
 
 ### 🔍 Pre-sync 分析
-- [ ] 阅读上游 PR 完整内容和 review 评论
-- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
-- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
-- [ ] 检查是否有相关联的其他 PR 需要一起同步
+- [x] 阅读上游 PR 完整内容和 review 评论
+- [x] 确认 antdv-next 中是否存在相同问题/缺失相同功能
+- [x] 查看上游变更的文件列表，评估 Vue3 适配工作量
+- [x] 检查是否有相关联的其他 PR 需要一起同步
 
 ### 🛠️ 实现步骤
 - [ ] 实现对应的 docs（参考上游代码逻辑）
-- [ ] 处理 React→Vue3 差异（见下方注意事项）
+- [x] 处理 React→Vue3 差异（见下方注意事项）
 - [ ] 编写/更新单元测试（根目录运行 vitest）
-- [ ] 更新组件文档（若有 API 变更）
-- [ ] 本地运行测试套件确认无回归
+- [x] 更新组件文档（若有 API 变更）
+- [x] 本地运行测试套件确认无回归
 
 ### ⚠️ React→Vue3 差异注意事项
 - [ ] `children` / `ReactNode` → `slots` / `VueNode`
@@ -32,6 +32,6 @@ float-button/index.zh-CN.md 译名统一
 - [ ] Context API → `provide` / `inject`
 
 ### 📦 提交与发布
-- [ ] 提交信息格式：`docs(<scope>): xxx (#58996)`
+- [x] 提交信息格式：`docs(<scope>): xxx (#58996)`
 - [ ] PR 描述中链接上游 PR
 - [ ] CI 全部通过

--- a/docs/src/pages/components/float-button/index.zh-CN.md
+++ b/docs/src/pages/components/float-button/index.zh-CN.md
@@ -23,7 +23,7 @@ demo:
   <demo src="./demo/shape.vue" iframe="360">形状</demo>
   <demo src="./demo/content.vue" iframe="360">描述</demo>
   <demo src="./demo/tooltip.vue" iframe="360">含有气泡卡片的悬浮按钮</demo>
-  <demo src="./demo/group.vue" iframe="360">浮动按钮组</demo>
+  <demo src="./demo/group.vue" iframe="360">悬浮按钮组</demo>
   <demo src="./demo/group-menu.vue" iframe="360">菜单模式</demo>
   <demo src="./demo/controlled.vue" iframe="360">受控模式</demo>
   <demo src="./demo/placement.vue" iframe="380">弹出方向</demo>


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58996
上游 commit: `e57c50affe02cd1e84e4cc029a64e96dbf62019f`
优先级: 🟢 P3

### 变更摘要
float-button/index.zh-CN.md 译名统一

> Checklist 见分支根目录 `.sync-checklist-ant-design-58996.md`