### PR TITLE
fix(form): render numeric zero labels (#59079)

### DIFF
--- a/packages/antdv-next/src/form/FormItemLabel.tsx
+++ b/packages/antdv-next/src/form/FormItemLabel.tsx
@@ -8,6 +8,7 @@ import { clsx } from '@v-c/util'
 import { omit } from 'es-toolkit'
 import { defineComponent } from 'vue'
 import convertToTooltipProps from '../_util/convertToTooltipProps.ts'
+import { isRenderable } from '../_util/is.ts'
 import { getSlotPropsFnRun } from '../_util/tools.ts'
 import { Col } from '../grid'
 import defaultLocale from '../locale/en_US'
@@ -65,7 +66,7 @@ const FormItemLabel = defineComponent<
         tooltip: contextTooltip,
       } = formContext.value
       const label = getSlotPropsFnRun(slots, props, 'label')
-      if (!label) {
+      if (!isRenderable(label)) {
         return null
       }
       const mergedLabelCol: ColPropsWithClass = labelCol || contextLabelCol || {} as ColPropsWithClass

--- a/packages/antdv-next/src/form/tests/item-aria.test.tsx
+++ b/packages/antdv-next/src/form/tests/item-aria.test.tsx
@@ -11,6 +11,25 @@ async function flushForm() {
 }
 
 describe('formItem aria attributes', () => {
+  it('renders and associates a numeric zero label', async () => {
+    const wrapper = mount(defineComponent(() => () => (
+      <Form>
+        <FormItem name="field" label={0}>
+          <input />
+        </FormItem>
+      </Form>
+    )), { attachTo: document.body })
+
+    await flushForm()
+    const label = wrapper.find('label')
+    const input = wrapper.find('input')
+    expect(label.text()).toBe('0')
+    expect(label.attributes('for')).toBe('field')
+    expect(input.attributes('id')).toBe('field')
+
+    wrapper.unmount()
+  })
+
   it('sets aria-required when the required prop is set', async () => {
     const model = reactive({ username: '' })
 


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59079

## Summary

- Treat numeric zero as valid Form label content.
- Adapted to the Vue 3 implementation and repository conventions.

## Validation

- Form item aria tests: 8 passed
- Changed-file lint and diff checks passed.