### PR TITLE
fix(ci): render size report as markdown table

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -154,6 +154,13 @@ jobs:
             return formatBytes(value)
           }
 
+          function formatTableRow(fields) {
+            const escapedFields = fields.map(field => String(field)
+              .replaceAll('|', '\\|')
+              .replace(/\r?\n/g, '<br>'))
+            return `| ${escapedFields.join(' | ')} |`
+          }
+
           function packageNames(before, after) {
             const preferred = ['antdv-next', '@antdv-next/cssinjs']
             const names = new Set([
@@ -197,12 +204,21 @@ jobs:
                 ? allFiles.filter(file => hasChanged(beforeFiles[file], afterFiles[file]))
                 : allFiles
 
-              lines.push(`Package: ${packageName}`)
-              lines.push('after                                      | before')
-              lines.push('files|size|gzip|brotli                    | files|size|gzip|brotli')
+              lines.push(`### Package: \`${packageName}\``)
+              lines.push('| After file | Size | Gzip | Brotli | Before file | Size | Gzip | Brotli |')
+              lines.push('| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: |')
 
               if (files.length === 0) {
-                lines.push(onlyChanged ? 'No changed files' : '—|—|—|—                                 | —|—|—|—')
+                lines.push(formatTableRow([
+                  onlyChanged ? 'No changed files' : 'No files',
+                  '—',
+                  '—',
+                  '—',
+                  '—',
+                  '—',
+                  '—',
+                  '—',
+                ]))
               }
               else {
                 for (const file of files) {
@@ -225,7 +241,7 @@ jobs:
                       ]
                     : ['—', '—', '—', '—']
 
-                  lines.push(`${afterFields.join('|')} | ${beforeFields.join('|')}`)
+                  lines.push(formatTableRow([...afterFields, ...beforeFields]))
                 }
               }
 


### PR DESCRIPTION
[English template / 英文模板](https://github.com/antdv-next/antdv-next/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [x] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

暂无。

### 💡 背景与方案

Size Report 工作流生成的 PR 评论缺少 Markdown 表格分隔行，并且表头与数据行的列数不一致，导致 GitHub 将报告显示为普通文本。

本次修改将前后构建的文件、原始大小、gzip 和 brotli 数据统一为合法的 8 列 Markdown 表格；同时集中处理表格行生成，对单元格中的竖线和换行进行转义，并为无文件或无变更场景生成结构一致的占位行。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Fix Size Report PR comments to render package comparisons as GitHub Markdown tables. |
| 🇨🇳 中文 | 修复 Size Report PR 评论，将包体积对比正确渲染为 GitHub Markdown 表格。 |
