### PR TITLE
fix(menu): align inline collapse transition with upstream (#59085)

### DIFF
--- a/packages/antdv-next/src/menu/style/vertical.ts
+++ b/packages/antdv-next/src/menu/style/vertical.ts
@@ -168,6 +168,10 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
 
         [`&${componentCls}-root`]: {
           [`${componentCls}-item, ${componentCls}-submenu ${componentCls}-submenu-title`]: {
+            transition: [`border-color`, `background-color`]
+              .map(property => `${property} ${motionDurationSlow}`)
+              .join(','),
+
             [`> ${componentCls}-inline-collapsed-noicon`]: {
               fontSize: fontSizeLG,
               textAlign: 'center',

--- a/packages/antdv-next/src/menu/tests/index.test.tsx
+++ b/packages/antdv-next/src/menu/tests/index.test.tsx
@@ -324,6 +324,15 @@ describe('menu', () => {
     expect(dynamicStyleText).toMatch(/ant-menu-inline-collapsed[\s\S]*justify-content:flex-start/)
     expect(dynamicStyleText).toMatch(/ant-menu-inline-collapsed[\s\S]*ant-menu-title-content\{width:0;opacity:0;overflow:hidden/)
 
+    const collapsedTransitionRule = dynamicStyleText.match(
+      /ant-menu-inline-collapsed[^{}]*ant-menu-root[^{}]*ant-menu-item[^{}]*\{([^{}]*)\}/,
+    )?.[1]
+
+    expect(collapsedTransitionRule).toContain(
+      'transition:border-color var(--ant-motion-duration-slow),background-color var(--ant-motion-duration-slow)',
+    )
+    expect(collapsedTransitionRule).not.toContain('padding')
+
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## What

- Align the inline-collapsed Menu transition with ant-design/ant-design#59085.
- Override the collapsed root item transition to keep only border-color and background-color.
- Preserve the shared menu-item padding transition for unaffected Menu modes.
- Add a regression assertion for the generated collapsed transition rule.

## Why

PR #775 removes the padding transition from the shared menu-item rule, which is broader than the upstream fix. The upstream implementation scopes the override to inline-collapsed root menus so other Menu modes retain their existing behavior.

## Related

- Upstream: https://github.com/ant-design/ant-design/pull/59085
- Supersedes #775
- Closes #772

## Validation

- pnpm -F antdv-next test src/menu/tests
- pnpm exec eslint packages/antdv-next/src/menu/style/vertical.ts packages/antdv-next/src/menu/tests/index.test.tsx
- git diff --check