### PR TITLE
fix(transfer): disable select all for disabled search results (#59121)

### DIFF
--- a/packages/antdv-next/src/transfer/Section.tsx
+++ b/packages/antdv-next/src/transfer/Section.tsx
@@ -238,7 +238,7 @@ const TransferSection = defineComponent<
     return () => {
       const checkBox = (
         <Checkbox
-          disabled={!dataSource.value.some(d => !d.disabled) || props.disabled}
+          disabled={!filteredItems.value.filterItems.some(d => !d.disabled) || props.disabled}
           checked={checkStatus.value === 'all'}
           indeterminate={checkStatus.value === 'part'}
           class={`${listPrefixCls.value}-checkbox`}

--- a/packages/antdv-next/src/transfer/tests/index.test.tsx
+++ b/packages/antdv-next/src/transfer/tests/index.test.tsx
@@ -464,6 +464,30 @@ describe('transfer', () => {
     expect(wrapper.text()).toContain('1 item')
   })
 
+  it('should disable select all when filtered items are all disabled', async () => {
+    const wrapper = mount(Transfer, {
+      props: {
+        dataSource: [
+          { key: 'enabled', title: 'Enabled item' },
+          { key: 'disabled', title: 'Disabled item', disabled: true },
+        ],
+        selectedKeys: [],
+        targetKeys: [],
+        showSearch: true,
+        render: item => item.title,
+      },
+    })
+
+    const sourceSection = wrapper.element.querySelectorAll('.ant-transfer-section')[0]
+    const searchInput = sourceSection?.querySelector('input[type="text"]') as HTMLInputElement
+    await setInputValue(searchInput, 'Disabled item')
+
+    const selectAll = sourceSection?.querySelector(
+      '.ant-transfer-list-header input[type="checkbox"]',
+    ) as HTMLInputElement
+    expect(selectAll.disabled).toBe(true)
+  })
+
   it('should display the correct locale', () => {
     const emptyProps = { dataSource: [], selectedKeys: [], targetKeys: [] }
     const locale = { itemUnit: 'Person', notFoundContent: 'Nothing', searchPlaceholder: 'Search' }


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59121

## Summary

- Disable Transfer select-all when every visible search result is disabled.
- Adapted to the Vue 3 implementation and repository conventions.

## Validation

- Transfer tests: 53 passed
- Changed-file lint and diff checks passed.