### PR TITLE
fix(Input.Password): [sync] ignore repeated key activation

### DIFF
--- a/packages/antdv-next/src/input/Password.tsx
+++ b/packages/antdv-next/src/input/Password.tsx
@@ -140,7 +140,9 @@ const InternalPassword = defineComponent<
           onKeydown={(e: KeyboardEvent) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault()
-              triggerVisibleChange()
+              if (!e.repeat) {
+                triggerVisibleChange()
+              }
             }
           }}
           {...triggerProps}

--- a/packages/antdv-next/src/input/tests/Password.test.tsx
+++ b/packages/antdv-next/src/input/tests/Password.test.tsx
@@ -82,6 +82,23 @@ describe('password', () => {
     expect(wrapper.find('input').attributes('type')).toBe('password')
   })
 
+  it.each(['Enter', ' '])('should ignore repeated %s key activation', async (key) => {
+    const onVisibleChange = vi.fn()
+    const wrapper = mount(Password, {
+      props: {
+        visibilityToggle: { onVisibleChange },
+      },
+    })
+
+    await wrapper.find('.ant-input-password-icon').trigger('keydown', {
+      key,
+      repeat: true,
+    })
+
+    expect(onVisibleChange).not.toHaveBeenCalled()
+    expect(wrapper.find('input').attributes('type')).toBe('password')
+  })
+
   it('should support visibilityToggle=false', () => {
     const wrapper = mount(Password, {
       props: {


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59135
- Upstream commit: `f8e2216c969ed3445c8c8b7a9463617582669631`
- Validation: all configured commands passed

Generated by RepoSync Hub.