### PR TITLE
fix(form): prevent height fluctuation during rapid validation changes (#59008)

### DIFF
--- a/packages/antdv-next/src/form/FormItem/ItemHolder.tsx
+++ b/packages/antdv-next/src/form/FormItem/ItemHolder.tsx
@@ -46,7 +46,10 @@ const ItemHolder = defineComponent<ItemHolderProps>(
       immediate: true,
     })
     const onErrorVisibleChanged = (visible: boolean) => {
-      if (!visible) {
+      // Keep the compensated margin when a new error is already showing,
+      // otherwise rapid validation changes cause height fluctuation.
+      // https://github.com/ant-design/ant-design/pull/59008
+      if (!visible && !hasError.value) {
         marginBottom.value = null
       }
     }


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/59008
上游 commit: `a76aa2353a55d76be14ee883dd97dc3ad7e53413`
优先级: 🟠 P1

### 变更摘要
FormItem/ItemHolder 在快速校验状态切换时高度抖动