### PR TITLE
docs: [sync] document Listy ConfigProvider configuration

### DIFF
--- a/docs/src/pages/components/config-provider/index.en-US.md
+++ b/docs/src/pages/components/config-provider/index.en-US.md
@@ -152,6 +152,7 @@ The following config keys set common props for corresponding components or globa
 - `inputPassword`: [Input.Password](/components/input#input-password)
 - `inputSearch`: [Input.Search](/components/input#input-search)
 - `layout`: [Layout](/components/layout#api)
+- `listy`: [Listy](/components/listy#api)
 - `masonry`: [Masonry](/components/masonry#api)
 - `mentions`: [Mentions](/components/mentions#api)
 - `menu`: [Menu](/components/menu#api)

--- a/docs/src/pages/components/config-provider/index.zh-CN.md
+++ b/docs/src/pages/components/config-provider/index.zh-CN.md
@@ -153,6 +153,7 @@ const { componentDisabled, componentSize } = config.value
 - `inputPassword`：[Input.Password](/components/input-cn#input-password)
 - `inputSearch`：[Input.Search](/components/input-cn#input-search)
 - `layout`：[Layout](/components/layout-cn#api)
+- `listy`：[Listy](/components/listy-cn#api)
 - `masonry`：[Masonry](/components/masonry-cn#api)
 - `mentions`：[Mentions](/components/mentions-cn#api)
 - `menu`：[Menu](/components/menu-cn#api)


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59202
- Upstream commit: `c07b32149ab8e0aa92196c0938306498226f79aa`
- Validation: all configured commands passed

Generated by RepoSync Hub.