### PR TITLE
chore: bump @v-c/select to 1.2.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,8 +402,8 @@ catalogs:
       specifier: ^1.0.4
       version: 1.0.4
     '@v-c/select':
-      specifier: ^1.2.3
-      version: 1.2.3
+      specifier: ^1.2.4
+      version: 1.2.4
     '@v-c/slick':
       specifier: ^1.0.2
       version: 1.0.2
@@ -889,7 +889,7 @@ importers:
         version: 1.0.4(vue@3.5.40(typescript@5.9.3))
       '@v-c/select':
         specifier: catalog:vc
-        version: 1.2.3(vue@3.5.40(typescript@5.9.3))
+        version: 1.2.4(vue@3.5.40(typescript@5.9.3))
       '@v-c/slick':
         specifier: catalog:vc
         version: 1.0.2(vue@3.5.40(typescript@5.9.3))
@@ -1073,6 +1073,11 @@ packages:
 
   '@antdv-next/icons@1.1.1':
     resolution: {integrity: sha512-SiblayeqWLW58funYgNVR8FaVDKNCZIbgRT3kTWZEag+UnNUOhaHRFj675u84IHACtUpmyLfMLysVnmfAljttg==}
+    peerDependencies:
+      vue: '>=3.2.0'
+
+  '@antdv-next/icons@1.1.2':
+    resolution: {integrity: sha512-Ul4me4fx72VqA9xPYf9JVjlHq1PXO4JWGJGDtr9vPZfZYowFWDMjd7NeME1APYrJosVTMbJsArRMURbEGwbliA==}
     peerDependencies:
       vue: '>=3.2.0'
 
