### PR TITLE
fix: [sync] support empty string values in tree filters

### DIFF
--- a/packages/antdv-next/src/table/hooks/useFilter/FilterDropdown.tsx
+++ b/packages/antdv-next/src/table/hooks/useFilter/FilterDropdown.tsx
@@ -231,7 +231,7 @@ const FilterDropdown = defineComponent<
     ) => {
       const { node, checked } = info as { node: EventDataNode<FilterTreeDataNode>, checked: boolean }
       if (!props.filterMultiple) {
-        onSelectKeys({ selectedKeys: checked && node.key ? [node.key as string] : [] })
+        onSelectKeys({ selectedKeys: checked ? [node.key as string] : [] })
       }
       else {
         onSelectKeys({ selectedKeys: keys as string[] })

--- a/packages/antdv-next/src/table/tests/Table.filter.test.tsx
+++ b/packages/antdv-next/src/table/tests/Table.filter.test.tsx
@@ -277,6 +277,45 @@ describe('table filter', () => {
     expect(wrapper.findAll('tbody tr')).toHaveLength(1)
   })
 
+  it('supports empty string values in single-select tree filters', async () => {
+    const dataSource = [
+      { key: 'blank', status: '', name: 'Blank row' },
+      { key: 'filled', status: 'filled', name: 'Filled row' },
+    ]
+    const columns = [
+      { title: 'Name', dataIndex: 'name' },
+      {
+        title: 'Status',
+        dataIndex: 'status',
+        filterMode: 'tree' as const,
+        filterMultiple: false,
+        filters: [
+          { text: 'Empty value', value: '' },
+          { text: 'Filled value', value: 'filled' },
+        ],
+        onFilter: (value: any, record: (typeof dataSource)[number]) => record.status === value,
+      },
+    ]
+    const wrapper = mount(Table, {
+      props: { columns, dataSource, pagination: false },
+      attachTo: document.body,
+    })
+
+    await wrapper.find('.ant-table-filter-trigger').trigger('click')
+    await waitFakeTimer()
+    const emptyValueCheckbox = document.querySelector<HTMLElement>('.ant-tree-checkbox')
+    emptyValueCheckbox?.click()
+    await waitFakeTimer()
+
+    expect(document.querySelectorAll('.ant-tree-checkbox-checked')).toHaveLength(1)
+
+    document.querySelector<HTMLElement>('.ant-table-filter-dropdown-btns .ant-btn-primary')?.click()
+    await waitFakeTimer()
+    expect(wrapper.findAll('tbody tr')).toHaveLength(1)
+    expect(wrapper.find('tbody tr').text()).toContain('Blank row')
+    wrapper.unmount()
+  })
+
   it('should filter with nested children data', () => {
     const nestedData = [
       { key: '1', name: 'John', age: 32, children: [{ key: '1-1', name: 'John Jr', age: 5 }] },


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59141
- Upstream commit: `77d831751b3452a8291256fa187553a258e2cf1e`
- Validation: all configured commands passed

Generated by RepoSync Hub.