### PR TITLE
fix(date-picker): hide decorative range separator (#58999)

### DIFF
--- a/packages/antdv-next/src/date-picker/generatePicker/generateRangePicker.tsx
+++ b/packages/antdv-next/src/date-picker/generatePicker/generateRangePicker.tsx
@@ -11,6 +11,7 @@ import { getTransitionName } from '@v-c/util/dist/utils/transition'
 import { computed, defineComponent, shallowRef } from 'vue'
 import { ContextIsolator } from '../../_util/ContextIsolator'
 import { getAttrStyleAndClass, useZIndex } from '../../_util/hooks'
+import { isNonNullable } from '../../_util/is'
 import { getMergedStatus, getStatusClassNames } from '../../_util/statusUtils'
 import { getSlotPropsFnRun, toPropsRefs } from '../../_util/tools'
 import { devUseWarning, isDev } from '../../_util/warning'
@@ -327,6 +328,7 @@ function generateRangePicker<DateType extends AnyObject = AnyObject>(generateCon
         }, 'separator', false)
         const separator = getSlotPropsFnRun(slots, props, 'separator', false) || _contextSeparator
         const mergedSeparator = separator ?? _contextSeparator
+        const hasCustomSeparator = isNonNullable(mergedSeparator)
 
         return (
           <ContextIsolator space>
@@ -335,8 +337,11 @@ function generateRangePicker<DateType extends AnyObject = AnyObject>(generateCon
               {...restProps}
               ref={innerRef as any}
               separator={(
-                <span aria-label="to" class={`${prefixCls.value}-separator`}>
-                  { mergedSeparator ?? <SwapRightOutlined />}
+                <span
+                  aria-hidden={hasCustomSeparator ? undefined : true}
+                  class={`${prefixCls.value}-separator`}
+                >
+                  {hasCustomSeparator ? mergedSeparator : <SwapRightOutlined />}
                 </span>
               )}
               disabled={mergedDisabled.value}

--- a/packages/antdv-next/src/date-picker/tests/RangePicker.test.tsx
+++ b/packages/antdv-next/src/date-picker/tests/RangePicker.test.tsx
@@ -43,6 +43,30 @@ describe('range-picker', () => {
     wrapper.unmount()
   })
 
+  // https://github.com/ant-design/ant-design/pull/58999
+  it('hides the default separator from the accessibility tree', () => {
+    const wrapper = mount(RangePicker)
+    const separator = wrapper.find('.ant-picker-separator')
+
+    expect(separator.attributes('aria-hidden')).toBe('true')
+    expect(separator.attributes('aria-label')).toBeUndefined()
+    expect(separator.find('.anticon-swap-right').exists()).toBe(true)
+  })
+
+  it('preserves a custom separator accessible name', () => {
+    const wrapper = mount(RangePicker, {
+      props: {
+        separator: () => <span aria-label="Custom range separator">test</span>,
+      },
+    })
+    const separator = wrapper.find('.ant-picker-separator')
+
+    expect(separator.attributes('aria-hidden')).toBeUndefined()
+    expect(separator.attributes('aria-label')).toBeUndefined()
+    expect(wrapper.find('[aria-label="Custom range separator"]').exists()).toBe(true)
+    expect(separator.text()).toContain('test')
+  })
+
   it('should support custom separator', () => {
     const wrapper = mount(RangePicker, {
       props: {
@@ -51,6 +75,7 @@ describe('range-picker', () => {
     })
 
     expect(wrapper.find('.ant-picker-separator').text()).toContain('test')
+    expect(wrapper.find('.ant-picker-separator').attributes('aria-hidden')).toBeUndefined()
   })
 
   it('should use default placeholders when placeholder is undefined', () => {

--- a/packages/antdv-next/src/date-picker/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/date-picker/tests/__snapshots__/demo.test.tsx.snap
@@ -1490,7 +1490,7 @@ exports[`date-picker demo > renders allow-empty correctly 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -2210,7 +2210,7 @@ exports[`date-picker demo > renders cell-render correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2544,7 +2544,7 @@ exports[`date-picker demo > renders disabled correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2642,7 +2642,7 @@ exports[`date-picker demo > renders disabled correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2942,7 +2942,7 @@ exports[`date-picker demo > renders disabled-date correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -3039,7 +3039,7 @@ exports[`date-picker demo > renders disabled-date correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -3343,7 +3343,7 @@ exports[`date-picker demo > renders extra-footer correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -3440,7 +3440,7 @@ exports[`date-picker demo > renders extra-footer correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -3886,7 +3886,7 @@ exports[`date-picker demo > renders format correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -4653,7 +4653,7 @@ exports[`date-picker demo > renders placement correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -4806,7 +4806,7 @@ exports[`date-picker demo > renders preset-ranges correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -4903,7 +4903,7 @@ exports[`date-picker demo > renders preset-ranges correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5008,7 +5008,7 @@ exports[`date-picker demo > renders range-picker correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5105,7 +5105,7 @@ exports[`date-picker demo > renders range-picker correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5202,7 +5202,7 @@ exports[`date-picker demo > renders range-picker correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5299,7 +5299,7 @@ exports[`date-picker demo > renders range-picker correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5396,7 +5396,7 @@ exports[`date-picker demo > renders range-picker correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5494,7 +5494,7 @@ exports[`date-picker demo > renders range-picker correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5671,7 +5671,7 @@ exports[`date-picker demo > renders select-in-range correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5785,7 +5785,7 @@ exports[`date-picker demo > renders select-in-range correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -6050,7 +6050,7 @@ exports[`date-picker demo > renders size correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -6302,7 +6302,7 @@ exports[`date-picker demo > renders status correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -6400,7 +6400,7 @@ exports[`date-picker demo > renders status correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -6694,7 +6694,7 @@ exports[`date-picker demo > renders suffix correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -6891,7 +6891,7 @@ exports[`date-picker demo > renders suffix correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -7140,7 +7140,7 @@ exports[`date-picker demo > renders suffix correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -7241,7 +7241,7 @@ exports[`date-picker demo > renders suffix correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -7511,7 +7511,7 @@ exports[`date-picker demo > renders time correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -7712,7 +7712,7 @@ exports[`date-picker demo > renders value-format correctly 1`] = `
             class="ant-picker-range-separator"
           >
             <span
-              aria-label="to"
+              aria-hidden="true"
               class="ant-picker-separator"
             >
               <span
@@ -7897,7 +7897,7 @@ exports[`date-picker demo > renders variant correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -8037,7 +8037,7 @@ exports[`date-picker demo > renders variant correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -8177,7 +8177,7 @@ exports[`date-picker demo > renders variant correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -8317,7 +8317,7 @@ exports[`date-picker demo > renders variant correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span

--- a/packages/antdv-next/src/form/tests/__snapshots__/demo.test.ts.snap
+++ b/packages/antdv-next/src/form/tests/__snapshots__/demo.test.ts.snap
@@ -13598,7 +13598,7 @@ exports[`form demo > renders time-related-controls correctly 1`] = `
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span
@@ -13744,7 +13744,7 @@ exports[`form demo > renders time-related-controls correctly 1`] = `
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span

--- a/packages/antdv-next/src/space/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/space/tests/__snapshots__/demo.test.tsx.snap
@@ -1635,7 +1635,7 @@ exports[`space demo > renders compact correctly 1`] = `
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span
@@ -1772,7 +1772,7 @@ exports[`space demo > renders compact correctly 1`] = `
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span
@@ -2281,7 +2281,7 @@ exports[`space demo > renders compact correctly 1`] = `
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span

--- a/packages/antdv-next/src/time-picker/tests/__snapshots__/TimePicker.test.tsx.snap
+++ b/packages/antdv-next/src/time-picker/tests/__snapshots__/TimePicker.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`time-picker > range-picker > should match snapshot 1`] = `
     <!---->
     <!---->
   </div>
-  <div class="ant-picker-range-separator"><span aria-label="to" class="ant-picker-separator"><span role="img" aria-label="swap-right" class="anticon anticon-swap-right"><svg data-icon="swap-right" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="0 0 1024 1024" focusable="false"><path d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"></path></svg></span></span></div>
+  <div class="ant-picker-range-separator"><span aria-hidden="true" class="ant-picker-separator"><span role="img" aria-label="swap-right" class="anticon anticon-swap-right"><svg data-icon="swap-right" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="0 0 1024 1024" focusable="false"><path d="M873.1 596.2l-164-208A32 32 0 00684 376h-64.8c-6.7 0-10.4 7.7-6.3 13l144.3 183H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h695.9c26.8 0 41.7-30.8 25.2-51.8z"></path></svg></span></span></div>
   <div class="ant-picker-input ant-picker-input-end"><input aria-invalid="false" class="ant-picker-input-end" data-range="end" size="10" placeholder="End time" value="18:00:00">
     <!---->
     <!---->

--- a/packages/antdv-next/src/time-picker/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/time-picker/tests/__snapshots__/demo.test.tsx.snap
@@ -1860,7 +1860,7 @@ exports[`time-picker demo > renders range-picker correctly 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -2386,7 +2386,7 @@ exports[`time-picker demo > renders status correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2486,7 +2486,7 @@ exports[`time-picker demo > renders status correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2794,7 +2794,7 @@ exports[`time-picker demo > renders suffix correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -3054,7 +3054,7 @@ exports[`time-picker demo > renders value-format correctly 1`] = `
             class="ant-picker-range-separator"
           >
             <span
-              aria-label="to"
+              aria-hidden="true"
               class="ant-picker-separator"
             >
               <span
@@ -3245,7 +3245,7 @@ exports[`time-picker demo > renders variant correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -3391,7 +3391,7 @@ exports[`time-picker demo > renders variant correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -3537,7 +3537,7 @@ exports[`time-picker demo > renders variant correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -3683,7 +3683,7 @@ exports[`time-picker demo > renders variant correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/58999
上游 commit: `4fe8ad0115d67d077a9ad41749bf22ca67b5e3d0`
优先级: 🟡 P2

### 变更摘要
generateRangePicker.tsx：范围分隔符 aria-hidden（含快照更新）