### PR TITLE
fix(menu): prevent icon jitter during inline collapse (#59018)

### DIFF
--- a/packages/antdv-next/src/menu/style/vertical.ts
+++ b/packages/antdv-next/src/menu/style/vertical.ts
@@ -58,12 +58,10 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
     colorTextLightSolid,
     dropdownWidth,
     controlHeightLG,
-    motionEaseOut,
     padding,
     paddingXL,
     itemMarginInline,
     fontSizeLG,
-    motionDurationFast,
     motionDurationSlow,
     paddingXS,
     boxShadowSecondary,
@@ -129,7 +127,6 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
             transition: [
               `border-color ${motionDurationSlow}`,
               `background-color ${motionDurationSlow}`,
-              `padding ${motionDurationFast} ${motionEaseOut}`,
             ].join(','),
 
             [`> ${componentCls}-title-content`]: {


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/59018
上游 commit: `68717476f4838abbf199f709fa2863129998cf7a`
优先级: 🟡 P2

### 变更摘要
menu/style/vertical.ts 纯样式修复：inline 收起时图标抖动