### PR TITLE
fix(tree): handle zero key in DirectoryTree range selection (#59029)

### DIFF
--- a/packages/antdv-next/src/tree/tests/directory.test.tsx
+++ b/packages/antdv-next/src/tree/tests/directory.test.tsx
@@ -156,6 +156,36 @@ describe('directory Tree', () => {
     wrapper.unmount()
   })
 
+  it('select range when the first selected key is 0', async () => {
+    const onSelect = vi.fn()
+    const treeData = [
+      { title: 'Zero', key: 0 },
+      { title: 'One', key: 1 },
+      { title: 'Two', key: 2 },
+    ]
+    const wrapper = mount(DirectoryTree, {
+      props: {
+        multiple: true,
+        treeData,
+        onSelect,
+      },
+    })
+    await waitFakeTimer(0, 1)
+
+    const nodes = wrapper.findAll('.ant-tree-node-content-wrapper')
+    await nodes[0]!.trigger('click')
+    await waitFakeTimer(0, 1)
+    await nodes[2]!.trigger('click', { shiftKey: true })
+    await waitFakeTimer(0, 1)
+
+    expect(wrapper.findAll('.ant-tree-node-selected')).toHaveLength(3)
+    expect(onSelect).toHaveBeenLastCalledWith(
+      [0, 1, 2],
+      expect.objectContaining({ selectedNodes: treeData }),
+    )
+    wrapper.unmount()
+  })
+
   it('directoryTree should expend all when use treeData and defaultExpandAll is true', async () => {
     const treeData = [
       {

--- a/packages/antdv-next/src/tree/utils/dictUtil.ts
+++ b/packages/antdv-next/src/tree/utils/dictUtil.ts
@@ -2,6 +2,7 @@ import type { DataNode, Key } from '@v-c/tree'
 import type { TreeProps } from '../Tree'
 
 import { fillFieldNames } from '@v-c/tree'
+import { isNonNullable } from '../../_util/is'
 
 const RECORD_NONE = 0
 const RECORD_START = 1
@@ -46,11 +47,11 @@ export function calcRangeKeys({
   const keys: Key[] = []
   let record: Record = RECORD_NONE
 
-  if (startKey && startKey === endKey) {
-    return [startKey]
-  }
-  if (!startKey || !endKey) {
+  if (!isNonNullable(startKey) || !isNonNullable(endKey)) {
     return []
+  }
+  if (startKey === endKey) {
+    return [startKey]
   }
 
   function matchKey(key: Key) {


### PR DESCRIPTION
Sync upstream ant-design/ant-design#59029.

DirectoryTree shift-range selection returned an empty range when the anchor key was `0` (falsy check). Aligned with upstream by using `isNonNullable` for start/end key guards, and ported the upstream regression test.