### PR TITLE
fix(tag): prioritize local checkable tag styles (#59087)

### DIFF
--- a/packages/antdv-next/src/tag/CheckableTagGroup.tsx
+++ b/packages/antdv-next/src/tag/CheckableTagGroup.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'vue'
 import type { SemanticClassNames, SemanticStyles } from '../_util/hooks'
 import type { VueNode } from '../_util/type.ts'
 import type { ComponentBaseProps } from '../config-provider/context.ts'
@@ -14,6 +15,8 @@ export interface CheckableTagOption<CheckableTagValue = CheckableTagDefaultValue
   value: CheckableTagValue
   label: VueNode
   disabled?: boolean
+  class?: string
+  style?: CSSProperties
 }
 
 interface CheckableTagGroupSingleProps<CheckableTagValue = CheckableTagDefaultValue> {
@@ -150,8 +153,8 @@ const CheckableTagGroup = defineComponent<
           return (
             <CheckableTag
               key={option.value}
-              class={clsx(`${groupPrefixCls.value}-item`, mergedClassNames.value.item)}
-              style={mergedStyles.value.item}
+              class={clsx(`${groupPrefixCls.value}-item`, mergedClassNames.value.item, option.class)}
+              style={[mergedStyles.value.item, option.style]}
               checked={multiple ? (mergedValue.value as CheckableTagDefaultValue[] || []).includes(option.value) : mergedValue.value === option.value}
               onChange={(checked: boolean) => handleChange(checked, option)}
               disabled={option.disabled ?? disabled}

--- a/packages/antdv-next/src/tag/tests/Tag.semantic.test.tsx
+++ b/packages/antdv-next/src/tag/tests/Tag.semantic.test.tsx
@@ -1,7 +1,7 @@
 import type { TagProps } from '..'
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'vue'
-import Tag from '..'
+import Tag, { CheckableTagGroup } from '..'
 import ConfigProvider from '../../config-provider'
 import { mount } from '/@tests/utils'
 
@@ -185,6 +185,50 @@ describe('tag.semantic', () => {
         },
       })
       expect(wrapper.find(`.${prefixCls}`).attributes('style')).toContain('background: rgb(200, 200, 200)')
+    })
+
+    it('should prioritize local CheckableTag style over context style', () => {
+      const wrapper = mount({
+        render() {
+          return h(
+            ConfigProvider,
+            { tag: { style: { color: 'rgb(255, 0, 0)' } } },
+            {
+              default: () => h(
+                Tag.CheckableTag,
+                { checked: true, style: { color: 'rgb(0, 0, 255)' } },
+                { default: () => 'Bamboo' },
+              ),
+            },
+          )
+        },
+      })
+
+      expect(wrapper.find('.ant-tag-checkable').attributes('style')).toContain('color: rgb(0, 0, 255)')
+    })
+
+    it('should prioritize group item and option styles over context style', () => {
+      const wrapper = mount({
+        render() {
+          return h(
+            ConfigProvider,
+            { tag: { style: { color: 'rgb(255, 0, 0)' } } },
+            {
+              default: () => h(CheckableTagGroup, {
+                styles: { item: { color: 'rgb(0, 128, 0)' } },
+                options: [
+                  { label: 'Bamboo', value: 'bamboo' },
+                  { label: 'Little', value: 'little', style: { color: 'rgb(0, 0, 255)' } },
+                ],
+              }),
+            },
+          )
+        },
+      })
+
+      const items = wrapper.findAll('.ant-tag-checkable')
+      expect(items[0]!.attributes('style')).toContain('color: rgb(0, 128, 0)')
+      expect(items[1]!.attributes('style')).toContain('color: rgb(0, 0, 255)')
     })
 
     it('should apply ConfigProvider tag variant', () => {


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59087

## Summary

- Prioritize component-local CheckableTag semantic styles over inherited configuration.
- Adapted to the Vue 3 implementation and repository conventions.

## Validation

- Tag semantic tests: 14 passed
- Changed-file lint and diff checks passed.