### PR TITLE
docs: [sync] explain Vue renderable content behavior

### DIFF
--- a/docs/src/pages/docs/vue/faq.en-US.md
+++ b/docs/src/pages/docs/vue/faq.en-US.md
@@ -26,6 +26,21 @@ npm ls dayjs
 
 If you are using a mismatched version of dayjs with antdv-next dependent dayjs in your project. That would be a problem cause locale not working.
 
+## Why is a DOM node still rendered for some empty content? {#vue-renderable}
+
+antdv-next uses the internal `isRenderable` utility to determine whether a content wrapper DOM should be created. It is designed as a compatibility-oriented content presence check, not a validator for valid Vue nodes, and it does not recursively predict whether Vue will eventually produce visible content.
+
+`isRenderable` treats only `null`, `undefined`, `false`, and the empty string `''` as having no content. All other values are treated as content. Therefore, when it controls whether a wrapper DOM is rendered:
+
+| Value | `isRenderable` | Result |
+| --- | --- | --- |
+| `null`, `undefined`, `false`, `''` | `false` | Neither the wrapper DOM nor any content is rendered |
+| `true` | `true` | The wrapper DOM is created, but Vue renders no text content for `true` |
+| `0` | `true` | The wrapper DOM is created and `0` is rendered normally |
+| Non-empty strings, other numbers, VNodes, etc. | `true` | The wrapper DOM is created and Vue handles the content |
+
+Here, `false` is treated as an explicit no-content marker, while `true` means that content was provided. Although `true` itself produces no text node, the wrapper DOM is still created. Similarly, an empty array, an empty Fragment, or a component that eventually returns `null` passes the check. The number `0` is not mistaken for empty content and is rendered normally.
+
 ## Camelcase slots / render props (e.g. `#tagRender`) don't work when using the CDN (UMD) build?
 
 This is a limitation of Vue **in-DOM templates**, not a component bug. When the template is written directly in the page's HTML (e.g. inside `<div id="app">`), the browser's HTML parser **lowercases** tag and attribute names — including slot names, so `#tagRender` reaches the component as `tagrender` instead of `tagRender`, and the camelCase slot never fires. This applies to every camelCase slot (`tagRender`, `maxTagPlaceholder`, `popupRender`, …), and writing `#tagrender` in lowercase does not help either. See the Vue docs on [in-DOM template parsing caveats](https://vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats).

--- a/docs/src/pages/docs/vue/faq.zh-CN.md
+++ b/docs/src/pages/docs/vue/faq.zh-CN.md
@@ -32,6 +32,21 @@ npm ls dayjs
 
 一般来说，如果项目中依赖的 dayjs 版本和 antdv-next 依赖的 dayjs 版本 无法兼容（semver 无法匹配，比如项目中的 dayjs 版本写死且较低），则会导致使用两个不同版本的 dayjs 实例，这样也会导致国际化失效。
 
+## 为什么有些空内容仍然会渲染 DOM？ {#vue-renderable}
+
+antdv-next 在判断是否需要创建内容的包裹 DOM 时，采用内部的 `isRenderable` 工具函数。它的设计目标是做兼容性的“内容存在性”检查，而不是验证一个值是否为合法的 Vue 节点，也不会递归预测 Vue 最终能否渲染出可见内容。
+
+`isRenderable` 只将 `null`、`undefined`、`false` 和空字符串 `''` 判定为无内容，其他值均判定为有内容。因此，在由它控制包裹 DOM 是否渲染的场景中：
+
+| 传入值 | `isRenderable` | 渲染结果 |
+| --- | --- | --- |
+| `null`、`undefined`、`false`、`''` | `false` | 不创建包裹 DOM，也不渲染内容 |
+| `true` | `true` | 创建包裹 DOM，但 Vue 不会为 `true` 渲染文本内容 |
+| `0` | `true` | 创建包裹 DOM，并正常渲染 `0` |
+| 非空字符串、其他数字、VNode 等 | `true` | 创建包裹 DOM，并交由 Vue 渲染内容 |
+
+其中 `false` 被视为显式的无内容标记，而 `true` 则表示内容已提供。虽然 `true` 本身不会产生文本节点，但包裹 DOM 仍然会被创建。类似地，空数组、空 Fragment 或最终返回 `null` 的组件也会通过检查。数字 `0` 则不会被误判为空内容，会被正常渲染。
+
 ## 通过 CDN（UMD 产物）使用时，`#tagRender` 等驼峰插槽 / 渲染属性不生效？
 
 这是 Vue **DOM 内模板（in-DOM template）** 的解析限制，并非组件的问题。当你把模板直接写在页面的 HTML 里（例如写在 `<div id="app">` 内部）时，浏览器的 HTML 解析器会把标签名和属性名（包括插槽名 `#tagRender`）**强制转为小写**，组件实际收到的是 `tagrender` 而不是 `tagRender`，因此驼峰命名的插槽和渲染属性都不会生效。这对所有驼峰插槽（如 `tagRender`、`maxTagPlaceholder`、`popupRender` 等）都成立，把插槽名改成小写 `#tagrender` 同样无效。详见 Vue 官方文档 [DOM 内模板解析注意事项](https://cn.vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats)。


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59192
- Upstream commit: `7793cab03924d29db45d64dadc1c81d0a8cf59e0`
- Validation: all configured commands passed

Generated by RepoSync Hub.