### PR TITLE
test(cascader): cover null notFoundContent behavior (#59028)

### DIFF
--- a/packages/antdv-next/src/cascader/tests/Cascader.test.tsx
+++ b/packages/antdv-next/src/cascader/tests/Cascader.test.tsx
@@ -385,6 +385,25 @@ describe('cascader', () => {
     expect(Cascader.Panel).toBe(CascaderPanel)
   })
 
+  it('should support notFoundContent={null}', async () => {
+    document.body.innerHTML = ''
+    const wrapper = mount(Cascader, {
+      props: { open: true, options: [], notFoundContent: null },
+      attachTo: document.body,
+    })
+    await nextTick()
+    expect(document.querySelector('.ant-empty')).toBeNull()
+    wrapper.unmount()
+  })
+
+  it('should support notFoundContent={null} in panel', () => {
+    const wrapper = mount(CascaderPanel, {
+      props: { options: [], notFoundContent: null },
+    })
+    expect(wrapper.find('.ant-empty').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
   it('should support Cascader.SHOW_PARENT and SHOW_CHILD', () => {
     expect(Cascader.SHOW_PARENT).toBeDefined()
     expect(Cascader.SHOW_CHILD).toBeDefined()


### PR DESCRIPTION
Sync upstream ant-design/ant-design#59028.

The Vue implementation already respects `notFoundContent: null` (it checks `=== undefined` before falling back to the default empty), so no code change is needed — this ports the upstream regression tests for Cascader and Cascader.Panel.