### PR TITLE
chore(deps): bump @v-c/select to 1.2.2 and @v-c/pagination to 1.1.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,8 +384,8 @@ catalogs:
       specifier: ^1.0.2
       version: 1.0.2
     '@v-c/pagination':
-      specifier: ^1.1.0
-      version: 1.1.0
+      specifier: ^1.1.1
+      version: 1.1.1
     '@v-c/picker':
       specifier: ^1.3.2
       version: 1.3.2
@@ -402,8 +402,8 @@ catalogs:
       specifier: ^1.0.4
       version: 1.0.4
     '@v-c/select':
-      specifier: ^1.2.1
-      version: 1.2.1
+      specifier: ^1.2.2
+      version: 1.2.2
     '@v-c/slick':
       specifier: ^1.0.2
       version: 1.0.2
@@ -868,7 +868,7 @@ importers:
         version: 2.0.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/pagination':
         specifier: catalog:vc
-        version: 1.1.0(vue@3.5.40(typescript@5.9.3))
+        version: 1.1.1(vue@3.5.40(typescript@5.9.3))
       '@v-c/picker':
         specifier: catalog:vc
         version: 1.3.2(dayjs@1.11.21)(vue@3.5.40(typescript@5.9.3))
@@ -889,7 +889,7 @@ importers:
         version: 1.0.4(vue@3.5.40(typescript@5.9.3))
       '@v-c/select':
         specifier: catalog:vc
-        version: 1.2.1(vue@3.5.40(typescript@5.9.3))
+        version: 1.2.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/slick':
         specifier: catalog:vc
         version: 1.0.2(vue@3.5.40(typescript@5.9.3))
@@ -2958,11 +2958,6 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/image@1.0.12':
-    resolution: {integrity: sha512-SwGOHRSHPiAWlazy+vfwE3dIniIWQLXfl6R0SdlMFbUZ6mbklkym2KqJxj+ZL7psl4tpO+WsgU9IZDMBzXmFPw==}
-    peerDependencies:
-      vue: ^3.0.0
-
   '@v-c/image@1.1.0':
     resolution: {integrity: sha512-kPe+HC4ZarWDv/zCD5oegrP+Yw+Ee/25xsjWVI7nkRAZRKwgGyFYjiIR1P0qomMvxdNFTaCbCxTx4Lh5ah2dzQ==}
     peerDependencies:
@@ -3013,6 +3008,11 @@ packages:
 
   '@v-c/pagination@1.1.0':
     resolution: {integrity: sha512-3m8hIkuwMS1LoSy+6n16D0I0UQkWt+2zwS0X3ndmgrvU5LfphiQ3UpSdOow0i/qk5TKbbPd5t97xsX5962ceSg==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@v-c/pagination@1.1.1':
+    resolution: {integrity: sha512-L6j7DatBvRT4a2RlzuN3q6WJK5jieWSaxiaUUWacj9lt1jd4Z5P592PuH1ECDILYey5Y1Jqz0RVG9JIsBvwN2Q==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3069,6 +3069,11 @@ packages:
 
   '@v-c/select@1.2.1':
     resolution: {integrity: sha512-4/xOcbf/3TnRIM0ati3v/jPiNn8V+QtC1wEG23pW/rHfijo8BvpN9oMlhnv83jQUUo25Tv0MBtHgiN7O5YI2zQ==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@v-c/select@1.2.2':
+    resolution: {integrity: sha512-OjxRUfw8qe7uvAfVIJJiqFWAh4X7VFv6g+uY/F4yTOZPvdwut+JOeiaYqx7Eqe9ilDFVpzWNeEFDOSaWmLT1Cw==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -8725,7 +8730,7 @@ snapshots:
 
   '@v-c/cascader@1.1.2(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      '@v-c/select': 1.2.1(vue@3.5.40(typescript@5.9.3))
+      '@v-c/select': 1.2.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/tree': 1.2.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
@@ -8761,12 +8766,6 @@ snapshots:
   '@v-c/dropdown@1.0.5(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@v-c/trigger': 1.1.0(vue@3.5.40(typescript@5.9.3))
-      '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
-      vue: 3.5.40(typescript@5.9.3)
-
-  '@v-c/image@1.0.12(vue@3.5.40(typescript@5.9.3))':
-    dependencies:
-      '@v-c/portal': 1.0.8(vue@3.5.40(typescript@5.9.3))
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
 
@@ -8836,6 +8835,11 @@ snapshots:
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
 
+  '@v-c/pagination@1.1.1(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
+
   '@v-c/picker@1.3.2(dayjs@1.11.21)(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.1.1(vue@3.5.40(typescript@5.9.3))
@@ -8894,6 +8898,14 @@ snapshots:
       vue: 3.5.40(typescript@5.9.3)
 
   '@v-c/select@1.2.1(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@v-c/overflow': 1.1.1(vue@3.5.40(typescript@5.9.3))
+      '@v-c/trigger': 1.1.0(vue@3.5.40(typescript@5.9.3))
+      '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
+      '@v-c/virtual-list': 1.1.1(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
+
+  '@v-c/select@1.2.2(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.1.1(vue@3.5.40(typescript@5.9.3))
       '@v-c/trigger': 1.1.0(vue@3.5.40(typescript@5.9.3))
@@ -8960,7 +8972,7 @@ snapshots:
 
   '@v-c/tree-select@1.1.2(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      '@v-c/select': 1.2.1(vue@3.5.40(typescript@5.9.3))
+      '@v-c/select': 1.2.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/tree': 1.2.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
@@ -9437,7 +9449,7 @@ snapshots:
       '@v-c/dialog': 1.2.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/drawer': 1.0.6(vue@3.5.40(typescript@5.9.3))
       '@v-c/dropdown': 1.0.5(vue@3.5.40(typescript@5.9.3))
-      '@v-c/image': 1.0.12(vue@3.5.40(typescript@5.9.3))
+      '@v-c/image': 1.1.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/input': 1.1.1(vue@3.5.40(typescript@5.9.3))
       '@v-c/input-number': 1.0.7(vue@3.5.40(typescript@5.9.3))
       '@v-c/mentions': 1.2.0(vue@3.5.40(typescript@5.9.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -148,7 +148,7 @@ catalogs:
     '@v-c/menu': ^1.3.0
     '@v-c/mutate-observer': ^1.0.2
     '@v-c/notification': ^2.0.2
-    '@v-c/pagination': ^1.1.0
+    '@v-c/pagination': ^1.1.1
     '@v-c/picker': ^1.3.2
     '@v-c/portal': ^1.0.8
     '@v-c/progress': ^1.0.1
@@ -156,7 +156,7 @@ catalogs:
     '@v-c/rate': ^1.0.1
     '@v-c/resize-observer': ^1.1.3
     '@v-c/segmented': ^1.0.4
-    '@v-c/select': ^1.2.1
+    '@v-c/select': ^1.2.2
     '@v-c/slick': ^1.0.2
     '@v-c/slider': ^1.1.0
     '@v-c/steps': ^1.0.0


### PR DESCRIPTION
升级 vc 补丁版本:

- `@v-c/select` `^1.2.1` → `^1.2.2`
- `@v-c/pagination` `^1.1.0` → `^1.1.1`

版本统一在 `pnpm-workspace.yaml` 的 `catalog:vc` 中管理,已同步更新 lockfile。

本地已跑 select / pagination / auto-complete 相关测试:14 个测试文件、184 个用例全部通过。