### PR TITLE
fix(alert): restrict global closable type (#59100)

### DIFF
--- a/docs/src/pages/components/alert/index.en-US.md
+++ b/docs/src/pages/components/alert/index.en-US.md
@@ -42,7 +42,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | type | Type of Alert styles, options: `success`, `info`, `warning`, `error` | 'success' \| 'info' \| 'warning' \| 'error' | `info`, in `banner` mode default is `warning` | - | × |
-| closable | The config of closable, &gt;=5.15.0: support `aria-*` | ClosableType | `false` | - | ✓ |
+| closable | The config of closable | ClosableType | `false` | `closable.closeIcon`, `closable.aria-*`: 5.15.0 | ✓ |
 | title | Content of Alert | VueNode | - | - | × |
 | message | Content of Alert, please use `title` instead | VueNode | - | - | × |
 | description | Additional content of Alert | VueNode | - | - | × |

--- a/docs/src/pages/components/alert/index.zh-CN.md
+++ b/docs/src/pages/components/alert/index.zh-CN.md
@@ -43,7 +43,7 @@ group:
 | 属性 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | type | 指定警告提示的样式，有四种选择 `success`、`info`、`warning`、`error` | 'success' \| 'info' \| 'warning' \| 'error' | `info`，`banner` 模式下默认值为 `warning` | - | × |
-| closable | 可关闭配置，&gt;=5.15.0: 支持 `aria-*` | ClosableType | `false` | - | ✓ |
+| closable | 可关闭配置 | ClosableType | `false` | `closable.closeIcon`、`closable.aria-*`：5.15.0 | ✓ |
 | title | 警告提示内容 | VueNode | - | - | × |
 | message | 警告提示内容，请使用 `title` 替换 | VueNode | - | - | × |
 | description | 警告提示的辅助性文字介绍 | VueNode | - | - | × |

--- a/packages/antdv-next/src/config-provider/context.ts
+++ b/packages/antdv-next/src/config-provider/context.ts
@@ -1,6 +1,6 @@
 import type { DerivativeFunc } from '@antdv-next/cssinjs'
 import type { MoreProps as TabsMoreProps } from '@v-c/tabs'
-import type { CSSProperties, InjectionKey, Ref } from 'vue'
+import type { AriaAttributes, CSSProperties, InjectionKey, Ref } from 'vue'
 import type { MaskType } from '../_util/hooks'
 import type { AnyObject, VueNode } from '../_util/type.ts'
 import type { WarningContextProps } from '../_util/warning.ts'
@@ -252,7 +252,8 @@ export type ButtonConfig = ComponentStyleConfig
 
 export type FlexConfig = ComponentStyleConfig & Pick<FlexProps, 'vertical'>
 
-export type AlertConfig = ComponentStyleConfig & Pick<AlertProps, 'variant' | 'closable' | 'closeIcon' | 'classes' | 'styles'> & {
+export type AlertConfig = ComponentStyleConfig & Pick<AlertProps, 'variant' | 'closeIcon' | 'classes' | 'styles'> & {
+  closable?: boolean | ({ closeIcon?: VueNode } & AriaAttributes)
   successIcon?: VueNode
   infoIcon?: VueNode
   warningIcon?: VueNode

--- a/packages/antdv-next/src/config-provider/tests/type.test.tsx
+++ b/packages/antdv-next/src/config-provider/tests/type.test.tsx
@@ -16,6 +16,22 @@ type StylesOf<K extends keyof ConfigProviderProps> = NonNullable<ConfigProviderP
   ? T
   : never
 
+type AlertConfig = NonNullable<ConfigProviderProps['alert']>
+
+const validAlertConfigs: AlertConfig[] = [
+  { closable: true },
+  { closable: false },
+  { closable: {} },
+  { closable: { closeIcon: 'close', 'aria-label': 'Close alert' } },
+]
+
+const invalidAlertConfig: AlertConfig = {
+  closable: {
+    // @ts-expect-error ConfigProvider must not expose instance-only disabled state
+    disabled: true,
+  },
+}
+
 const classAssertions: [
   ExpectFalse<IsAny<ClassesOf<'anchor'>>>,
   ExpectFalse<IsAny<ClassesOf<'breadcrumb'>>>,
@@ -100,5 +116,7 @@ describe('config-provider.TypeScript', () => {
   it('semantic config entries should expose typed classes and styles', () => {
     expect(classAssertions).toHaveLength(18)
     expect(styleAssertions).toHaveLength(18)
+    expect(validAlertConfigs).toHaveLength(4)
+    expect(invalidAlertConfig).toBeDefined()
   })
 })


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59100

## Summary

- Restrict the ConfigProvider Alert closable option to the supported global configuration type.
- Adapted to the Vue 3 implementation and repository conventions.

## Validation

- ConfigProvider type test: 1 passed
- Changed-file lint and diff checks passed.