### PR TITLE
fix(Tag): [sync] ignore repeated key activation

### DIFF
--- a/packages/antdv-next/src/tag/CheckableTag.tsx
+++ b/packages/antdv-next/src/tag/CheckableTag.tsx
@@ -71,9 +71,11 @@ const CheckableTag = defineComponent<
       }
       if (e.key === ' ') {
         e.preventDefault()
-        const checked = !props.checked
-        emit('change', checked)
-        emit('update:checked', checked)
+        if (!e.repeat) {
+          const checked = !props.checked
+          emit('change', checked)
+          emit('update:checked', checked)
+        }
       }
     }
     const [hashId, cssVarCls] = useStyle(prefixCls)

--- a/packages/antdv-next/src/tag/index.tsx
+++ b/packages/antdv-next/src/tag/index.tsx
@@ -154,7 +154,9 @@ const InternalTag = defineComponent<
     const handleCloseKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault()
-        ;(e.currentTarget as HTMLElement)?.click()
+        if (!e.repeat) {
+          ;(e.currentTarget as HTMLElement)?.click()
+        }
       }
     }
 

--- a/packages/antdv-next/src/tag/tests/Tag.test.tsx
+++ b/packages/antdv-next/src/tag/tests/Tag.test.tsx
@@ -284,6 +284,28 @@ describe('tag', () => {
     expect(wrapper.find('span').classes()).toContain(`${prefixCls}-hidden`)
   })
 
+  it.each(['Enter', ' '])('should ignore repeated %s key activation on close controls', async (key) => {
+    const onClose = vi.fn()
+    const wrapper = mount(Tag, {
+      props: { closable: true, onClose },
+      slots: { default: () => 'Closable' },
+    })
+    const closeIcon = wrapper.find(`.${prefixCls}-close-icon`).element
+    const keydownEvent = new KeyboardEvent('keydown', {
+      key,
+      repeat: true,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    closeIcon.dispatchEvent(keydownEvent)
+    await nextTick()
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(wrapper.find('span').classes()).not.toContain(`${prefixCls}-hidden`)
+    expect(keydownEvent.defaultPrevented).toBe(true)
+  })
+
   // ===================== closeIcon slot =====================
 
   it('should render closeIcon slot', () => {
@@ -625,6 +647,26 @@ describe('checkable-tag', () => {
     })
     await wrapper.find('span').trigger('keydown', { key: ' ' })
     expect(onChange).toHaveBeenCalledWith(true)
+  })
+
+  it('should ignore repeated Space key activation', () => {
+    const onChange = vi.fn()
+    const wrapper = mount(CheckableTag, {
+      props: { checked: false, onChange },
+      slots: { default: () => 'Toggle' },
+    })
+    const tag = wrapper.find('span').element
+    const keydownEvent = new KeyboardEvent('keydown', {
+      key: ' ',
+      repeat: true,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    tag.dispatchEvent(keydownEvent)
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(keydownEvent.defaultPrevented).toBe(true)
   })
 
   it('should not trigger change when key event is prevented', async () => {


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59134
- Upstream commit: `57961337e43b3efabf2640e549529a0b11f3ccfc`
- Validation: all configured commands passed

Generated by RepoSync Hub.