### PR TITLE
fix: render numeric zero content nodes (#59117)

### DIFF
--- a/packages/antdv-next/src/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/antdv-next/src/breadcrumb/BreadcrumbItem.tsx
@@ -6,6 +6,7 @@ import type { ItemType } from './Breadcrumb'
 import { clsx } from '@v-c/util'
 import { filterEmpty } from '@v-c/util/dist/props-util'
 import { defineComponent } from 'vue'
+import { isRenderable } from '../_util/is'
 import isNonNullable from '../_util/isNonNullable'
 import { getSlotPropsFnRun } from '../_util/tools'
 import { checkRenderNode } from '../_util/vueNode'
@@ -102,7 +103,7 @@ export const InternalBreadcrumbItem = defineComponent<
             <li class={clsx(`${prefixCls}-item`, mergedClassNames?.item)} style={mergedStyles?.item}>
               {link}
             </li>
-            {!!separator && <BreadcrumbSeparator>{separator}</BreadcrumbSeparator>}
+            {isRenderable(separator) && <BreadcrumbSeparator>{separator}</BreadcrumbSeparator>}
           </>
         )
       }

--- a/packages/antdv-next/src/breadcrumb/tests/Breadcrumb.test.tsx
+++ b/packages/antdv-next/src/breadcrumb/tests/Breadcrumb.test.tsx
@@ -48,6 +48,17 @@ describe('breadcrumb', () => {
     expect(wrapper.find('.ant-breadcrumb-separator').text()).toBe('>')
   })
 
