### PR TITLE
docs: [sync] add missing es_US locale to i18n docs

### DIFF
--- a/docs/src/pages/docs/vue/i18n.en-US.md
+++ b/docs/src/pages/docs/vue/i18n.en-US.md
@@ -43,6 +43,7 @@ The following languages are currently supported:
 | English (United Kingdom) | en_GB    |
 | English                  | en_US    |
 | Spanish                  | es_ES    |
+| Spanish (United States)  | es_US    |
 | Basque                   | eu_ES    |
 | Estonian                 | et_EE    |
 | Persian                  | fa_IR    |

--- a/docs/src/pages/docs/vue/i18n.zh-CN.md
+++ b/docs/src/pages/docs/vue/i18n.zh-CN.md
@@ -41,6 +41,7 @@ import frFR from 'antdv-next/locale/fr_FR'
 | 英语                   | en_GB  |
 | 英语（美式）           | en_US  |
 | 西班牙语               | es_ES  |
+| 西班牙语（美式）       | es_US  |
 | 巴斯克语               | eu_ES  |
 | 爱沙尼亚语             | et_EE  |
 | 波斯语                 | fa_IR  |


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59204
- Upstream commit: `08050d38c54c952380133d0f16f835a472b8c290`
- Validation: all configured commands passed

Generated by RepoSync Hub.