### PR TITLE
fix(color-picker): use styles.description instead of classes.description for trigger text style

### DIFF
--- a/packages/antdv-next/src/color-picker/components/ColorTrigger.tsx
+++ b/packages/antdv-next/src/color-picker/components/ColorTrigger.tsx
@@ -120,7 +120,7 @@ export default defineComponent<
           {props.showText && (
             <div
               class={[colorTextPrefixCls.value, classes.description]}
-              style={classes.description}
+              style={styles.description}
             >
               {desc.value}
             </div>

--- a/packages/antdv-next/src/color-picker/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/color-picker/tests/__snapshots__/demo.test.tsx.snap
@@ -31,7 +31,6 @@ exports[`color-picker demo > renders _semantic correctly 1`] = `
           </div>
           <div
             class="ant-color-picker-trigger-text semantic-mark-description"
-            style=""
           >
             #1677FF
           </div>


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/antdv-next/antdv-next/blob/main/.github/PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://www.antdv-next.com/components/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed ColorPicker trigger text not applying the styles.description customization correctly. |
| 🇨🇳 Chinese | 修复 ColorPicker 触发区文字未正确应用 styles.description 自定义样式的问题。|
