### PR TITLE
docs(typography): clarify editable onChange trigger description (#59021)

### DIFF
--- a/.sync-checklist-ant-design-59021.md
+++ b/.sync-checklist-ant-design-59021.md
@@ -11,27 +11,25 @@
 typography 文档：editable onChange 触发时机
 
 ### 🔍 Pre-sync 分析
-- [ ] 阅读上游 PR 完整内容和 review 评论
-- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
-- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
-- [ ] 检查是否有相关联的其他 PR 需要一起同步
+- [x] 阅读上游 PR 完整内容和 review 评论
+- [x] 确认 antdv-next 中是否存在相同问题/缺失相同功能（下游 editable 事件表中 `change` 事件描述同样为"文本域编辑时触发"/"Called when input at textarea"，需同步澄清）
+- [x] 查看上游变更的文件列表，评估 Vue3 适配工作量（仅两份 md 各一行）
+- [x] 检查是否有相关联的其他 PR 需要一起同步（无）
 
 ### 🛠️ 实现步骤
-- [ ] 实现对应的 docs（参考上游代码逻辑）
-- [ ] 处理 React→Vue3 差异（见下方注意事项）
-- [ ] 编写/更新单元测试（根目录运行 vitest）
-- [ ] 更新组件文档（若有 API 变更）
-- [ ] 本地运行测试套件确认无回归
+- [x] 实现对应的 docs（参考上游代码逻辑）
+  - `docs/src/pages/components/typography/index.zh-CN.md`：`change` 事件描述改为"文本域编辑完成时触发"
+  - `docs/src/pages/components/typography/index.en-US.md`：`change` 事件描述改为 "Called when editing is completed"
+- [x] 处理 React→Vue3 差异（下游为 `change` emit，非 `onChange` prop，措辞按下游 API 等价澄清）
+- [x] 编写/更新单元测试（纯文档改动，无需测试）
+- [x] 更新组件文档（本 PR 即文档改动）
+- [x] 本地运行测试套件确认无回归（纯 md 改动，不涉及代码）
 
 ### ⚠️ React→Vue3 差异注意事项
-- [ ] `children` / `ReactNode` → `slots` / `VueNode`
-- [ ] `React.forwardRef` → `defineExpose` / `ref`
-- [ ] `useEffect` → `watchEffect` / `onMounted`
-- [ ] `className` → `attrs.class`；`rootClassName` → `rootClass`；`classNames` → `classes`
-- [ ] `on*` props → emits 声明
-- [ ] Context API → `provide` / `inject`
+- [x] `on*` props → emits 声明（上游 `onChange` 对应下游 `change` 事件行）
+- 其余差异项不适用（纯文档变更）
 
 ### 📦 提交与发布
-- [ ] 提交信息格式：`docs(<scope>): xxx (#59021)`
+- [x] 提交信息格式：`docs(typography): clarify editable onChange trigger description (#59021)`
 - [ ] PR 描述中链接上游 PR
 - [ ] CI 全部通过

--- a/.sync-checklist-ant-design-59021.md
+++ b/.sync-checklist-ant-design-59021.md
@@ -1,0 +1,37 @@
+## ✅ 同步任务：#59021 - docs: clarify Typography editable onChange trigger description
+
+**优先级**: 🟢 P3
+**类型**: docs
+**上游 PR**: https://github.com/ant-design/ant-design/pull/59021
+**上游 Commit**: `c452c62a1fb7bc6f8f533b3653304c196aa76bc0`
+**涉及组件**: Typography
+**同步难度**: Low
+
+### 📖 变更摘要
+typography 文档：editable onChange 触发时机
+
+### 🔍 Pre-sync 分析
+- [ ] 阅读上游 PR 完整内容和 review 评论
+- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
+- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
+- [ ] 检查是否有相关联的其他 PR 需要一起同步
+
+### 🛠️ 实现步骤
+- [ ] 实现对应的 docs（参考上游代码逻辑）
+- [ ] 处理 React→Vue3 差异（见下方注意事项）
+- [ ] 编写/更新单元测试（根目录运行 vitest）
+- [ ] 更新组件文档（若有 API 变更）
+- [ ] 本地运行测试套件确认无回归
+
+### ⚠️ React→Vue3 差异注意事项
+- [ ] `children` / `ReactNode` → `slots` / `VueNode`
+- [ ] `React.forwardRef` → `defineExpose` / `ref`
+- [ ] `useEffect` → `watchEffect` / `onMounted`
+- [ ] `className` → `attrs.class`；`rootClassName` → `rootClass`；`classNames` → `classes`
+- [ ] `on*` props → emits 声明
+- [ ] Context API → `provide` / `inject`
+
+### 📦 提交与发布
+- [ ] 提交信息格式：`docs(<scope>): xxx (#59021)`
+- [ ] PR 描述中链接上游 PR
+- [ ] CI 全部通过

--- a/docs/src/pages/components/typography/index.en-US.md
+++ b/docs/src/pages/components/typography/index.en-US.md
@@ -154,7 +154,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 
 | Event | Description | Type | Version |
 | --- | --- | --- | --- |
-| change | Called when input at textarea | (value: string) =&gt; void | - |
+| change | Called when editing is completed | (value: string) =&gt; void | - |
 | cancel | Called when type ESC to exit editable state | () =&gt; void | - |
 | start | Called when enter editable state | () =&gt; void | - |
 | end | Called when type ENTER to exit editable state | () =&gt; void | - |

--- a/docs/src/pages/components/typography/index.zh-CN.md
+++ b/docs/src/pages/components/typography/index.zh-CN.md
@@ -152,7 +152,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 
 | 事件 | 说明 | 类型 |
 | --- | --- | --- |
-| change | 文本域编辑时触发 | (value: string) =&gt; void |
+| change | 文本域编辑完成时触发 | (value: string) =&gt; void |
 | cancel | 按 ESC 退出编辑状态时触发 | () =&gt; void |
 | start | 进入编辑中状态时触发 | () =&gt; void |
 | end | 按 ENTER 结束编辑状态时触发 | () =&gt; void |


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/59021
上游 commit: `c452c62a1fb7bc6f8f533b3653304c196aa76bc0`
优先级: 🟢 P3

### 变更摘要
typography 文档：editable onChange 触发时机

> Checklist 见分支根目录 `.sync-checklist-ant-design-59021.md`