### PR TITLE
fix(menu): omit conflicting title type in SubMenuProps (#59048)

### DIFF
--- a/packages/antdv-next/src/menu/SubMenu.tsx
+++ b/packages/antdv-next/src/menu/SubMenu.tsx
@@ -9,7 +9,7 @@ import { pureAttrs, useZIndex } from '../_util/hooks'
 import { getSlotPropsFnRun } from '../_util/tools.ts'
 import { useMenuContext, useMenuContextProvider } from './MenuContext.tsx'
 
-export interface SubMenuProps extends Omit<SubMenuType, 'key' | 'label' | 'children'> {
+export interface SubMenuProps extends Omit<SubMenuType, 'key' | 'label' | 'children' | 'title'> {
   title?: VueNode
 }
 


### PR DESCRIPTION
Sync upstream ant-design/ant-design#59048.

Upstream fixed duplicate submenu popup ids by upgrading @rc-component/menu and omitting the conflicting `title` field in `SubMenuProps`. On the Vue side, @v-c/menu already generates unique popup ids (`useId` incorporates the menu `id` prop, falling back to Vue's per-instance `useId`), so no dependency upgrade is needed — only the `SubMenuProps` type alignment: omit `title?: string` inherited from `SubMenuType` so the redeclared `title?: VueNode` is authoritative.