### PR TITLE
fix(menu): stop padding transition during collapse

### DIFF
--- a/packages/antdv-next/src/menu/style/index.ts
+++ b/packages/antdv-next/src/menu/style/index.ts
@@ -429,7 +429,6 @@ const genMenuItemStyle: GenerateStyle<MenuToken, CSSObject> = (token) => {
       transition: [
         `border-color ${motionDurationSlow}`,
         `background-color ${motionDurationSlow}`,
-        `padding calc(${motionDurationSlow} + 0.1s) ${motionEaseInOut}`,
       ].join(','),
 
       [`${componentCls}-item-icon, ${iconCls}`]: {

--- a/packages/antdv-next/src/menu/tests/index.test.tsx
+++ b/packages/antdv-next/src/menu/tests/index.test.tsx
@@ -47,6 +47,23 @@ describe('menu', () => {
     expect(wrapper.text()).toContain('Navigation Two')
   })
 
+  it('does not animate item padding during inline collapse', () => {
+    mount(Menu, {
+      props: {
+        mode: 'inline',
+        inlineCollapsed: true,
+        items,
+      },
+    })
+
+    const menuStyles = Array.from(document.head.querySelectorAll('style'))
+      .map(style => style.textContent)
+      .filter(Boolean)
+      .join('\n')
+
+    expect(menuStyles).not.toContain('padding calc(')
+  })
+
   it('exposes Item/SubMenu/Divider static members', () => {
     expect(Menu.Item).toBe(MenuItem)
     expect(Menu.SubMenu).toBe(SubMenu)


### PR DESCRIPTION
## What
Remove the global menu-item `padding` transition.

## Why
When an inline `Menu` is hosted in a collapsible `Layout.Sider`, the sider width can reach its collapsed value before the menu-item padding animation finishes. This leaves icons moving briefly after the sider has stopped, producing a visible tail movement.

The inline-root menu rule already avoids animating padding; removing the global transition keeps the remaining menu-item motion from reintroducing the same effect through the broader selector. This follows the upstream Ant Design fix discussed in #59082.

## Test
- `pnpm exec vitest run packages/antdv-next/src/menu/tests/index.test.tsx --reporter=dot`
- `pnpm exec eslint packages/antdv-next/src/menu/style/index.ts packages/antdv-next/src/menu/tests/index.test.tsx`
- `git diff --check`
