### PR TITLE
fix(docs): isolate demo TS/JS toggle per demo instead of global sync

### DIFF
--- a/docs/src/components/code-demo/index.vue
+++ b/docs/src/components/code-demo/index.vue
@@ -104,15 +104,6 @@ const router = useRouter()
 const appStore = useAppStore()
 const { t } = useLocale()
 
-const codeType = computed<DemoCodeType>({
-  get() {
-    return appStore.demoCodeType
-  },
-  set(value) {
-    appStore.setDemoCodeType(value)
-  },
-})
-
 const hasJsSource = computed(() => {
   const jsSource = sourceData.value?.jsSource?.trim()
   return Boolean(jsSource)
@@ -129,19 +120,26 @@ const codeTabKeys = computed(() => {
   return keys
 })
 
-// 当前激活的代码 tab。ts/js 偏好持久化到全局 store，多文件 tab 仅作用于当前 demo。
+// ts/js 切换改为 demo 级别隔离：每个 Demo 实例维护独立的偏好，
+// 初始值取自全局 store 以保持刷新后持久化，切换时同步写回全局 store
+// 但不通过 computed 依赖全局状态，避免一个 demo 切换导致所有 demo 同步切换。
+const localTsJs = shallowRef<DemoCodeType>(appStore.demoCodeType)
 const localCodeKey = shallowRef<string | null>(null)
 
 const activeCodeType = computed<string>({
   get() {
-    const preferred = localCodeKey.value ?? codeType.value
+    if (localCodeKey.value && codeTabKeys.value.includes(localCodeKey.value))
+      return localCodeKey.value
+    const preferred = localTsJs.value
     if (codeTabKeys.value.includes(preferred))
       return preferred
     return 'ts'
   },
   set(value) {
     if (value === 'ts' || value === 'js') {
-      codeType.value = value
+      localTsJs.value = value
+      // 持久化到全局，供新挂载的 demo 或刷新后使用，但不触发已挂载 demo 的联动
+      appStore.setDemoCodeType(value)
       localCodeKey.value = null
     }
     else {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [ ] 🆕 New feature
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement

### 🔗 Related Issues

fix demo TS/JS toggle being global — switching one demo caused all demos to switch simultaneously.

### 💡 Background and Solution

**Problem:** `docs/src/components/code-demo/index.vue` used `computed` wrapping `appStore.demoCodeType` as `codeType`, and `activeCodeType` directly depended on it (`localCodeKey ?? codeType`). Toggling TS/JS in one demo called `appStore.setDemoCodeType()` which propagated reactively to every mounted `Demo` instance, making the switch global.

**Solution:**
- Replace global `computed codeType` with per-demo `localTsJs = shallowRef<DemoCodeType>(appStore.demoCodeType)` initialized from the global store for persistence.
- `activeCodeType.get` now prefers `localCodeKey` (extra file) then `localTsJs`, with `codeTabKeys` fallback to `ts`.
- `activeCodeType.set('ts'|'js')` updates `localTsJs` locally and persists via `appStore.setDemoCodeType(value)` **without** making other mounted demos reactively switch. Newly mounted demos / page reload still pick up the latest persisted preference from `localStorage`.

Isolates per demo while keeping cross-session persistence.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix docs demo TS/JS toggle from global sync to per-demo isolated state, persisting preference for newly mounted demos. |
| 🇨🇳 Chinese | 修复文档 Demo 的 TS/JS 切换为全局联动的问题，改为按 Demo 隔离，切换后仍持久化供新 Demo / 刷新后使用。 |