### PR TITLE
fix(table): preserve custom filter dropdown close semantics

### DIFF
--- a/docs/src/pages/components/table/demo/custom-filter-close.vue
+++ b/docs/src/pages/components/table/demo/custom-filter-close.vue
@@ -1,0 +1,108 @@
+<docs lang="zh-CN">
+自定义筛选面板关闭时不会自动提交暂存值。输入筛选值后，再次点击表头筛选图标关闭面板，`change` 不会触发；只有通过 `confirm` 才会应用筛选。
+</docs>
+
+<docs lang="en-US">
+Closing a custom filter panel does not submit staged values automatically. Stage a value and click the header filter icon again to close the panel; `change` only fires after an explicit `confirm`.
+</docs>
+
+<script setup lang="ts">
+import type { TableEmits, TableProps } from 'antdv-next'
+import { Button, Input, Space } from 'antdv-next'
+import { h, ref } from 'vue'
+
+interface DataType {
+  key: string
+  name: string
+  age: number
+}
+
+const dataSource: DataType[] = [
+  { key: '1', name: 'John', age: 32 },
+  { key: '2', name: 'Jim', age: 42 },
+  { key: '3', name: 'Joe', age: 22 },
+]
+
+const changeCount = ref(0)
+const appliedFilter = ref('')
+
+const columns: TableProps<DataType>['columns'] = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    key: 'name',
+    onFilter: (value, record) => record.name.includes(String(value)),
+    filterDropdown: ({ clearFilters, confirm, selectedKeys, setSelectedKeys }) => h(
+      'div',
+      {
+        class: 'custom-filter-close-panel',
+        onKeydown: (event: KeyboardEvent) => event.stopPropagation(),
+      },
+      [
+        h(Input, {
+          class: 'custom-filter-stage-input',
+          placeholder: 'Stage a name',
+          value: String(selectedKeys[0] || ''),
+          'onUpdate:value': (value: string) => setSelectedKeys(value ? [value] : []),
+        }),
+        h(Space, null, {
+          default: () => [
+            h(Button, {
+              class: 'custom-filter-apply',
+              size: 'small',
+              type: 'primary',
+              onClick: () => confirm(),
+            }, { default: () => 'Apply' }),
+            h(Button, {
+              class: 'custom-filter-reset',
+              size: 'small',
+              onClick: () => clearFilters?.({ confirm: true, closeDropdown: true }),
+            }, { default: () => 'Reset' }),
+          ],
+        }),
+      ],
+    ),
+  },
+  {
+    title: 'Age',
+    dataIndex: 'age',
+    key: 'age',
+  },
+]
+
+const handleChange: TableEmits<DataType>['change'] = (_, filters) => {
+  changeCount.value += 1
+  const nameFilter = filters.name
+  appliedFilter.value = Array.isArray(nameFilter) ? nameFilter.map(String).join(', ') : ''
+}
+</script>
+
+<template>
+  <a-space direction="vertical">
+    <div class="custom-filter-status">
+      <span data-testid="change-count">Change events: {{ changeCount }}</span>
+      <span data-testid="applied-filter">Applied filter: {{ appliedFilter || 'none' }}</span>
+    </div>
+    <a-table
+      :columns="columns"
+      :data-source="dataSource"
+      :pagination="false"
+      @change="handleChange"
+    />
+  </a-space>
+</template>
+
+<style scoped>
+.custom-filter-close-panel {
+  display: flex;
+  width: 220px;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+}
+
+.custom-filter-status {
+  display: flex;
+  gap: 16px;
+}
+</style>

