### PR TITLE
fix(grid): clear stale row alignment classes (#59066)

### DIFF
--- a/packages/antdv-next/src/grid/row.tsx
+++ b/packages/antdv-next/src/grid/row.tsx
@@ -2,7 +2,7 @@ import type { App, CSSProperties, Ref } from 'vue'
 import type { Breakpoint, ScreenMap } from '../_util/responsiveObserver.ts'
 import { classNames } from '@v-c/util'
 import { getAttrStyleAndClass } from '@v-c/util/dist/props-util'
-import { computed, defineComponent, shallowRef, watch } from 'vue'
+import { computed, defineComponent } from 'vue'
 import { responsiveArray } from '../_util/responsiveObserver.ts'
 import { useConfig } from '../config-provider/context.ts'
 import { useBreakpoint } from './hooks/useBreakpoint.tsx'
@@ -40,37 +40,27 @@ function useMergedPropByScreen(
   oriProp: Ref<RowProps['align'] | RowProps['justify']>,
   screen: Ref<ScreenMap | null>,
 ) {
-  const prop = shallowRef(typeof oriProp.value === 'string' ? oriProp.value : '')
-  const calcMergedAlignOrJustify = () => {
-    if (typeof oriProp.value === 'string') {
-      prop.value = oriProp.value
+  return computed(() => {
+    const value = oriProp.value
+    if (typeof value === 'string') {
+      return value
     }
-    if (typeof oriProp.value !== 'object') {
-      return
-    }
-    for (let i = 0; i < responsiveArray.length; i++) {
-      const breakpoint: Breakpoint = responsiveArray[i]!
-      // if do not match, do nothing
-      if (!screen.value || !screen.value[breakpoint]) {
-        continue
-      }
-      const curVal = oriProp.value[breakpoint]
-      if (curVal !== undefined) {
-        prop.value = curVal
-        return
+
+    if (typeof value === 'object') {
+      for (let i = 0; i < responsiveArray.length; i++) {
+        const breakpoint: Breakpoint = responsiveArray[i]!
+        if (!screen.value || !screen.value[breakpoint]) {
+          continue
+        }
+        const curVal = value[breakpoint]
+        if (curVal !== undefined) {
+          return curVal
+        }
       }
     }
-  }
-  watch(
-    [() => JSON.stringify(oriProp.value), screen],
-    () => {
-      calcMergedAlignOrJustify()
-    },
-    {
-      immediate: true,
-    },
-  )
-  return prop
+
+    return ''
+  })
 }
 const defaults = {
   gutter: 0,

--- a/packages/antdv-next/src/grid/tests/Grid.test.tsx
+++ b/packages/antdv-next/src/grid/tests/Grid.test.tsx
@@ -197,6 +197,28 @@ describe('grid', () => {
 
     // ==================== dynamic props ====================
     describe('dynamic props', () => {
+      it('should clear align and justify when props are removed or no responsive value matches', async () => {
+        const wrapper = mount(Row, {
+          props: { align: 'middle', justify: 'center' },
+        })
+        expect(wrapper.find('.ant-row-middle').exists()).toBe(true)
+        expect(wrapper.find('.ant-row-center').exists()).toBe(true)
+
+        await wrapper.setProps({ align: undefined, justify: undefined })
+
+        expect(wrapper.find('.ant-row-middle').exists()).toBe(false)
+        expect(wrapper.find('.ant-row-center').exists()).toBe(false)
+
+        await wrapper.setProps({ align: { xs: 'middle' }, justify: { xs: 'center' } })
+        await nextTick()
+        expect(wrapper.find('.ant-row-middle').exists()).toBe(true)
+        expect(wrapper.find('.ant-row-center').exists()).toBe(true)
+
+        await wrapper.setProps({ align: {}, justify: {} })
+        expect(wrapper.find('.ant-row-middle').exists()).toBe(false)
+        expect(wrapper.find('.ant-row-center').exists()).toBe(false)
+      })
+
       it('should update justify class reactively', async () => {
         const justify = ref<'start' | 'end'>('start')
         const wrapper = mount(() => <Row justify={justify.value}>content</Row>)


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59066

## Summary

- Clear stale row alignment classes when Grid responsive alignment changes.
- Adapted to the Vue 3 implementation and repository conventions.

## Validation

- Grid tests: 80 passed
- Changed-file lint and diff checks passed.