### PR TITLE
feat(carousel): localize default arrow aria-labels via ConfigProvider locale (#59014)

### DIFF
--- a/packages/antdv-next/src/carousel/index.tsx
+++ b/packages/antdv-next/src/carousel/index.tsx
@@ -11,6 +11,8 @@ import { getAttrStyleAndClass } from '../_util/hooks'
 import { getSlotPropsFnRun } from '../_util/tools.ts'
 import { devUseWarning, isDev } from '../_util/warning.ts'
 import { useComponentBaseConfig } from '../config-provider/context.ts'
+import defaultLocale from '../locale/en_US'
+import useLocale from '../locale/useLocale'
 import useStyle, { DotDuration } from './style'
 
 export type CarouselEffect = 'scrollx' | 'fade'
@@ -141,6 +143,7 @@ const Carousel = defineComponent<
       class: contextClassName,
       style: contextStyle,
     } = useComponentBaseConfig('carousel', props)
+    const [contextLocale] = useLocale('Carousel', defaultLocale.Carousel)
     const slickRef = shallowRef()
     const nativeElementRef = shallowRef<HTMLDivElement>()
 
@@ -269,8 +272,8 @@ const Carousel = defineComponent<
             dots={enableDots}
             dotsClass={dsClass}
             arrows={arrows}
-            prevArrow={prevArrow ?? <ArrowButton aria-label={isRTL.value ? 'next' : 'prev'} />}
-            nextArrow={nextArrow ?? <ArrowButton aria-label={isRTL.value ? 'prev' : 'next'} />}
+            prevArrow={prevArrow ?? <ArrowButton aria-label={isRTL.value ? contextLocale.value.nextSlide : contextLocale.value.prevSlide} />}
+            nextArrow={nextArrow ?? <ArrowButton aria-label={isRTL.value ? contextLocale.value.prevSlide : contextLocale.value.nextSlide} />}
             draggable={draggable}
             verticalSwiping={mergedVertical.value}
             autoplaySpeed={autoplaySpeed}

--- a/packages/antdv-next/src/carousel/tests/Carousel.test.tsx
+++ b/packages/antdv-next/src/carousel/tests/Carousel.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import Carousel from '..'
 import ConfigProvider from '../../config-provider'
+import zhCN from '../../locale/zh_CN'
 import rtlTest from '/@tests/shared/rtlTest'
 import { mount } from '/@tests/utils'
 
@@ -224,6 +225,28 @@ describe('carousel', () => {
     })
     expect(wrapper.find('.custom-prev').exists()).toBe(true)
     expect(wrapper.find('.custom-next').exists()).toBe(true)
+  })
+
+  it('should use localized aria-labels for arrows by default', async () => {
+    const wrapper = mount(Carousel, {
+      props: { arrows: true },
+      slots: { default: () => createSlides(3) },
+    })
+    await nextTick()
+    expect(wrapper.find('.slick-prev').attributes('aria-label')).toBe('Previous slide')
+    expect(wrapper.find('.slick-next').attributes('aria-label')).toBe('Next slide')
+  })
+
+  it('should use localized aria-labels when a custom locale is provided', async () => {
+    const wrapper = mount(ConfigProvider, {
+      props: { locale: zhCN },
+      slots: {
+        default: () => h(Carousel, { arrows: true }, { default: () => createSlides(3) }),
+      },
+    })
+    await nextTick()
+    expect(wrapper.find('.slick-prev').attributes('aria-label')).toBe('上一张幻灯片')
+    expect(wrapper.find('.slick-next').attributes('aria-label')).toBe('下一张幻灯片')
   })
 
   // ============ Expose methods tests ============

--- a/packages/antdv-next/src/carousel/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/carousel/tests/__snapshots__/demo.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`carousel demo > renders arrows correctly 1`] = `
       dir="ltr"
     >
       <button
-        aria-label="prev"
+        aria-label="Previous slide"
         class="slick-arrow slick-prev slick-disabled"
         data-role="none"
         style="display: block;"
@@ -109,7 +109,7 @@ exports[`carousel demo > renders arrows correctly 1`] = `
         </div>
       </div>
       <button
-        aria-label="next"
+        aria-label="Next slide"
         class="slick-arrow slick-next"
         data-role="none"
         style="display: block;"
@@ -161,7 +161,7 @@ exports[`carousel demo > renders arrows correctly 1`] = `
       dir="ltr"
     >
       <button
-        aria-label="prev"
+        aria-label="Previous slide"
         class="slick-arrow slick-prev slick-disabled"
         data-role="none"
         style="display: block;"
@@ -258,7 +258,7 @@ exports[`carousel demo > renders arrows correctly 1`] = `
         </div>
       </div>
       <button
-        aria-label="next"
+        aria-label="Next slide"
         class="slick-arrow slick-next"
         data-role="none"
         style="display: block;"

--- a/packages/antdv-next/src/locale/en_US.ts
+++ b/packages/antdv-next/src/locale/en_US.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Expand',
     collapse: 'Collapse',
   },
+  Carousel: {
+    prevSlide: 'Previous slide',
+    nextSlide: 'Next slide',
+  },
   Form: {
     optional: '(optional)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/index.tsx
+++ b/packages/antdv-next/src/locale/index.tsx
@@ -64,6 +64,10 @@ export interface Locale {
     refresh?: string
     scanned?: string
   }
+  Carousel?: {
+    prevSlide: string
+    nextSlide: string
+  }
   ColorPicker?: {
     presetEmpty: string
     transparent: string

--- a/packages/antdv-next/src/locale/zh_CN.ts
+++ b/packages/antdv-next/src/locale/zh_CN.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: '展开',
     collapse: '收起',
   },
+  Carousel: {
+    prevSlide: '上一张幻灯片',
+    nextSlide: '下一张幻灯片',
+  },
   Form: {
     optional: '（可选）',
     defaultValidateMessages: {


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/59014
上游 commit: `460b5fc504ee18176ee569acd52b0d46b4412e31`
优先级: 🟡 P2

### 变更摘要
carousel/index.tsx + locale：箭头 aria-label 走 locale，en_US/zh_CN 增加词条