--- a/docs/src/pages/components/table/index.en-US.md
+++ b/docs/src/pages/components/table/index.en-US.md
@@ -78,6 +78,7 @@ const columns = [
   <demo src="./demo/summary.vue">Summary</demo>
   <demo src="./demo/custom-empty.vue">Custom Empty</demo>
   <demo src="./demo/custom-filter-panel.vue">Custom Filter Panel</demo>
+  <demo src="./demo/custom-filter-close.vue">Close Custom Filter Panel</demo>
   <demo src="./demo/filter-search.vue">Filter Search</demo>
   <demo src="./demo/filter-in-tree.vue">Tree Filter</demo>
   <demo src="./demo/head.vue">Sorting & Filtering</demo>

--- a/docs/src/pages/components/table/index.zh-CN.md
+++ b/docs/src/pages/components/table/index.zh-CN.md
@@ -79,6 +79,7 @@ const columns = [
   <demo src="./demo/summary.vue">汇总行</demo>
   <demo src="./demo/custom-empty.vue">自定义空状态</demo>
   <demo src="./demo/custom-filter-panel.vue">自定义筛选</demo>
+  <demo src="./demo/custom-filter-close.vue">关闭自定义筛选面板</demo>
   <demo src="./demo/filter-search.vue">筛选搜索</demo>
   <demo src="./demo/filter-in-tree.vue">树形筛选</demo>
   <demo src="./demo/head.vue">排序与筛选</demo>

--- a/packages/antdv-next/src/table/hooks/useFilter/FilterDropdown.tsx
+++ b/packages/antdv-next/src/table/hooks/useFilter/FilterDropdown.tsx
@@ -325,7 +325,12 @@ const FilterDropdown = defineComponent<
           setFilteredKeysSync(wrapStringListType(propFilteredKeys.value))
         }
 
-        if (!newVisible && !hasPropDropdownRender && props.filterOnClose) {
+        if (
+          !newVisible
+          && !hasPropDropdownRender
+          && !column.value.filterDropdown
+          && props.filterOnClose
+        ) {
           onConfirm()
         }
         else {

--- a/packages/antdv-next/src/table/tests/Table.filter.test.tsx
+++ b/packages/antdv-next/src/table/tests/Table.filter.test.tsx
@@ -1,3 +1,4 @@
+import type { ColumnsType, FilterDropdownProps } from '../interface'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'vue'
 import Table from '..'
@@ -170,6 +171,48 @@ describe('table filter', () => {
       attachTo: document.body,
     })
     expect(wrapper.find('.ant-table-filter-trigger').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  // https://github.com/ant-design/ant-design/issues/17833
+  it('should not confirm a column filterDropdown when closing it from the trigger', async () => {
+    const onChange = vi.fn()
+    const onOpenChange = vi.fn()
+    const columns: ColumnsType<(typeof data)[number]> = [
+      {
+        title: 'Name',
+        dataIndex: 'name',
+        key: 'name',
+        filterDropdown: ({ setSelectedKeys }: FilterDropdownProps) => h(
+          'button',
+          {
+            class: 'stage-custom-filter',
+            onClick: () => setSelectedKeys(['John']),
+          },
+          'Stage filter',
+        ),
+        filterDropdownProps: { onOpenChange },
+        onFilter: (value, record) => record.name === value,
+      },
+    ]
+    const wrapper = mount(Table, {
+      props: { columns, dataSource: data, pagination: false, onChange },
+      attachTo: document.body,
+    })
+
+    await wrapper.find('.ant-table-filter-trigger').trigger('click')
+    await waitFakeTimer()
+    const stageButton = document.querySelector<HTMLButtonElement>('.stage-custom-filter')
+    expect(stageButton).toBeTruthy()
+    stageButton?.click()
+    await waitFakeTimer()
+
+    await wrapper.find('.ant-table-filter-trigger').trigger('click')
+    await waitFakeTimer()
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(onOpenChange.mock.calls).toEqual([[true], [false]])
+    expect(wrapper.findAll('tbody tr')).toHaveLength(data.length)
     wrapper.unmount()
   })
 

--- a/packages/antdv-next/src/table/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/table/tests/__snapshots__/demo.test.tsx.snap
@@ -4384,6 +4384,201 @@ exports[`table demo > renders custom-empty correctly 1`] = `
 </div>
 `;
 
+exports[`table demo > renders custom-filter-close correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-root"
+  data-v-8203daa8=""
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="custom-filter-status"
+      data-v-8203daa8=""
+    >
+      <span
+        data-testid="change-count"
+        data-v-8203daa8=""
+      >
+        Change events: 0
+      </span>
+      <span
+        data-testid="applied-filter"
+        data-v-8203daa8=""
+      >
+        Applied filter: none
+      </span>
+    </div>
+  </div>
+  <!---->
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="css-var-root ant-table-css-var ant-table-wrapper"
+      data-allow-mismatch="true"
+      data-v-8203daa8=""
+    >
+      <div
+        aria-busy="false"
+        aria-live="polite"
+        class="ant-spin css-var-root"
+      >
+        <!---->
+        <div
+          class="ant-spin-container"
+        >
+          <div
+            class="ant-table css-var-root ant-table-css-var"
+          >
+            <!---->
+            <div
+              class="ant-table-container"
+            >
+              <div
+                class="ant-table-content"
+              >
+                <table
+                  style="table-layout: auto;"
+                >
+                  <!---->
+                  <!---->
+                  <thead
+                    class="ant-table-thead"
+                  >
+                    <tr
+                      class=""
+                    >
+                      <th
+                        class="ant-table-cell"
+                        colend="0"
+                        colstart="0"
+                        scope="col"
+                      >
+                        <!---->
+                        <div
+                          class="ant-table-filter-column"
+                        >
+                          <span
+                            class="ant-table-column-title"
+                          >
+                            Name
+                          </span>
+                          <span
+                            class="ant-table-filter-trigger ant-dropdown-trigger"
+                            role="button"
+                            tabindex="-1"
+                          >
+                            <span
+                              aria-label="filter"
+                              class="anticon anticon-filter"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="filter"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M349 838c0 17.7 14.2 32 31.8 32h262.4c17.6 0 31.8-14.3 31.8-32V642H349v196zm531.1-684H143.9c-24.5 0-39.8 26.7-27.5 48l221.3 376h348.8l221.3-376c12.1-21.3-3.2-48-27.7-48z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <!---->
+                        </div>
+                      </th>
+                      <th
+                        class="ant-table-cell"
+                        colend="1"
+                        colstart="1"
+                        scope="col"
+                      >
+                        <!---->
+                        Age
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="ant-table-tbody"
+                  >
+                    <!---->
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="1"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        John
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        32
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="2"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Jim
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        42
+                      </td>
+                    </tr>
+                    <tr
+                      class="ant-table-row ant-table-row-level-0"
+                      data-row-key="3"
+                    >
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        Joe
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                        scope="row"
+                      >
+                        <!---->
+                        22
+                      </td>
+                    </tr>
+                  </tbody>
+                  <!---->
+                </table>
+              </div>
+            </div>
+            <!---->
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!---->
+</div>
+`;
+
 exports[`table demo > renders custom-filter-panel correctly 1`] = `
 <div
   class="css-var-root ant-table-css-var ant-table-wrapper"


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/antdv-next/antdv-next/blob/main/.github/PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Refs #752
- Follow-up to #749
- Upstream behavior: ant-design/ant-design#17833

### 💡 Background and Solution

While reviewing #749, we found a historical behavior difference between `antdv-next` and Ant Design for column-level custom `filterDropdown` content.

#### What happened

Ant Design treats a custom filter panel as the owner of confirmation: `setSelectedKeys()` only stages a value, and closing the panel must not apply it unless the custom content calls `confirm()`.

Before commit [`7faa94d0`](https://github.com/antdv-next/antdv-next/commit/7faa94d0fcd561f0b5f4968c3aa35163a75b5db3), the close-confirm guard used `filterDropdownDefined`, which covered both Table-level and column-level custom dropdowns. That commit introduced `hasPropDropdownRender` so an empty Table-level `filterDropdown` slot could correctly fall back to the built-in panel. However, replacing the original guard also dropped the column-level `filterDropdown` check.

Consequently, when a column custom panel staged `John` and the user closed it from the header trigger, `onVisibleChange()` entered `onConfirm()`. Table emitted `change` and filtered the rows even though the custom panel never called `confirm()`.

#749 subsequently fixed duplicate close callbacks by moving `triggerVisible(newVisible)` into the `else` branch, but did not address this older confirmation-semantic difference.

#### Solution

This PR combines both requirements in the final close path:

```ts
if (
  !newVisible
  && !hasPropDropdownRender
  && !column.value.filterDropdown
  && props.filterOnClose
) {
  onConfirm()
}
else {
  triggerVisible(newVisible)
}
```

| Dropdown path | Close behavior |
| --- | --- |
| Built-in panel with `filterOnClose` | Confirm once |
| Non-empty Table-level custom render | Close without implicit confirmation |
| Column-level custom `filterDropdown` | Close without implicit confirmation |
| Empty Table-level custom render | Fall back to the built-in panel |

The regression test opens the column custom panel, stages `John`, and closes it by clicking the same header trigger. It asserts that `change` is not emitted, all rows remain visible, and the open/close callbacks each fire exactly once. A bilingual interactive demo exposes both the close-without-confirm and explicit Apply paths.

#### Browser verification

Closing the custom panel from the header trigger does not apply the staged value (`0` change events, no applied filter, 3 rows):

<img width="800" alt="Close custom filterDropdown without confirming" src="https://github.com/user-attachments/assets/f14d494f-0cbb-429a-ad0c-f7fe01dae384" />

Calling `confirm()` through Apply still applies `John` (`1` change event, 1 matching row):

<img width="800" alt="Apply custom filterDropdown explicitly" src="https://github.com/user-attachments/assets/40bd802c-913b-4443-bbd7-1543792ef8d5" />

#### Verification

- `pnpm -F antdv-next test src/table/tests/Table.filter.test.tsx` — 12/12 passed
- `pnpm -F antdv-next test src/table/tests/demo.test.tsx` — 49/49 passed
- `pnpm -F antdv-next test src/table/tests` — 188/188 passed across 12 files
- Targeted ESLint — passed
- `pnpm exec vue-tsc --noEmit --project docs/tsconfig.json` — passed
- `pnpm -F docs build` — passed
- GitHub repository checks — all passed; the separate Vercel status only reports that fork preview authorization is required

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Table custom `filterDropdown` no longer applies staged filters when it closes without an explicit confirmation. |
| 🇨🇳 Chinese | Table 自定义 `filterDropdown` 关闭时不再隐式提交暂存的筛选值。 |
