### PR TITLE
fix(upload): avoid canvas leak for GIF previews (#59137)

### DIFF
--- a/packages/antdv-next/src/upload/tests/uploadlist.test.tsx
+++ b/packages/antdv-next/src/upload/tests/uploadlist.test.tsx
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { nextTick } from 'vue'
 import Upload from '..'
 import ConfigProvider from '../../config-provider'
+import { previewImage } from '../utils'
 import { setup, teardown } from './mock'
 import { errorRequest, successRequest } from './requests'
 
@@ -608,5 +609,16 @@ describe('upload List', () => {
         expect((width > height ? offsetX : offsetY) === 0).toBeTruthy()
       })
     })
+  })
+
+  it('should not leave a canvas after generating a GIF preview', async () => {
+    const mockFile = new File([''], 'foo.gif', { type: 'image/gif' })
+    const canvasCount = document.body.querySelectorAll('canvas').length
+
+    const preview = previewImage(mockFile)
+    await vi.runAllTimersAsync()
+    await preview
+
+    expect(document.body.querySelectorAll('canvas')).toHaveLength(canvasCount)
   })
 })

--- a/packages/antdv-next/src/upload/utils.ts
+++ b/packages/antdv-next/src/upload/utils.ts
@@ -84,6 +84,16 @@ export function previewImage(file: File | Blob): Promise<string> {
       resolve('')
       return
     }
+    if (file.type.startsWith('image/gif')) {
+      const reader = new FileReader()
+      reader.onload = () => {
+        if (reader.result) {
+          resolve(reader.result as string)
+        }
+      }
+      reader.readAsDataURL(file)
+      return
+    }
     const canvas = document.createElement('canvas')
     canvas.width = MEASURE_SIZE
     canvas.height = MEASURE_SIZE
@@ -120,15 +130,6 @@ export function previewImage(file: File | Blob): Promise<string> {
       reader.onload = () => {
         if (reader.result && typeof reader.result === 'string') {
           img.src = reader.result
-        }
-      }
-      reader.readAsDataURL(file)
-    }
-    else if (file.type.startsWith('image/gif')) {
-      const reader = new FileReader()
-      reader.onload = () => {
-        if (reader.result) {
-          resolve(reader.result as string)
         }
       }
       reader.readAsDataURL(file)


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59137

## Summary

- Clean up the temporary canvas used while generating GIF upload previews.
- Adapted to the Vue 3 implementation and repository conventions.

## Validation

- UploadList tests: 21 passed
- Changed-file lint and diff checks passed.