@@ -1894,12 +1899,12 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
-  '@napi-rs/wasm-runtime@1.2.2':
-    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     peerDependencies:
-      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
-      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3062,13 +3067,8 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/select@1.2.2':
-    resolution: {integrity: sha512-OjxRUfw8qe7uvAfVIJJiqFWAh4X7VFv6g+uY/F4yTOZPvdwut+JOeiaYqx7Eqe9ilDFVpzWNeEFDOSaWmLT1Cw==}
-    peerDependencies:
-      vue: ^3.0.0
-
-  '@v-c/select@1.2.3':
-    resolution: {integrity: sha512-CV2hvjYF4O7ldVkohXB3QtQsyk+BX4UYeLxWnlUiKFbaiR9tLEXPHICglkrsVDvsnE3eQYMnjXK1dcQw8p/NyQ==}
+  '@v-c/select@1.2.4':
+    resolution: {integrity: sha512-Mnk/EOpmRPvdXhXXzswdK/OR7dNIcOIUnhuEvY9jz/F9cuPL/GkeKo0rcf2gbpGlA2rVqeJH02PyUkLv0s/euA==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3919,6 +3919,9 @@ packages:
 
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
+  dayjs@1.11.23:
+    resolution: {integrity: sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -6832,6 +6835,13 @@ snapshots:
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
 
+  '@antdv-next/icons@1.1.2(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@ant-design/colors': 7.2.1
+      '@ant-design/icons-svg': 4.5.0
+      '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
+
   '@antdv-next/img-crop@0.0.2(antdv-next@1.3.7(vue@3.5.40(typescript@5.9.3)))(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@antdv-next/vue-easy-crop': 0.0.2(vue@3.5.40(typescript@5.9.3))
@@ -7852,7 +7862,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
@@ -8156,7 +8166,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -8725,7 +8735,7 @@ snapshots:
 
   '@v-c/cascader@1.1.2(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      '@v-c/select': 1.2.3(vue@3.5.40(typescript@5.9.3))
+      '@v-c/select': 1.2.4(vue@3.5.40(typescript@5.9.3))
       '@v-c/tree': 1.2.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
@@ -8840,6 +8850,16 @@ snapshots:
     optionalDependencies:
       dayjs: 1.11.21
 
+  '@v-c/picker@1.3.2(dayjs@1.11.23)(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@v-c/overflow': 1.1.1(vue@3.5.40(typescript@5.9.3))
+      '@v-c/resize-observer': 1.1.3(vue@3.5.40(typescript@5.9.3))
+      '@v-c/trigger': 1.1.0(vue@3.5.40(typescript@5.9.3))
+      '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
+    optionalDependencies:
+      dayjs: 1.11.23
+
   '@v-c/portal@1.0.8(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
@@ -8887,15 +8907,7 @@ snapshots:
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
 
-  '@v-c/select@1.2.2(vue@3.5.40(typescript@5.9.3))':
-    dependencies:
-      '@v-c/overflow': 1.1.1(vue@3.5.40(typescript@5.9.3))
-      '@v-c/trigger': 1.1.0(vue@3.5.40(typescript@5.9.3))
-      '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
-      '@v-c/virtual-list': 1.1.1(vue@3.5.40(typescript@5.9.3))
-      vue: 3.5.40(typescript@5.9.3)
-
-  '@v-c/select@1.2.3(vue@3.5.40(typescript@5.9.3))':
+  '@v-c/select@1.2.4(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.1.1(vue@3.5.40(typescript@5.9.3))
       '@v-c/trigger': 1.1.0(vue@3.5.40(typescript@5.9.3))
@@ -8962,7 +8974,7 @@ snapshots:
 
   '@v-c/tree-select@1.1.2(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      '@v-c/select': 1.2.3(vue@3.5.40(typescript@5.9.3))
+      '@v-c/select': 1.2.4(vue@3.5.40(typescript@5.9.3))
       '@v-c/tree': 1.2.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
@@ -9430,7 +9442,7 @@ snapshots:
       '@ant-design/colors': 8.0.1
       '@ant-design/fast-color': 3.0.1
       '@antdv-next/cssinjs': 1.0.6(vue@3.5.40(typescript@5.9.3))
-      '@antdv-next/icons': 1.1.1(vue@3.5.40(typescript@5.9.3))
+      '@antdv-next/icons': 1.1.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/async-validator': 1.0.1
       '@v-c/cascader': 1.1.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/checkbox': 1.0.1(vue@3.5.40(typescript@5.9.3))
@@ -9447,13 +9459,13 @@ snapshots:
       '@v-c/mutate-observer': 1.0.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/notification': 2.0.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/pagination': 1.1.1(vue@3.5.40(typescript@5.9.3))
-      '@v-c/picker': 1.3.2(dayjs@1.11.21)(vue@3.5.40(typescript@5.9.3))
+      '@v-c/picker': 1.3.2(dayjs@1.11.23)(vue@3.5.40(typescript@5.9.3))
       '@v-c/progress': 1.0.1(vue@3.5.40(typescript@5.9.3))
       '@v-c/qrcode': 1.0.1(vue@3.5.40(typescript@5.9.3))
       '@v-c/rate': 1.0.1(vue@3.5.40(typescript@5.9.3))
       '@v-c/resize-observer': 1.1.3(vue@3.5.40(typescript@5.9.3))
       '@v-c/segmented': 1.0.4(vue@3.5.40(typescript@5.9.3))
-      '@v-c/select': 1.2.2(vue@3.5.40(typescript@5.9.3))
+      '@v-c/select': 1.2.4(vue@3.5.40(typescript@5.9.3))
       '@v-c/slick': 1.0.2(vue@3.5.40(typescript@5.9.3))
       '@v-c/slider': 1.1.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/steps': 1.0.0(vue@3.5.40(typescript@5.9.3))
@@ -9470,7 +9482,7 @@ snapshots:
       '@v-c/util': 1.1.0(vue@3.5.40(typescript@5.9.3))
       '@v-c/virtual-list': 1.1.1(vue@3.5.40(typescript@5.9.3))
       '@vueuse/core': 14.4.0(vue@3.5.40(typescript@5.9.3))
-      dayjs: 1.11.21
+      dayjs: 1.11.23
       es-toolkit: 1.45.1
       scroll-into-view-if-needed: 3.1.0
       throttle-debounce: 5.0.2
@@ -9848,6 +9860,8 @@ snapshots:
       is-data-view: 1.0.2
 
   dayjs@1.11.21: {}
+
+  dayjs@1.11.23: {}
 
   debug@2.6.9:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -156,7 +156,7 @@ catalogs:
     '@v-c/rate': ^1.0.1
     '@v-c/resize-observer': ^1.1.3
     '@v-c/segmented': ^1.0.4
-    '@v-c/select': ^1.2.3
+    '@v-c/select': ^1.2.4
     '@v-c/slick': ^1.0.2
     '@v-c/slider': ^1.1.0
     '@v-c/steps': ^1.0.0


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [x] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

No related issue. Dependency maintenance upgrade.

### 💡 Background and Solution

Upgrade `@v-c/select` from `1.2.3` to `1.2.4` (`latest` dist-tag).

- Update `pnpm-workspace.yaml` `catalogs.vc[@v-c/select]`: `^1.2.3` → `^1.2.4`
- Sync `pnpm-lock.yaml` to `1.2.4` (`sha512-Mnk/EOpmRPvdXhXXzswdK/OR7dNIcOIUnhuEvY9jz/F9cuPL/GkeKo0rcf2gbpGlA2rVqeJH02PyUkLv0s/euA==`)
- Keep `packages/antdv-next/package.json` at `catalog:vc` (no specifier change)
- Verified with `pnpm install` and `pnpm -F antdv-next test select --run` (9 test files, 119 tests passed)

No API / breaking change adaptation required for `antdv-next` `Select` wrapper.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | chore: bump `@v-c/select` to `1.2.4` |
| 🇨🇳 Chinese | chore: 升级 `@v-c/select` 至 `1.2.4` |