+  it('should render numeric zero separator', () => {
+    const wrapper = mount(Breadcrumb, {
+      props: {
+        separator: 0,
+        items: [{ title: 'foo' }, { title: 'bar' }],
+      },
+    })
+
+    expect(wrapper.find('.ant-breadcrumb-separator').text()).toBe('0')
+  })
+
   it('should render item with href as link', () => {
     const wrapper = mount(Breadcrumb, {
       props: {

--- a/packages/antdv-next/src/card/Card.tsx
+++ b/packages/antdv-next/src/card/Card.tsx
@@ -7,6 +7,7 @@ import { clsx } from '@v-c/util'
 import { filterEmpty } from '@v-c/util/dist/props-util'
 import { computed, defineComponent, isVNode } from 'vue'
 import { getAttrStyleAndClass, useMergeSemantic, useSemanticRootStyle, useToArr, useToProps } from '../_util/hooks'
+import { isRenderable } from '../_util/is'
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools'
 import { devUseWarning, isDev } from '../_util/warning'
 import { useComponentBaseConfig } from '../config-provider/context'
@@ -260,7 +261,7 @@ const Card = defineComponent<
             />
           )
         : null
-      if (title || extra || tabs) {
+      if (isRenderable(title) || isRenderable(extra) || tabs) {
         const headClasses = clsx(`${prefixCls.value}-head`, mergedClassNames.value.header)
         const titleClasses = clsx(`${prefixCls.value}-head-title`, mergedClassNames.value.title)
         const extraClasses = clsx(`${prefixCls.value}-extra`, mergedClassNames.value.extra)
@@ -271,12 +272,12 @@ const Card = defineComponent<
         head = (
           <div class={headClasses} style={mergedHeadStyle}>
             <div class={`${prefixCls.value}-head-wrapper`}>
-              {!!title && (
+              {isRenderable(title) && (
                 <div class={titleClasses} style={mergedStyles.value.title}>
                   {title}
                 </div>
               )}
-              {!!extra && (
+              {isRenderable(extra) && (
                 <div class={extraClasses} style={mergedStyles.value.extra}>
                   {extra}
                 </div>
@@ -288,7 +289,7 @@ const Card = defineComponent<
       }
       const coverClasses = clsx(`${prefixCls.value}-cover`, mergedClassNames.value.cover)
 
-      const coverDom = cover
+      const coverDom = isRenderable(cover)
         ? (
             <div class={coverClasses} style={mergedStyles.value.cover}>{cover}</div>
           )

--- a/packages/antdv-next/src/card/CardMeta.tsx
+++ b/packages/antdv-next/src/card/CardMeta.tsx
@@ -4,6 +4,7 @@ import type { EmptyEmit, VueNode } from '../_util/type.ts'
 import { clsx } from '@v-c/util'
 import { computed, defineComponent, shallowRef } from 'vue'
 import { getAttrStyleAndClass, useMergeSemantic, useSemanticRootStyle, useToArr, useToProps } from '../_util/hooks'
+import { isRenderable } from '../_util/is'
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools.ts'
 import { useComponentBaseConfig } from '../config-provider/context.ts'
 
@@ -105,19 +106,19 @@ const CardMeta = defineComponent<
       const avatar = getSlotPropsFnRun(slots, props, 'avatar')
       const title = getSlotPropsFnRun(slots, props, 'title')
       const description = getSlotPropsFnRun(slots, props, 'description')
-      const avatarDom = avatar
+      const avatarDom = isRenderable(avatar)
         ? (
             <div class={avatarClassNames} style={mergedStyles.value.avatar}>{avatar}</div>
           )
         : null
 
-      const titleDom = title
+      const titleDom = isRenderable(title)
         ? (
             <div class={titleClassNames} style={mergedStyles.value.title}>{title}</div>
           )
         : null
 
-      const descriptionDom = description
+      const descriptionDom = isRenderable(description)
         ? (
             <div class={descriptionClassNames} style={mergedStyles.value.description}>{description}</div>
           )

--- a/packages/antdv-next/src/card/tests/Card.test.tsx
+++ b/packages/antdv-next/src/card/tests/Card.test.tsx
@@ -304,6 +304,16 @@ describe('card', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('should render numeric zero for title, extra, and cover', () => {
+    const wrapper = mount(Card, {
+      props: { title: 0, extra: 0, cover: 0 },
+    })
+
+    expect(wrapper.find('.ant-card-head-title').text()).toBe('0')
+    expect(wrapper.find('.ant-card-extra').text()).toBe('0')
+    expect(wrapper.find('.ant-card-cover').text()).toBe('0')
+  })
+
   it('should match snapshot - loading', () => {
     const wrapper = mount(() => (
       <Card title="Card Title" loading>

--- a/packages/antdv-next/src/card/tests/CardMeta.test.tsx
+++ b/packages/antdv-next/src/card/tests/CardMeta.test.tsx
@@ -66,6 +66,16 @@ describe('cardMeta', () => {
     expect(wrapper.find('.ant-card-meta-section').exists()).toBe(false)
   })
 
+  it('should render numeric zero for avatar, title, and description', () => {
+    const wrapper = mount(CardMeta, {
+      props: { avatar: 0, title: 0, description: 0 },
+    })
+
+    expect(wrapper.find('.ant-card-meta-avatar').text()).toBe('0')
+    expect(wrapper.find('.ant-card-meta-title').text()).toBe('0')
+    expect(wrapper.find('.ant-card-meta-description').text()).toBe('0')
+  })
+
   it('should match snapshot', () => {
     const wrapper = mount(() => (
       <CardMeta

--- a/packages/antdv-next/src/float-button/FloatButton.tsx
+++ b/packages/antdv-next/src/float-button/FloatButton.tsx
@@ -13,6 +13,7 @@ import { omit } from 'es-toolkit/compat'
 import { computed, defineComponent, shallowRef } from 'vue'
 import convertToTooltipProps from '../_util/convertToTooltipProps'
 import { pureAttrs, useMergeSemantic, useToArr, useToProps, useZIndex } from '../_util/hooks'
+import { isRenderable } from '../_util/is'
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools'
 import Badge from '../badge'
 import Button from '../button'
@@ -172,7 +173,7 @@ const InternalFloatButton = defineComponent<
 
       const hasContent = Array.isArray(contentNodes)
         ? contentNodes.length > 0
-        : contentNodes !== null && contentNodes !== undefined && contentNodes !== false
+        : isRenderable(contentNodes)
 
       const iconNode = getSlotPropsFnRun(slots, props, 'icon')
       const mergedIcon = iconNode ?? props.icon ?? (!hasContent ? <FileTextOutlined /> : null)

--- a/packages/antdv-next/src/float-button/tests/FloatButton.test.tsx
+++ b/packages/antdv-next/src/float-button/tests/FloatButton.test.tsx
@@ -87,6 +87,16 @@ describe('floatButton', () => {
     expect(wrapper.find('.ant-float-btn-icon-only').exists()).toBe(false)
   })
 
+  it('should render numeric zero content without fallback icon', () => {
+    const wrapper = mount(FloatButton, {
+      props: { content: 0, shape: 'square' },
+    })
+
+    expect(wrapper.find('.ant-float-btn-icon-only').exists()).toBe(false)
+    expect(wrapper.find('.anticon-file-text').exists()).toBe(false)
+    expect(wrapper.text()).toContain('0')
+  })
+
   it('should render content via default slot', () => {
     const wrapper = mount(FloatButton, {
       slots: { default: () => 'Slot Content' },

--- a/packages/antdv-next/src/segmented/index.tsx
+++ b/packages/antdv-next/src/segmented/index.tsx
@@ -14,6 +14,7 @@ import { clsx } from '@v-c/util'
 import { filterEmpty, removeUndefined } from '@v-c/util/dist/props-util'
 import { computed, defineComponent, useId } from 'vue'
 import { pureAttrs, useMergeSemantic, useOrientation, useSemanticRootStyle, useToArr, useToProps } from '../_util/hooks'
+import { isRenderable } from '../_util/is.ts'
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools.ts'
 import { useComponentBaseConfig } from '../config-provider/context.ts'
 import { useSize } from '../config-provider/hooks/useSize.ts'
@@ -168,7 +169,7 @@ const InternalSegmented = defineComponent<
         if (hasIcon || hasCustomLabel) {
           const { label, icon: _icon, ...restOption } = _option as SegmentedLabeledOptionWithIcon
           const mergedLabel = labelFromSlot.length > 0 ? labelFromSlot : label
-          const showLabel = !!(labelFromSlot.length > 0) || !!label
+          const showLabel = labelFromSlot.length > 0 || isRenderable(label)
           const icon = getSlotPropsFnRun({}, option, 'icon') ?? iconFromSlot
           return {
             ...restOption,

--- a/packages/antdv-next/src/segmented/tests/Segmented.test.tsx
+++ b/packages/antdv-next/src/segmented/tests/Segmented.test.tsx
@@ -561,6 +561,21 @@ describe('segmented', () => {
   // ===================== Snapshot =====================
 
   describe('snapshot', () => {
+    it('should render numeric zero label when icon is configured', () => {
+      const wrapper = mount(Segmented, {
+        props: {
+          options: [
+            { icon: h('span', { class: 'zero-icon' }), label: 0, value: 'zero' },
+            { label: 'one', value: 'one' },
+          ],
+        },
+      })
+
+      const firstLabel = wrapper.find(`.${prefixCls}-item-label`)
+      expect(firstLabel.text()).toContain('0')
+      expect(firstLabel.findAll('span').at(-1)?.text()).toBe('0')
+    })
+
     it('should match snapshot with various options', () => {
       const wrapper = mount(Segmented, {
         props: {

--- a/packages/antdv-next/src/tag/index.tsx
+++ b/packages/antdv-next/src/tag/index.tsx
@@ -10,6 +10,7 @@ import { filterEmpty } from '@v-c/util/dist/props-util'
 import { computed, createVNode, defineComponent, shallowRef } from 'vue'
 import { pureAttrs, useMergeSemantic, useSemanticRootStyle, useToArr, useToProps } from '../_util/hooks'
 import useClosable, { pickClosable } from '../_util/hooks/useClosable.tsx'
+import { isRenderable } from '../_util/is.ts'
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools.ts'
 import { replaceElement } from '../_util/vueNode.ts'
 import Wave from '../_util/wave'
@@ -255,7 +256,7 @@ const InternalTag = defineComponent<
         ? (
             <>
               {iconNodes}
-              {children && (
+              {isRenderable(children) && (
                 <span
                   class={mergedClassNames.value.content}
                   style={mergedStyles.value.content}

--- a/packages/antdv-next/src/tag/tests/Tag.test.tsx
+++ b/packages/antdv-next/src/tag/tests/Tag.test.tsx
@@ -47,6 +47,18 @@ describe('tag', () => {
     expect(a.attributes('target')).toBe('_blank')
   })
 
+  it('should render numeric zero inside content span when icon is present', () => {
+    const wrapper = mount(Tag, {
+      slots: {
+        icon: () => h('span', { class: 'my-icon' }),
+        default: () => 0,
+      },
+    })
+
+    expect(wrapper.find('.ant-tag').text()).toContain('0')
+    expect(wrapper.findAll('.ant-tag > span').at(-1)?.text()).toBe('0')
+  })
+
   // ===================== color prop =====================
 
   it('should apply preset color class', () => {


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59117

## Summary

- Render numeric zero consistently in content slots across affected components.
- Adapted to the Vue 3 implementation and repository conventions.

## Validation

- Targeted Card, Breadcrumb, Segmented, FloatButton, and Tag tests: 266 passed
- Changed-file lint and diff checks passed.