### PR TITLE
fix: [sync] respect controlled password visibility

### DIFF
--- a/packages/antdv-next/src/input/Password.tsx
+++ b/packages/antdv-next/src/input/Password.tsx
@@ -98,7 +98,9 @@ const InternalPassword = defineComponent<
         removePasswordTimeout()
       }
       const next = !visible.value
-      visible.value = next
+      if (!visibilityControlled.value) {
+        visible.value = next
+      }
       if (typeof visibilityToggle.value === 'object') {
         visibilityToggle.value.onVisibleChange?.(next)
       }

--- a/packages/antdv-next/src/input/tests/Password.test.tsx
+++ b/packages/antdv-next/src/input/tests/Password.test.tsx
@@ -107,6 +107,20 @@ describe('password', () => {
     expect(wrapper.find('input').attributes('type')).toBe('text')
   })
 
+  it('should not change password visibility in controlled mode', async () => {
+    const onVisibleChange = vi.fn()
+    const wrapper = mount(Password, {
+      props: {
+        visibilityToggle: { visible: false, onVisibleChange },
+      },
+    })
+
+    await wrapper.find('.ant-input-password-icon').trigger('click')
+
+    expect(wrapper.find('input').attributes('type')).toBe('password')
+    expect(onVisibleChange).toHaveBeenCalledWith(true)
+  })
+
   it('should support action=hover', async () => {
     const wrapper = mount(Password, {
       props: {


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59168
- Upstream commit: `d082122f4ef0542b9aeabb28a876cf24b7340c8b`
- Validation: all configured commands passed

Generated by RepoSync Hub.