### PR TITLE
fix(transfer): avoid duplicate onSearch calls when clearing (#59016)

### DIFF
--- a/packages/antdv-next/src/transfer/search.tsx
+++ b/packages/antdv-next/src/transfer/search.tsx
@@ -35,10 +35,11 @@ const Search = defineComponent<
 >(
   (props, { emit, slots }) => {
     const handleChange = (e: Event) => {
-      emit('change', e)
-      const target = e?.target as HTMLInputElement | null
-      if (!target?.value) {
+      if (e.type === 'click') {
         emit('clear')
+      }
+      else {
+        emit('change', e)
       }
     }
 

--- a/packages/antdv-next/src/transfer/tests/search.test.tsx
+++ b/packages/antdv-next/src/transfer/tests/search.test.tsx
@@ -71,6 +71,7 @@ describe('transfer.Search', () => {
     clearIcons[0]?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await nextTick()
 
+    expect(onSearch).toHaveBeenCalledTimes(1)
     expect(onSearch).toHaveBeenCalledWith('left', '')
 
     wrapper.unmount()


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/59016
上游 commit: `6b28e00b5166c4de62b10b2ee61eb257a7e49dec`
优先级: 🟡 P2

### 变更摘要
transfer/search.tsx：清空搜索时避免重复 onSearch