### PR TITLE
fix(image): use RTL icons in PreviewGroup (#59145)

### DIFF
--- a/packages/antdv-next/src/image/PreviewGroup.tsx
+++ b/packages/antdv-next/src/image/PreviewGroup.tsx
@@ -102,7 +102,7 @@ const InternalPreviewGroup = defineComponent<PreviewGroupProps>(
       prefixCls,
       mergedRootClassName,
       getContextPopupContainer,
-      computed(() => icons),
+      memoizedIcons,
     )
 
     const mergedMask = computed(() => mergedPreview.value?.mask)

--- a/packages/antdv-next/src/image/tests/Image.test.tsx
+++ b/packages/antdv-next/src/image/tests/Image.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'vue'
 import Image, { ImagePreviewGroup } from '..'
+import ConfigProvider from '../../config-provider'
 import rtlTest from '/@tests/shared/rtlTest'
 import { mount } from '/@tests/utils'
 
@@ -149,6 +150,28 @@ describe('image.PreviewGroup', () => {
       },
     })
     expect(wrapper.find('.ant-image').exists()).toBe(true)
+  })
+
+  it('should use RTL switch icons in preview config', async () => {
+    const wrapper = mount(() => (
+      <ConfigProvider direction="rtl">
+        <ImagePreviewGroup preview={{ open: true }}>
+          <Image src={src} />
+          <Image src="https://example.com/test2.png" />
+        </ImagePreviewGroup>
+      </ConfigProvider>
+    ))
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    expect(
+      document.querySelector('.ant-image-preview-switch-prev .anticon-right'),
+    ).not.toBeNull()
+    expect(
+      document.querySelector('.ant-image-preview-switch-next .anticon-left'),
+    ).not.toBeNull()
+
+    wrapper.unmount()
   })
 
   it('should disable preview when preview is false', () => {


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59145

## Summary

- Pass the direction-aware PreviewGroup icons into the merged preview configuration.
- Ensure RTL preview navigation uses the right arrow for previous and the left arrow for next.
- Add behavioral coverage for both RTL switch icons.

## Validation

- pnpm -F antdv-next test src/image/tests
- pnpm exec eslint packages/antdv-next/src/image/PreviewGroup.tsx packages/antdv-next/src/image/tests/Image.test.tsx
- git diff --check