### PR TITLE
fix(docs): prevent demo edit revert after http lazy-load

### DIFF
--- a/docs/plugins/markdown/demo/index.ts
+++ b/docs/plugins/markdown/demo/index.ts
@@ -337,9 +337,6 @@ const demoData = {
 
 if (import.meta.hot) {
   import.meta.hot.accept()
-  import.meta.hot.on('vite:beforeUpdate', () => {
-    sourceVersionRef.value = Date.now()
-  })
   import.meta.hot.on(${JSON.stringify(`demo-update:${normalizedFile}`)}, (data) => {
     if ('locales' in data) localesRef.value = data.locales
     if ('timestamp' in data) sourceVersionRef.value = data.timestamp

--- a/docs/src/components/code-demo/index.vue
+++ b/docs/src/components/code-demo/index.vue
@@ -228,6 +228,11 @@ watch(
   (version, previousVersion) => {
     if (version === previousVersion)
       return
+    // 如果用户正在编辑，暂缓重载，避免覆盖编辑内容
+    if (currentCode.value !== null || liveComponent.value !== null) {
+      sourceStale = true
+      return
+    }
     if (showCode.value) {
       releaseSource()
       void ensureSourceLoaded().catch(() => {})
@@ -251,8 +256,12 @@ watch(activeCodeType, () => {
   })
 })
 
-const handleCodeChange = useDebounceFn(async (newCode: string) => {
+function handleCodeChange(newCode: string) {
   currentCode.value = newCode
+  debouncedCompile(newCode)
+}
+
+const debouncedCompile = useDebounceFn(async (newCode: string) => {
   // 伴生文件 tab 不参与主 demo 的实时编译
   if (activeExtraFile.value)
     return
@@ -290,6 +299,11 @@ const sandpackActiveFile = computed(() => {
     return extraFileToSandpackPath(activeExtraFile.value.name)
   return '/src/App.vue'
 })
+
+const sandpackOptions = computed(() => ({
+  autorun: false,
+  activeFile: sandpackActiveFile.value,
+}))
 const active = computed(() => route.hash === `#${id.value}`)
 function handleScroll(e: Event) {
   e.preventDefault()
@@ -464,7 +478,7 @@ async function handleOpenPlayground() {
               template="vite-vue-ts"
               :files="sandpackFiles"
               :theme="sandpackTheme"
-              :options="{ autorun: false, activeFile: sandpackActiveFile }"
+              :options="sandpackOptions"
             >
               <CodeEditorBridge
                 ref="editorBridgeRef"

--- a/docs/src/components/code-demo/index.vue
+++ b/docs/src/components/code-demo/index.vue
@@ -256,11 +256,6 @@ watch(activeCodeType, () => {
   })
 })
 
-function handleCodeChange(newCode: string) {
-  currentCode.value = newCode
-  debouncedCompile(newCode)
-}
-
 const debouncedCompile = useDebounceFn(async (newCode: string) => {
   // 伴生文件 tab 不参与主 demo 的实时编译
   if (activeExtraFile.value)
@@ -280,6 +275,11 @@ const debouncedCompile = useDebounceFn(async (newCode: string) => {
     compileError.value = error
   }
 }, 300)
+
+function handleCodeChange(newCode: string) {
+  currentCode.value = newCode
+  debouncedCompile(newCode)
+}
 
 const sandpackTheme = computed(() => appStore.darkMode ? atomDark : aquaBlue)
 


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 🐞 Bug 修复
- [ ] 🆕 新功能
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进

### 🔗 相关 Issue

fix: docs demo http 懒加载后编辑 1s 后回退到原始代码

### 💡 背景与方案

**问题**：#lazy-load 改造后，`docs/src/components/code-demo/index.vue` 以及 `docs/plugins/markdown/demo/index.ts` 导致展开代码后编辑会 1s 后被重置。

**根因分析：**
1. `SandpackProvider` 的 `:options="{ autorun:false, activeFile }"` 为**内联对象**，每次渲染产生新引用，触发 `sandpack-vue3` 内部 `watch(e.options,e.files) -> a.files=p.files` 强制把内部文件系统重置为 `props.files` 原始源码，覆盖 `updateCurrentFile` 的编辑结果。懒加载前 `options` 为静态可提升，加入 `activeFile` 后变为动态必触发。
2. `demo` 插件对每个 demo 注入 `vite:beforeUpdate => sourceVersion=Date.now()`，任意文件 HMR 都会 bump 所有 demo 的 `sourceVersion`，触发 `releaseSource+ensureSourceLoaded` 重新拉取并重置 `files`。
3. `handleCodeChange` 整体被 `useDebounceFn(300)` 包裹，`currentCode` 延迟 300ms 置位，导致 `watch(sourceVersion)` 守卫在 300ms 窗口内失效。

**方案：**
- `docs/src/components/code-demo/index.vue`: `options` 抽为 `computed sandpackOptions` 稳定引用；`watch(sourceVersion)` 增加 `currentCode/liveComponent` 守卫，编辑中仅标记 `sourceStale`；`handleCodeChange` 拆为同步更新 `currentCode` + `debouncedCompile`。
- `docs/plugins/markdown/demo/index.ts`: 移除全局 `vite:beforeUpdate` 监听，仅保留 `demo-update:${file}` 精准更新。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | fix(docs): prevent demo code edit reverting after http lazy-load |
| 🇨🇳 中文 | fix(docs): 修复 demo http 懒加载后编辑 1s 后回退的问题 |

