### PR TITLE
fix(form): keep FormItem children shape stable to avoid child remount

### DIFF
--- a/packages/antdv-next/src/form/FormItem/index.tsx
+++ b/packages/antdv-next/src/form/FormItem/index.tsx
@@ -9,7 +9,6 @@ import { clsx } from '@v-c/util'
 import { filterEmpty } from '@v-c/util/dist/props-util'
 import { computed, createVNode, defineComponent, isVNode, onBeforeUnmount, shallowRef, watch } from 'vue'
 import { getSlotPropsFnRun } from '../../_util/tools.ts'
-import { checkRenderNode } from '../../_util/vueNode.ts'
 import { useComponentBaseConfig } from '../../config-provider/context'
 import useCSSVarCls from '../../config-provider/hooks/useCSSVarCls'
 import { useFormContext, useFormItemProvider, useNoStyleItemContext } from '../context.tsx'
@@ -532,7 +531,10 @@ const InternalFormItem = defineComponent<
       triggerFocus: onFieldFocus,
     })
     return () => {
-      const children: any = checkRenderNode(filterEmpty(slots.default?.() ?? []))
+      // Keep children as a flat array so toggling a sibling (e.g. `v-if`) only
+      // patches positionally instead of swapping between a bare vnode and a
+      // Fragment wrapper, which would remount every child. See issue #762.
+      const children: any = filterEmpty(slots.default?.() ?? [])
       return renderLayout(
         children,
         fieldId.value,
@@ -546,8 +548,8 @@ const InternalFormItem = defineComponent<
       isRequiredMark?: boolean,
     ) {
       // 判断children是否为单一的元素，如果是则塞入onBlur用以触发校验
-      if ((Array.isArray(baseChildren) && baseChildren.length === 1 && isVNode(baseChildren[0])) || isVNode(baseChildren)) {
-        const child = isVNode(baseChildren) ? baseChildren : baseChildren[0]
+      if (Array.isArray(baseChildren) && baseChildren.length === 1 && isVNode(baseChildren[0])) {
+        const child = baseChildren[0]
         const childProps = child.props || {}
         const _onBlur = childProps.onBlur
         const _onFocus = childProps.onFocus
@@ -616,7 +618,8 @@ const InternalFormItem = defineComponent<
         if (props.required ?? isRequiredMark) {
           newChildProps['aria-required'] = 'true'
         }
-        baseChildren = createVNode(child, newChildProps)
+        // Keep the array shape stable across renders (see issue #762).
+        baseChildren = [createVNode(child, newChildProps)]
       }
       if (props.noStyle && !props.hidden) {
         return (

--- a/packages/antdv-next/src/form/tests/item-child-remount.test.tsx
+++ b/packages/antdv-next/src/form/tests/item-child-remount.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { createCommentVNode, defineComponent, nextTick, ref } from 'vue'
+import Form, { FormItem } from '..'
+import { mount } from '/@tests/utils'
+
+// https://github.com/antdv-next/antdv-next/issues/762
+// FormItem 多子节点下，其中一个子节点带 v-if 时，v-if 切换导致所有子节点 setup 重建
+describe('form item child remount (issue #762)', () => {
+  it('keeps the control instance when a sibling v-if child toggles', async () => {
+    let setupCount = 0
+    const Child = defineComponent({
+      setup() {
+        setupCount++
+        return () => <input class="child-input" />
+      },
+    })
+
+    // 模拟 <div v-if="showSibling">：false 分支编译产物是注释占位节点
+    const showSibling = ref(false)
+    const wrapper = mount(() => (
+      <Form model={{ id: '' }}>
+        <FormItem name="id" label="id">
+          <Child />
+          {showSibling.value ? <div class="sibling">sibling</div> : createCommentVNode('v-if')}
+        </FormItem>
+      </Form>
+    ))
+
+    expect(setupCount).toBe(1)
+
+    // 输入一些 DOM 状态，用于验证实例是否被保留
+    const input = wrapper.find('.child-input')
+    await input.setValue('hello')
+
+    showSibling.value = true
+    await nextTick()
+    expect(wrapper.find('.sibling').exists()).toBe(true)
+    // 子控件不应被卸载重建
+    expect(setupCount).toBe(1)
+    expect((wrapper.find('.child-input').element as HTMLInputElement).value).toBe('hello')
+
+    showSibling.value = false
+    await nextTick()
+    expect(wrapper.find('.sibling').exists()).toBe(false)
+    expect(setupCount).toBe(1)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
fix #762

## 根因

`FormItem` 通过 `checkRenderNode(filterEmpty(...))` 处理默认插槽：单个子节点返回裸 vnode，多个子节点包成 `Fragment`。当某个兄弟节点带 `v-if` 时（false 分支的注释占位节点会被 `filterEmpty` 过滤），切换 `v-if` 会让子树根节点在「裸 vnode」和「Fragment」之间来回变化，`isSameVNodeType` 判定为不同类型 → 整棵子树卸载重挂 → 所有子组件 setup 重建、内部状态丢失。React 版 antd 无此包裹，children 按位置 diff，无此问题。

## 修复

children 始终保持为扁平数组：恰好一个子节点时把注入 id/onBlur/ref/aria 后的克隆放回数组，多个时原样传递。两种状态下都是数组按位置 diff，实例得以保留。

## 校验影响

无影响：
- change 校验由 FormItem 内部 `watch(fieldValue)` 驱动，与 children 结构无关；
- radio/checkbox/switch 等通过 `useFormItemContext` 的 `triggerChange/triggerBlur`（context 注入，不受影响）；
- 单子节点的 onBlur/onFocus/id/aria 注入逻辑原样保留；多子节点时这些 props 之前注入在 Fragment 上本就无效，行为等价，也与 React 一致。

## 测试

- 新增 `item-child-remount.test.tsx` 还原 issue 场景（修复前失败：setup 触发 2 次；修复后通过）
- form 全套 24 文件 165 测试通过；仓库全量 360 文件 4830 测试通过