### PR TITLE
fix(steps): hide decorative panel arrows (#59105)

### DIFF
--- a/packages/antdv-next/src/steps/PanelArrow.tsx
+++ b/packages/antdv-next/src/steps/PanelArrow.tsx
@@ -9,12 +9,12 @@ const PanelArrow = defineComponent<PanelArrowProps>(
       const { prefixCls } = props
       return (
         <svg
+          aria-hidden="true"
           class={`${prefixCls}-panel-arrow`}
           viewBox="0 0 100 100"
           xmlns="http://www.w3.org/2000/svg"
           preserveAspectRatio="none"
         >
-          <title>Arrow</title>
           <path d="M 0 0 L 100 50 L 0 100" />
         </svg>
       )

--- a/packages/antdv-next/src/steps/tests/PanelArrow.test.tsx
+++ b/packages/antdv-next/src/steps/tests/PanelArrow.test.tsx
@@ -33,6 +33,16 @@ describe('panelArrow', () => {
     expect(wrapper.find('path').attributes('d')).toBe('M 0 0 L 100 50 L 0 100')
   })
 
+  it('should hide the decorative arrow from assistive technology', () => {
+    const wrapper = mount(PanelArrow, {
+      props: { prefixCls: 'ant-steps' },
+    })
+    const svg = wrapper.find('svg')
+
+    expect(svg.attributes('aria-hidden')).toBe('true')
+    expect(svg.find('title').exists()).toBe(false)
+  })
+
   it('should apply custom prefixCls', () => {
     const wrapper = mount(PanelArrow, {
       props: {

--- a/packages/antdv-next/src/steps/tests/__snapshots__/PanelArrow.test.tsx.snap
+++ b/packages/antdv-next/src/steps/tests/__snapshots__/PanelArrow.test.tsx.snap
@@ -2,14 +2,12 @@
 
 exports[`panelArrow > should match snapshot 1`] = `
 <svg
+  aria-hidden="true"
   class="ant-steps-panel-arrow"
   preserveAspectRatio="none"
   viewBox="0 0 100 100"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <title>
-    Arrow
-  </title>
   <path
     d="M 0 0 L 100 50 L 0 100"
   />

--- a/packages/antdv-next/src/steps/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/steps/tests/__snapshots__/demo.test.tsx.snap
@@ -242,14 +242,12 @@ exports[`steps demo > renders _semantic correctly 1`] = `
               </div>
             </div>
             <svg
+              aria-hidden="true"
               class="ant-steps-panel-arrow"
               preserveAspectRatio="none"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title>
-                Arrow
-              </title>
               <path
                 d="M 0 0 L 100 50 L 0 100"
               />
@@ -301,14 +299,12 @@ exports[`steps demo > renders _semantic correctly 1`] = `
               </div>
             </div>
             <svg
+              aria-hidden="true"
               class="ant-steps-panel-arrow"
               preserveAspectRatio="none"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title>
-                Arrow
-              </title>
               <path
                 d="M 0 0 L 100 50 L 0 100"
               />
@@ -358,14 +354,12 @@ exports[`steps demo > renders _semantic correctly 1`] = `
               </div>
             </div>
             <svg
+              aria-hidden="true"
               class="ant-steps-panel-arrow"
               preserveAspectRatio="none"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title>
-                Arrow
-              </title>
               <path
                 d="M 0 0 L 100 50 L 0 100"
               />
@@ -4647,14 +4641,12 @@ exports[`steps demo > renders panel correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -4715,14 +4707,12 @@ exports[`steps demo > renders panel correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -4767,14 +4757,12 @@ exports[`steps demo > renders panel correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -4834,14 +4822,12 @@ exports[`steps demo > renders panel correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -4902,14 +4888,12 @@ exports[`steps demo > renders panel correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -4954,14 +4938,12 @@ exports[`steps demo > renders panel correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59105

## Summary

- Hide decorative Steps panel arrows from assistive technology.
- Adapted to the Vue 3 implementation and repository conventions.

## Validation

- PanelArrow tests: 6 passed
- Changed-file lint and diff checks passed.