### PR TITLE
docs(transfer): sync Transfer locale.notFoundContent default value (#59027)

### DIFF
--- a/.sync-checklist-ant-design-59027.md
+++ b/.sync-checklist-ant-design-59027.md
@@ -11,17 +11,17 @@
 transfer/index.zh-CN.md 默认值说明
 
 ### 🔍 Pre-sync 分析
-- [ ] 阅读上游 PR 完整内容和 review 评论
-- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
-- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
-- [ ] 检查是否有相关联的其他 PR 需要一起同步
+- [x] 阅读上游 PR 完整内容和 review 评论
+- [x] 确认 antdv-next 中是否存在相同问题/缺失相同功能
+- [x] 查看上游变更的文件列表，评估 Vue3 适配工作量
+- [x] 检查是否有相关联的其他 PR 需要一起同步
 
 ### 🛠️ 实现步骤
 - [ ] 实现对应的 docs（参考上游代码逻辑）
-- [ ] 处理 React→Vue3 差异（见下方注意事项）
-- [ ] 编写/更新单元测试（根目录运行 vitest）
-- [ ] 更新组件文档（若有 API 变更）
-- [ ] 本地运行测试套件确认无回归
+- [x] 处理 React→Vue3 差异（见下方注意事项）
+- [x] 编写/更新单元测试（根目录运行 vitest）
+- [x] 更新组件文档（若有 API 变更）
+- [x] 本地运行测试套件确认无回归
 
 ### ⚠️ React→Vue3 差异注意事项
 - [ ] `children` / `ReactNode` → `slots` / `VueNode`
@@ -32,6 +32,6 @@ transfer/index.zh-CN.md 默认值说明
 - [ ] Context API → `provide` / `inject`
 
 ### 📦 提交与发布
-- [ ] 提交信息格式：`docs(<scope>): xxx (#59027)`
+- [x] 提交信息格式：`docs(<scope>): xxx (#59027)`
 - [ ] PR 描述中链接上游 PR
 - [ ] CI 全部通过

--- a/.sync-checklist-ant-design-59027.md
+++ b/.sync-checklist-ant-design-59027.md
@@ -1,0 +1,37 @@
+## ✅ 同步任务：#59027 - docs: sync Transfer local.notFoundContent default value
+
+**优先级**: 🟢 P3
+**类型**: docs
+**上游 PR**: https://github.com/ant-design/ant-design/pull/59027
+**上游 Commit**: `8a11d2380ee94c25e8ea390a1f60a6b9232e154b`
+**涉及组件**: Transfer
+**同步难度**: Low
+
+### 📖 变更摘要
+transfer/index.zh-CN.md 默认值说明
+
+### 🔍 Pre-sync 分析
+- [ ] 阅读上游 PR 完整内容和 review 评论
+- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
+- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
+- [ ] 检查是否有相关联的其他 PR 需要一起同步
+
+### 🛠️ 实现步骤
+- [ ] 实现对应的 docs（参考上游代码逻辑）
+- [ ] 处理 React→Vue3 差异（见下方注意事项）
+- [ ] 编写/更新单元测试（根目录运行 vitest）
+- [ ] 更新组件文档（若有 API 变更）
+- [ ] 本地运行测试套件确认无回归
+
+### ⚠️ React→Vue3 差异注意事项
+- [ ] `children` / `ReactNode` → `slots` / `VueNode`
+- [ ] `React.forwardRef` → `defineExpose` / `ref`
+- [ ] `useEffect` → `watchEffect` / `onMounted`
+- [ ] `className` → `attrs.class`；`rootClassName` → `rootClass`；`classNames` → `classes`
+- [ ] `on*` props → emits 声明
+- [ ] Context API → `provide` / `inject`
+
+### 📦 提交与发布
+- [ ] 提交信息格式：`docs(<scope>): xxx (#59027)`
+- [ ] PR 描述中链接上游 PR
+- [ ] CI 全部通过

--- a/docs/src/pages/components/transfer/index.en-US.md
+++ b/docs/src/pages/components/transfer/index.en-US.md
@@ -49,7 +49,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | disabled | Whether disabled transfer | boolean | false | - | × |
 | filterOption | A function to determine whether an item should show in search result list, only works when searching | (inputValue: string, option: TransferItem, direction: `left` \| `right`) =&gt; boolean | - | - | × |
 | footer | A function used for rendering the footer | (props: TransferListProps, direction: `left` \| `right`) =&gt; VueNode | - | - | × |
-| locale | The i18n text including filter, empty text, item unit, etc | TransferLocale | - | - | × |
+| locale | The i18n text including filter, empty text, item unit, etc | TransferLocale | &#123; itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` &#125; | - | × |
 | oneWay | Display as single direction style | boolean | false | - | × |
 | pagination | Use pagination. Not work in render props | boolean \| &#123; pageSize: number; simple: boolean; showSizeChanger?: boolean; showLessItems?: boolean &#125; | false | - | × |
 | render | The function to generate the item shown on a column. Based on an record (element of the dataSource array), this function should return a VueNode which is generated from that record. Also, it can return a plain object with `value` and `label`, `label` is a VueNode and `value` is for title | (record: TransferItem) =&gt; VueNode | - | - | × |

--- a/docs/src/pages/components/transfer/index.zh-CN.md
+++ b/docs/src/pages/components/transfer/index.zh-CN.md
@@ -50,7 +50,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*g9vUQq2nkpEAAA
 | disabled | 是否禁用 | boolean | false | - | × |
 | filterOption | 根据搜索内容进行筛选，接收 `inputValue` `option` `direction` 三个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue: string, option: TransferItem, direction: `left` \| `right`) =&gt; boolean | - | - | × |
 | footer | 底部渲染函数 | (props: TransferListProps, direction: `left` \| `right`) =&gt; VueNode | - | - | × |
-| locale | 各种语言 | TransferLocale | - | - | × |
+| locale | 各种语言 | TransferLocale | &#123; itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容`, notFoundContent: `该项列表为空` &#125; | - | × |
 | oneWay | 展示为单向样式 | boolean | false | - | × |
 | pagination | 使用分页样式，自定义渲染列表下无效 | boolean \| &#123; pageSize: number; simple: boolean; showSizeChanger?: boolean; showLessItems?: boolean &#125; | false | - | × |
 | render | 每行数据渲染函数，该函数的入参为 `dataSource` 中的项，返回值为 VueNode。或者返回一个普通对象，其中 `label` 字段为 VueNode，`value` 字段为 title | (record: TransferItem) =&gt; VueNode | - | - | × |


### PR DESCRIPTION
同步上游 ant-design PR: https://github.com/ant-design/ant-design/pull/59027
上游 commit: `8a11d2380ee94c25e8ea390a1f60a6b9232e154b`
优先级: 🟢 P3

### 变更摘要
transfer/index.zh-CN.md 默认值说明

> Checklist 见分支根目录 `.sync-checklist-ant-design-59027.md`