### PR TITLE
docs(select): add multiple fields search demo

### DIFF
--- a/docs/src/pages/components/select/demo/multiple-fields-search.vue
+++ b/docs/src/pages/components/select/demo/multiple-fields-search.vue
@@ -1,18 +1,12 @@
 <docs lang="zh-CN">
-使用 `optionFilterProp` 的多字段搜索，通过传入字符串数组可以对多个字段进行 OR 匹配搜索。
-例如搜索 `b11` 会同时匹配 `label` 和 `otherField` 字段。
+多字段搜索，使用 `showSearch.optionFilterProp` 传入数组对多个字段进行匹配。
 </docs>
 
 <docs lang="en-US">
-Multiple field search using `optionFilterProp`. By passing a string array, multiple fields are searched with OR matching.
-For example, searching `b11` will match both `label` and `otherField` fields.
+Multiple fields search with `showSearch.optionFilterProp` as array.
 </docs>
 
 <script setup lang="ts">
-import { shallowRef } from 'vue'
-
-const value = shallowRef<string>()
-
 const options = [
   { value: 'a11', label: 'a11', otherField: 'c11' },
   { value: 'b22', label: 'b22', otherField: 'b11' },
@@ -22,30 +16,10 @@ const options = [
 </script>
 
 <template>
-  <a-flex vertical gap="middle">
-    <div>
-      <div style="margin-bottom: 8px;">
-        通过 <code>showSearch</code> 对象传入（对齐 React API）：
-      </div>
-      <a-select
-        v-model:value="value"
-        placeholder="Select an option"
-        style="width: 200px"
-        :options="options"
-        :show-search="{ optionFilterProp: ['label', 'otherField'] }"
-      />
-    </div>
-    <div>
-      <div style="margin-bottom: 8px;">
-        通过顶层 <code>optionFilterProp</code> 传入：
-      </div>
-      <a-select
-        placeholder="Select an option"
-        style="width: 200px"
-        show-search
-        :option-filter-prop="['label', 'otherField']"
-        :options="options"
-      />
-    </div>
-  </a-flex>
+  <a-select
+    placeholder="Select an option"
+    style="width: 200px"
+    :show-search="{ optionFilterProp: ['label', 'otherField'] }"
+    :options="options"
+  />
 </template>

--- a/docs/src/pages/components/select/demo/multiple-fields-search.vue
+++ b/docs/src/pages/components/select/demo/multiple-fields-search.vue
@@ -1,9 +1,9 @@
 <docs lang="zh-CN">
-多字段搜索，使用 `showSearch.optionFilterProp` 传入数组对多个字段进行匹配。
+多字段搜索，使用 `optionFilterProp` 传入数组对多个字段进行匹配。
 </docs>
 
 <docs lang="en-US">
-Multiple fields search with `showSearch.optionFilterProp` as array.
+Multiple fields search with `optionFilterProp` as array.
 </docs>
 
 <script setup lang="ts">
@@ -18,7 +18,8 @@ const options = [
 <template>
   <a-select
     placeholder="Select an option"
-    :show-search="{ optionFilterProp: ['label', 'otherField'] }"
+    show-search
+    :option-filter-prop="['label', 'otherField']"
     :options="options"
   />
 </template>

--- a/docs/src/pages/components/select/demo/multiple-fields-search.vue
+++ b/docs/src/pages/components/select/demo/multiple-fields-search.vue
@@ -18,7 +18,6 @@ const options = [
 <template>
   <a-select
     placeholder="Select an option"
-    style="width: 200px"
     :show-search="{ optionFilterProp: ['label', 'otherField'] }"
     :options="options"
   />

--- a/docs/src/pages/components/select/demo/multiple-fields-search.vue
+++ b/docs/src/pages/components/select/demo/multiple-fields-search.vue
@@ -1,0 +1,51 @@
+<docs lang="zh-CN">
+使用 `optionFilterProp` 的多字段搜索，通过传入字符串数组可以对多个字段进行 OR 匹配搜索。
+例如搜索 `b11` 会同时匹配 `label` 和 `otherField` 字段。
+</docs>
+
+<docs lang="en-US">
+Multiple field search using `optionFilterProp`. By passing a string array, multiple fields are searched with OR matching.
+For example, searching `b11` will match both `label` and `otherField` fields.
+</docs>
+
+<script setup lang="ts">
+import { shallowRef } from 'vue'
+
+const value = shallowRef<string>()
+
+const options = [
+  { value: 'a11', label: 'a11', otherField: 'c11' },
+  { value: 'b22', label: 'b22', otherField: 'b11' },
+  { value: 'c33', label: 'c33', otherField: 'b33' },
+  { value: 'd44', label: 'd44', otherField: 'd44' },
+]
+</script>
+
+<template>
+  <a-flex vertical gap="middle">
+    <div>
+      <div style="margin-bottom: 8px;">
+        通过 <code>showSearch</code> 对象传入（对齐 React API）：
+      </div>
+      <a-select
+        v-model:value="value"
+        placeholder="Select an option"
+        style="width: 200px"
+        :options="options"
+        :show-search="{ optionFilterProp: ['label', 'otherField'] }"
+      />
+    </div>
+    <div>
+      <div style="margin-bottom: 8px;">
+        通过顶层 <code>optionFilterProp</code> 传入：
+      </div>
+      <a-select
+        placeholder="Select an option"
+        style="width: 200px"
+        show-search
+        :option-filter-prop="['label', 'otherField']"
+        :options="options"
+      />
+    </div>
+  </a-flex>
+</template>

--- a/docs/src/pages/components/select/index.en-US.md
+++ b/docs/src/pages/components/select/index.en-US.md
@@ -21,6 +21,7 @@ demo:
 <demo-group>
   <demo src="./demo/basic.vue">Basic Usage</demo>
   <demo src="./demo/search.vue">Select with search field</demo>
+  <demo src="./demo/multiple-fields-search.vue">Multiple fields search</demo>
   <demo src="./demo/search-filter-option.vue">Custom Search</demo>
   <demo src="./demo/multiple.vue">Multiple selection</demo>
   <demo src="./demo/size.vue">Sizes</demo>

--- a/docs/src/pages/components/select/index.zh-CN.md
+++ b/docs/src/pages/components/select/index.zh-CN.md
@@ -22,6 +22,7 @@ demo:
 <demo-group>
   <demo src="./demo/basic.vue">基本使用</demo>
   <demo src="./demo/search.vue">带搜索框</demo>
+  <demo src="./demo/multiple-fields-search.vue">多字段搜索</demo>
   <demo src="./demo/search-filter-option.vue">自定义搜索</demo>
   <demo src="./demo/multiple.vue">多选</demo>
   <demo src="./demo/size.vue">三种大小</demo>

--- a/packages/antdv-next/src/select/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/select/tests/__snapshots__/demo.test.tsx.snap
@@ -2771,6 +2771,68 @@ exports[`select demo > renders multiple correctly 1`] = `
 </div>
 `;
 
+exports[`select demo > renders multiple-fields-search correctly 1`] = `
+<div
+  data-v-app=""
+>
+  <!---->
+  <div
+    class="ant-select ant-select-outlined css-var-root ant-select-css-var ant-select-single ant-select-show-arrow ant-select-show-search"
+  >
+    <!---->
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-placeholder"
+      >
+        Select an option
+      </div>
+      <input
+        aria-autocomplete="list"
+        aria-controls="test-id_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="test-id_list"
+        autocomplete="new-password"
+        class="ant-select-input"
+        id="test-id"
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+      <!---->
+    </div>
+    <!---->
+    <!---->
+  </div>
+  <!---->
+</div>
+`;
+
 exports[`select demo > renders optgroup correctly 1`] = `
 <div
   data-v-app=""


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📽️ Demo improvement
- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

> - Align Select docs with upstream Ant Design React: multiple fields search demo (`optionFilterProp` as array).

### 💡 Background and Solution

- Add `docs/src/pages/components/select/demo/multiple-fields-search.vue` — demonstrates `optionFilterProp` accepting an array to filter by multiple option fields (`label`, `otherField`), strictly aligned with React implementation.
- Register demo in `docs/src/pages/components/select/index.en-US.md` and `index.zh-CN.md` after `search.vue` / `带搜索框`.
- Iteratively refined to remove custom styles and use direct `optionFilterProp` field to match upstream semantics 1:1.

Upstream reference: `ant-design/ant-design` Select `multiple-fields-search` demo.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | docs(select): add multiple fields search demo with `optionFilterProp` array |
| 🇨🇳 Chinese | docs(select): 新增多字段搜索示例，支持 `optionFilterProp` 数组 |
