### PR TITLE
fix(collapse): hide decorative expand icon (#59000)

### DIFF
--- a/packages/antdv-next/src/collapse/Collapse.tsx
+++ b/packages/antdv-next/src/collapse/Collapse.tsx
@@ -152,12 +152,16 @@ const Collapse = defineComponent<
 
     const renderExpandIcon = (panelProps: PanelProps = {}) => {
       const mergedExpandIcon = slots?.expandIcon ?? props?.expandIcon ?? expandIcon.value
+      const iconIsInteractive
+        = panelProps.collapsible === 'header' || panelProps.collapsible === 'icon'
       const icon = typeof mergedExpandIcon === 'function'
         ? mergedExpandIcon?.(panelProps)
         : (
             <RightOutlined
               rotate={panelProps.isActive ? (direction.value === 'rtl' ? -90 : 90) : undefined}
-              aria-label={panelProps.isActive ? 'expanded' : 'collapsed'}
+              {...(iconIsInteractive
+                ? { 'aria-label': panelProps.isActive ? 'expanded' : 'collapsed' }
+                : { 'aria-hidden': 'true' })}
             />
           )
       return cloneElement(icon, () => {

--- a/packages/antdv-next/src/collapse/tests/Collapse.test.tsx
+++ b/packages/antdv-next/src/collapse/tests/Collapse.test.tsx
@@ -182,20 +182,55 @@ describe('collapse', () => {
   })
 
   // ==================== expand icon ====================
-  it('should render default expand icon with aria-label=collapsed', () => {
-    const wrapper = mount(Collapse, { props: { items: basicItems } })
-    const arrow = wrapper.find('.ant-collapse-arrow')
-    expect(arrow.exists()).toBe(true)
-    expect(arrow.attributes('aria-label')).toBe('collapsed')
+  it('hides the default expand icon and exposes state on the header', async () => {
+    const activeKey = ref<string[]>(['1'])
+    const wrapper = mount(() => (
+      <Collapse items={basicItems} activeKey={activeKey.value} />
+    ))
+    const header = wrapper.find('.ant-collapse-header')
+    const icon = wrapper.find('.ant-collapse-arrow')
+
+    expect(header.attributes('aria-expanded')).toBe('true')
+    expect(icon.attributes('aria-hidden')).toBe('true')
+
+    activeKey.value = []
+    await nextTick()
+
+    expect(header.attributes('aria-expanded')).toBe('false')
+    expect(icon.attributes('aria-hidden')).toBe('true')
   })
 
-  it('should show aria-label=expanded when panel is active', () => {
-    const wrapper = mount(Collapse, {
-      props: { items: basicItems, defaultActiveKey: ['1'] },
-    })
-    const arrow = wrapper.findAll('.ant-collapse-arrow')[0]!
-    expect(arrow.attributes('aria-label')).toBe('expanded')
+  it('preserves the accessible name of a custom expand icon', () => {
+    const wrapper = mount(() => (
+      <Collapse
+        items={basicItems}
+        expandIcon={() => <span role="img" aria-label="Custom status" />}
+      />
+    ))
+    const customIcon = wrapper.find('[role="img"]')
+    expect(customIcon.exists()).toBe(true)
+    expect(customIcon.attributes('aria-label')).toBe('Custom status')
   })
+
+  it.each(['header', 'icon'] as const)(
+    'keeps a state name when the default icon is interactive for collapsible=%s',
+    async (collapsible) => {
+      const activeKey = ref<string[]>(['1'])
+      const wrapper = mount(() => (
+        <Collapse items={basicItems} activeKey={activeKey.value} collapsible={collapsible} />
+      ))
+      const icon = wrapper.find('.ant-collapse-arrow')
+
+      expect(icon.attributes('aria-label')).toBe('expanded')
+      expect(icon.attributes('aria-hidden')).toBeUndefined()
+
+      activeKey.value = []
+      await nextTick()
+
+      expect(icon.attributes('aria-label')).toBe('collapsed')
+      expect(icon.attributes('aria-hidden')).toBeUndefined()
+    },
+  )
 
   it('should rotate arrow 90deg when active (LTR)', () => {
     const wrapper = mount(Collapse, {

--- a/packages/antdv-next/src/collapse/tests/__snapshots__/Collapse.test.tsx.snap
+++ b/packages/antdv-next/src/collapse/tests/__snapshots__/Collapse.test.tsx.snap
@@ -29,7 +29,8 @@ exports[`collapse > should match snapshot 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -90,7 +91,8 @@ exports[`collapse > should match snapshot 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >

--- a/packages/antdv-next/src/collapse/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/collapse/tests/__snapshots__/demo.test.tsx.snap
@@ -33,7 +33,8 @@ exports[`collapse demo > renders _semantic correctly 1`] = `
                 class="ant-collapse-expand-icon semantic-mark-icon"
               >
                 <span
-                  aria-label="expanded"
+                  aria-hidden="true"
+                  aria-label="right"
                   class="anticon anticon-right ant-collapse-arrow"
                   role="img"
                 >
@@ -764,7 +765,8 @@ exports[`collapse demo > renders accordion correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -814,7 +816,8 @@ exports[`collapse demo > renders accordion correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -864,7 +867,8 @@ exports[`collapse demo > renders accordion correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -921,7 +925,8 @@ exports[`collapse demo > renders basic correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -984,7 +989,8 @@ exports[`collapse demo > renders basic correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1034,7 +1040,8 @@ exports[`collapse demo > renders basic correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1091,7 +1098,8 @@ exports[`collapse demo > renders borderless correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1154,7 +1162,8 @@ exports[`collapse demo > renders borderless correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1204,7 +1213,8 @@ exports[`collapse demo > renders borderless correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1416,7 +1426,8 @@ exports[`collapse demo > renders collapsible correctly 1`] = `
             class="ant-collapse-expand-icon"
           >
             <span
-              aria-label="collapsed"
+              aria-hidden="true"
+              aria-label="right"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -1653,7 +1664,8 @@ exports[`collapse demo > renders extra correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="expanded"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1739,7 +1751,8 @@ exports[`collapse demo > renders extra correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1812,7 +1825,8 @@ exports[`collapse demo > renders extra correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1951,7 +1965,8 @@ exports[`collapse demo > renders ghost correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2014,7 +2029,8 @@ exports[`collapse demo > renders ghost correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2064,7 +2080,8 @@ exports[`collapse demo > renders ghost correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2121,7 +2138,8 @@ exports[`collapse demo > renders icon correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2203,7 +2221,8 @@ exports[`collapse demo > renders icon correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2276,7 +2295,8 @@ exports[`collapse demo > renders mix correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2326,7 +2346,8 @@ exports[`collapse demo > renders mix correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2376,7 +2397,8 @@ exports[`collapse demo > renders mix correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2433,7 +2455,8 @@ exports[`collapse demo > renders noarrow correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2531,7 +2554,8 @@ exports[`collapse demo > renders sfc correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2592,7 +2616,8 @@ exports[`collapse demo > renders sfc correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -2681,7 +2706,8 @@ exports[`collapse demo > renders size correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2751,7 +2777,8 @@ exports[`collapse demo > renders size correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2821,7 +2848,8 @@ exports[`collapse demo > renders size correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2884,7 +2912,8 @@ exports[`collapse demo > renders style-class correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="expanded"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2946,7 +2975,8 @@ exports[`collapse demo > renders style-class correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2997,7 +3027,8 @@ exports[`collapse demo > renders style-class correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -3053,7 +3084,8 @@ exports[`collapse demo > renders style-class correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -3104,7 +3136,8 @@ exports[`collapse demo > renders style-class correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="expanded"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -3166,7 +3199,8 @@ exports[`collapse demo > renders style-class correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/59000
上游 commit: `61140f857a102295139f8acd45284d474b611f19`
优先级: 🟡 P2

### 变更摘要
Collapse.tsx：装饰性展开图标 aria-hidden（含大量快照更新）