### PR TITLE
fix(locale): correct Traditional Chinese picker terms (#59129)

### DIFF
--- a/packages/antdv-next/src/date-picker/locale/zh_TW.ts
+++ b/packages/antdv-next/src/date-picker/locale/zh_TW.ts
@@ -23,7 +23,7 @@ const locale: PickerLocale = {
   },
 }
 
-locale.lang.ok = '確 定'
+locale.lang.ok = '確定'
 
 // All settings at:
 // https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json

--- a/packages/antdv-next/src/locale/tests/locale.test.ts
+++ b/packages/antdv-next/src/locale/tests/locale.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import esUS from '../es_US'
+import zhTW from '../zh_TW'
 
 describe('locale es_US', () => {
   it('should extend es_ES and override locale codes for picker', () => {
@@ -8,5 +9,12 @@ describe('locale es_US', () => {
     expect(esUS.DatePicker?.lang.locale).toBe('en_US')
     expect(esUS.Calendar?.lang.locale).toBe('en_US')
     expect(esUS.Table?.filterTitle).toBe('Filtrar menú')
+  })
+})
+
+describe('locale zh_TW', () => {
+  it('uses Taiwan terminology for picker controls', () => {
+    expect(zhTW.DatePicker?.lang.ok).toBe('確定')
+    expect(zhTW.ColorPicker?.gradientColor).toBe('漸層色')
   })
 })

--- a/packages/antdv-next/src/locale/zh_TW.ts
+++ b/packages/antdv-next/src/locale/zh_TW.ts
@@ -143,7 +143,7 @@ const localeValues: Locale = {
     presetEmpty: '暫無',
     transparent: '透明',
     singleColor: '單色',
-    gradientColor: '漸變色',
+    gradientColor: '漸層色',
   },
 }
 


### PR DESCRIPTION
## Upstream

- https://github.com/ant-design/ant-design/pull/59129

## Summary

- Remove the unintended space from the zh-TW DatePicker confirmation label (`確 定` → `確定`).
- Use the Taiwan-standard ColorPicker gradient term (`漸變色` → `漸層色`).
- Add focused locale-contract regression coverage for both strings.

## Validation

- `pnpm -F antdv-next test src/locale/tests`
- `pnpm exec eslint packages/antdv-next/src/date-picker/locale/zh_TW.ts packages/antdv-next/src/locale/zh_TW.ts packages/antdv-next/src/locale/tests/locale.test.ts`
- `git diff --check`