### PR TITLE
fix(checkbox): let group override global disabled (#59109)

### DIFF
--- a/packages/antdv-next/src/checkbox/Checkbox.tsx
+++ b/packages/antdv-next/src/checkbox/Checkbox.tsx
@@ -132,7 +132,7 @@ const InternalCheckbox = defineComponent<
     const formItemInputContext = useFormItemInputContext()
     const formItemContext = useFormItemContext()
     const contextDisabled = useDisabledContext()
-    const mergedDisabled = computed(() => (checkboxGroup?.value?.disabled || props?.disabled) ?? contextDisabled.value)
+    const mergedDisabled = computed(() => props.disabled ?? checkboxGroup?.value?.disabled ?? contextDisabled.value)
 
     // ===================== Checked Value =====================
     // 获取选中和非选中的值，默认为 true/false

--- a/packages/antdv-next/src/checkbox/tests/Checkbox.test.tsx
+++ b/packages/antdv-next/src/checkbox/tests/Checkbox.test.tsx
@@ -328,6 +328,18 @@ describe('checkboxGroup', () => {
     expect(disabledItems.length).toBe(3)
   })
 
+  it('should let an enabled group override global disabled context', () => {
+    const wrapper = mount(() => (
+      <ConfigProvider componentDisabled>
+        <CheckboxGroup disabled={false}>
+          <Checkbox value="Apple" />
+        </CheckboxGroup>
+      </ConfigProvider>
+    ))
+
+    expect((wrapper.find('input[type="checkbox"]').element as HTMLInputElement).disabled).toBe(false)
+  })
+
   it('should support individual option disabled', () => {
     const wrapper = mount(CheckboxGroup, {
       props: {

--- a/packages/antdv-next/src/checkbox/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/checkbox/tests/__snapshots__/demo.test.tsx.snap
@@ -837,14 +837,13 @@ exports[`checkbox demo > renders group correctly 1`] = `
       </span>
     </label>
     <label
-      class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-group-item css-var-root ant-checkbox-css-var"
+      class="ant-checkbox-wrapper ant-checkbox-group-item css-var-root ant-checkbox-css-var"
     >
       <span
-        class="ant-checkbox ant-wave-target ant-checkbox-disabled ant-wave-target"
+        class="ant-checkbox ant-wave-target ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
-          disabled=""
           type="checkbox"
         />
       </span>


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59109

## Summary

- Allow CheckboxGroup disabled state to override the global disabled context.
- Adapted to the Vue 3 implementation and repository conventions.

## Validation

- Checkbox tests: 42 passed
- Changed-file lint and diff checks passed.