### PR TITLE
fix(select): exclude internal popup visibility callback (#59142)

### DIFF
--- a/packages/antdv-next/src/auto-complete/index.tsx
+++ b/packages/antdv-next/src/auto-complete/index.tsx
@@ -16,7 +16,7 @@ import { clsx } from '@v-c/util'
 import { filterEmpty } from '@v-c/util/dist/props-util'
 import { omit } from 'es-toolkit'
 import { toArray } from 'es-toolkit/compat'
-import { computed, defineComponent, isVNode, Text } from 'vue'
+import { computed, defineComponent, getCurrentInstance, isVNode, Text } from 'vue'
 import { getAttrStyleAndClass, useMergeSemantic, useToArr, useToProps } from '../_util/hooks'
 import genPurePanel from '../_util/PurePanel.tsx'
 import { toPropsRefs } from '../_util/tools'
@@ -76,7 +76,6 @@ type RcEventKeys
     | 'onMouseEnter'
     | 'onFocus'
     | 'onPopupScroll'
-    | 'onPopupVisibleChange'
     | 'onSelect'
     | 'onSearch'
 
@@ -187,6 +186,8 @@ const omitKeys: (keyof AutoCompleteProps)[] = [
   'classes',
   'styles',
   'popupRender',
+  'onOpenChange',
+  'onDropdownVisibleChange',
 ]
 
 const InternalAutoComplete = defineComponent<
@@ -198,6 +199,16 @@ const InternalAutoComplete = defineComponent<
   (props, { slots, emit, attrs }) => {
     const { prefixCls } = useComponentBaseConfig('select', props)
     const { classes, styles } = toPropsRefs(props, 'classes', 'styles')
+    const instance = getCurrentInstance()
+
+    const mergedOnOpenChange = (open: boolean) => {
+      if (instance?.vnode.props?.onOpenChange) {
+        emit('openChange', open)
+      }
+      else {
+        emit('dropdownVisibleChange', open)
+      }
+    }
 
     const mergedProps = computed(() => {
       return {
@@ -224,6 +235,7 @@ const InternalAutoComplete = defineComponent<
 
     return () => {
       const { className, style, restAttrs } = getAttrStyleAndClass(attrs)
+      const forwardedAttrs = omit(restAttrs, ['onOpenChange', 'onDropdownVisibleChange'])
       const childNodes = toArray(filterEmpty(slots.default?.() ?? []))
       const hasSelectOptions = !!childNodes.length && isSelectOptionOrSelectOptGroup(childNodes[0])
 
@@ -394,18 +406,12 @@ const InternalAutoComplete = defineComponent<
         onSearch: (value: any) => {
           emit('search', value)
         },
-        onOpenChange: (open: boolean) => {
-          emit('openChange', open)
-        },
-        onDropdownVisibleChange: (open: boolean) => {
-          emit('dropdownVisibleChange', open)
-        },
       }
 
       const inputProps = getInputElement ? ({ getInputElement } as any) : {}
       return (
         <Select
-          {...restAttrs}
+          {...forwardedAttrs}
           {...selectProps}
           {...onAttrs}
           {...inputProps}
@@ -418,6 +424,7 @@ const InternalAutoComplete = defineComponent<
           popupMatchSelectWidth={mergedPopupMatchSelectWidth}
           mode={(Select as any).SECRET_COMBOBOX_MODE_DO_NOT_USE as SelectProps['mode']}
           suffixIcon={null}
+          onOpenChange={mergedOnOpenChange}
           {...{
             'onUpdate:value': (value: any) => emit('update:value', value),
           }}

--- a/packages/antdv-next/src/auto-complete/tests/AutoComplete.test.tsx
+++ b/packages/antdv-next/src/auto-complete/tests/AutoComplete.test.tsx
@@ -76,6 +76,47 @@ describe('autoComplete', () => {
     expect(onSearch).toHaveBeenCalledWith('test')
   })
 
+  it('should prefer onOpenChange over deprecated onDropdownVisibleChange', async () => {
+    const onOpenChange = vi.fn()
+    const onDropdownVisibleChange = vi.fn()
+    const wrapper = mount(AutoComplete, {
+      props: {
+        options: [{ value: 'test' }],
+        onOpenChange,
+        onDropdownVisibleChange,
+      },
+      attachTo: document.body,
+    })
+
+    await wrapper.find('.ant-select-content').trigger('mousedown')
+    await nextTick()
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1)
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+    expect(onDropdownVisibleChange).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('should fall back to deprecated onDropdownVisibleChange', async () => {
+    const onDropdownVisibleChange = vi.fn()
+    const wrapper = mount(AutoComplete, {
+      props: {
+        options: [{ value: 'test' }],
+        onDropdownVisibleChange,
+      },
+      attachTo: document.body,
+    })
+
+    await wrapper.find('.ant-select-content').trigger('mousedown')
+    await nextTick()
+
+    expect(onDropdownVisibleChange).toHaveBeenCalledTimes(1)
+    expect(onDropdownVisibleChange).toHaveBeenCalledWith(true)
+
+    wrapper.unmount()
+  })
+
   it('should trigger onSelect when option is selected', async () => {
     const onSelect = vi.fn()
     const value = ref('')

--- a/packages/antdv-next/src/select/index.tsx
+++ b/packages/antdv-next/src/select/index.tsx
@@ -51,7 +51,7 @@ export interface LabeledValue {
 export type SelectValue = RawValue | RawValue[] | LabeledValue | LabeledValue[] | undefined
 
 export interface InternalSelectProps
-  extends ComponentBaseProps, Omit<VcSelectProps, 'mode' | 'classNames' | 'className' | 'style' | 'prefix' | 'styles'> {
+  extends ComponentBaseProps, Omit<VcSelectProps, 'mode' | 'classNames' | 'className' | 'style' | 'prefix' | 'styles' | 'onPopupVisibleChange'> {
   prefix?: VueNode
   suffixIcon?: VueNode
   size?: SizeType
@@ -138,7 +138,6 @@ type RcEventKeys
     | 'onMouseEnter'
     | 'onFocus'
     | 'onPopupScroll'
-    | 'onPopupVisibleChange'
     | 'onSelect'
     | 'optionRender'
 


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59142

## Summary

- Exclude the internal popup visibility callback from Select DOM passthrough.
- Adapted to the Vue 3 implementation and repository conventions.

## Validation

- Select and AutoComplete tests: 53 passed
- Changed-file lint and diff checks passed.