### PR TITLE
fix(Radio): fix checked and disabled states in semantic callbacks

### DIFF
--- a/packages/antdv-next/src/radio/radio.tsx
+++ b/packages/antdv-next/src/radio/radio.tsx
@@ -113,7 +113,8 @@ const InternalRadio = defineComponent<
       return {
         ...props,
         ...radioProps.value,
-        disabled: mergedChecked.value,
+        disabled: radioProps.value.disabled,
+        checked: mergedChecked.value,
       }
     })
 

--- a/packages/antdv-next/src/radio/tests/Radio.semantic.test.tsx
+++ b/packages/antdv-next/src/radio/tests/Radio.semantic.test.tsx
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import type { RadioProps } from '../interface'
+import { describe, expect, it, vi } from 'vitest'
 import Radio from '..'
 import ConfigProvider from '../../config-provider'
 import { expectSemanticRootStylePriority, semanticRootStylePriority } from '/@tests/shared/semanticStylePriority'
@@ -63,6 +64,27 @@ describe('radio semantic', () => {
     expect(wrapper.find(`.${prefixCls}`).attributes('style')).toContain('color: rgb(0, 255, 0)')
     expect(wrapper.find(`.${prefixCls}-label`).classes()).toContain('c-label')
     expect(wrapper.find(`.${prefixCls}-label`).attributes('style')).toContain('color: rgb(0, 0, 255)')
+  })
+
+  it.each([
+    {
+      props: { checked: true },
+      expected: { checked: true, disabled: false },
+    },
+    {
+      props: { checked: false, disabled: true },
+      expected: { checked: false, disabled: true },
+    },
+  ])('should pass merged checked and disabled states to semantic callbacks', ({ props, expected }) => {
+    const classes = vi.fn((_info: { props: RadioProps }) => ({}))
+    const styles = vi.fn((_info: { props: RadioProps }) => ({}))
+
+    mount(Radio, {
+      props: { ...props, classes, styles },
+    })
+
+    expect(classes).toHaveBeenCalledWith({ props: expect.objectContaining(expected) })
+    expect(styles).toHaveBeenCalledWith({ props: expect.objectContaining(expected) })
   })
 
   // ===================== ConfigProvider semantic merging =====================


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

fix https://github.com/antdv-next/antdv-next/issues/814

### 💡 背景与方案

Radio 的 `classes` 和 `styles` 回调应通过 `info.props` 接收组件合并后的状态。

此前 `info.props.disabled` 被错误赋值为 `mergedChecked`，导致选中但可用的 Radio 被识别为禁用，而未选中但禁用的 Radio 被识别为可用。

本次修改将 `disabled` 设置为 Radio 的最终禁用状态，并显式传递合并后的 `checked` 状态。同时增加回归测试，验证 `classes` 和 `styles` 回调在以下场景中收到正确的属性：

- `checked: true, disabled: false`
- `checked: false, disabled: true`

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Fix Radio semantic callbacks receiving an incorrect disabled state. |
| 🇨🇳 中文 | 修复 Radio 语义化回调接收到错误禁用状态的问题。 |