### PR TITLE
fix(table): avoid duplicate filter close callbacks (#59023)

### DIFF
--- a/packages/antdv-next/src/table/hooks/useFilter/FilterDropdown.tsx
+++ b/packages/antdv-next/src/table/hooks/useFilter/FilterDropdown.tsx
@@ -325,10 +325,11 @@ const FilterDropdown = defineComponent<
           setFilteredKeysSync(wrapStringListType(propFilteredKeys.value))
         }
 
-        triggerVisible(newVisible)
-
         if (!newVisible && !hasPropDropdownRender && props.filterOnClose) {
           onConfirm()
+        }
+        else {
+          triggerVisible(newVisible)
         }
       }
     }

--- a/packages/antdv-next/src/table/tests/Table.filter.test.tsx
+++ b/packages/antdv-next/src/table/tests/Table.filter.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'vue'
 import Table from '..'
-import { mount } from '/@tests/utils'
+import { mount, waitFakeTimer } from '/@tests/utils'
 
 const data = [
   { key: '1', name: 'John', age: 32 },
@@ -39,6 +39,37 @@ describe('table filter', () => {
       attachTo: document.body,
     })
     expect(wrapper.find('.ant-table-filter-trigger').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('fires change event when visible change', async () => {
+    const onFilterDropdownOpenChange = vi.fn()
+    const onOpenChange = vi.fn()
+    const columns = [
+      {
+        title: 'Name',
+        dataIndex: 'name',
+        key: 'name',
+        filters: [
+          { text: 'John', value: 'John' },
+          { text: 'Jim', value: 'Jim' },
+        ],
+        filterDropdownProps: {
+          onOpenChange,
+        },
+        onFilterDropdownOpenChange,
+      },
+    ]
+    const wrapper = mount(Table, {
+      props: { columns, dataSource: data, pagination: false },
+      attachTo: document.body,
+    })
+    await wrapper.find('.ant-table-filter-trigger').trigger('click')
+    await waitFakeTimer()
+    await wrapper.find('.ant-table-filter-trigger').trigger('click')
+    await waitFakeTimer()
+    expect(onOpenChange.mock.calls).toEqual([[true], [false]])
+    expect(onFilterDropdownOpenChange.mock.calls).toEqual([[true], [false]])
     wrapper.unmount()
   })
 


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/59023
上游 commit: `fe3c108262e54966df6b2df369d76baeb1ecad1f`
优先级: 🟠 P1

### 变更摘要
FilterDropdown 关闭时重复触发回调，需对齐 hooks/useFilter/FilterDropdown 的去重逻辑