### PR TITLE
fix: [sync] support non-element popupRender results

### DIFF
--- a/docs/src/pages/components/auto-complete/index.en-US.md
+++ b/docs/src/pages/components/auto-complete/index.en-US.md
@@ -61,7 +61,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | optionRender | Customize the rendering dropdown options | (option: FlattenOptionData&lt;BaseOptionType&gt;, info: &#123; index: number &#125;) =&gt; VueNode | - | - | × |
 | placeholder | The placeholder of input | string | - | - | × |
 | popupMatchSelectWidth | Determine whether the dropdown menu and the select input are the same width. Default set `min-width` same as input. Will ignore when value less than select width. `false` will disable virtual scroll | boolean \| number | true | - | × |
-| popupRender | Customize dropdown content | (menu: VueNode) =&gt; VueNode | - | - | × |
+| popupRender | Customize dropdown content | (menu: VNode) =&gt; VueNode | - | - | × |
 | showSearch | Search configuration | boolean \| [SearchConfig](#showsearch) | true | - | × |
 | size | The size of the input box | `large` \| `medium` \| `small` | - | - | × |
 | status | Set validation status | `error` \| `warning` | - | - | × |
@@ -92,7 +92,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | labelRender | Customize selected label render | (props: LabelInValueType) =&gt; VueNode | - |
 | notFoundContent | Specify content to show when no result matches | () =&gt; VueNode | - |
 | optionRender | Customize the rendering dropdown options | (option: FlattenOptionData&lt;BaseOptionType&gt;, info: &#123; index: number &#125;) =&gt; VueNode | - |
-| popupRender | Customize dropdown content | (menu: VueNode) =&gt; VueNode | - |
+| popupRender | Customize dropdown content | (menu: VNode) =&gt; VueNode | - |
 | prefix | The custom prefix | () =&gt; VueNode | - |
 | suffixIcon | The custom suffix icon | () =&gt; VueNode | - |
 

--- a/docs/src/pages/components/auto-complete/index.zh-CN.md
+++ b/docs/src/pages/components/auto-complete/index.zh-CN.md
@@ -62,7 +62,7 @@ demo:
 | optionRender | 自定义下拉选项渲染 | (option: FlattenOptionData&lt;BaseOptionType&gt;, info: &#123; index: number &#125;) =&gt; VueNode | - | - | × |
 | placeholder | 输入框提示 | string | - | - | × |
 | popupMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`，当值小于选择框宽度时会被忽略。false 时会关闭虚拟滚动 | boolean \| number | true | - | × |
-| popupRender | 自定义下拉框内容 | (menu: VueNode) =&gt; VueNode | - | - | × |
+| popupRender | 自定义下拉框内容 | (menu: VNode) =&gt; VueNode | - | - | × |
 | showSearch | 搜索配置 | boolean \| [SearchConfig](#showsearch) | true | - | × |
 | size | 控件大小 | `large` \| `medium` \| `small` | - | - | × |
 | status | 设置校验状态 | `error` \| `warning` | - | - | × |
@@ -93,7 +93,7 @@ demo:
 | labelRender | 自定义当前选中的 label 内容 render | (props: LabelInValueType) =&gt; VueNode | - |
 | notFoundContent | 当下拉列表为空时显示的内容 | () =&gt; VueNode | - |
 | optionRender | 自定义下拉选项渲染 | (option: FlattenOptionData&lt;BaseOptionType&gt;, info: &#123; index: number &#125;) =&gt; VueNode | - |
-| popupRender | 自定义下拉框内容 | (menu: VueNode) =&gt; VueNode | - |
+| popupRender | 自定义下拉框内容 | (menu: VNode) =&gt; VueNode | - |
 | prefix | 自定义前缀 | () =&gt; VueNode | - |
 | suffixIcon | 自定义后缀图标 | () =&gt; VueNode | - |
 

--- a/docs/src/pages/components/cascader/index.en-US.md
+++ b/docs/src/pages/components/cascader/index.en-US.md
@@ -84,7 +84,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | loadingIcon | The appearance of lazy loading (now is useless) | VueNode | - |
 | notFoundContent | Specify content to show when no result matches | VueNode | - |
 | optionRender | Customize the rendering dropdown options | (option: Option) => VueNode | - |
-| popupRender | Customize dropdown content | (menus: VueNode) => VueNode | - |
+| popupRender | Customize dropdown content | (menus: VNode) => VueNode | - |
 | prefix | The custom prefix | VueNode | - |
 | removeIcon | The custom remove icon | VueNode | - |
 | suffixIcon | The custom suffix icon | VueNode | - |

--- a/docs/src/pages/components/cascader/index.zh-CN.md
+++ b/docs/src/pages/components/cascader/index.zh-CN.md
@@ -90,7 +90,7 @@ demo:
 | loadingIcon | 延迟加载的外观（现已无用） | VueNode | - |
 | notFoundContent | 当下拉列表为空时显示的内容 | VueNode | - |
 | optionRender | 自定义渲染下拉选项 | (option: Option) => VueNode | - |
-| popupRender | 自定义下拉框内容 | (menus: VueNode) => VueNode | - |
+| popupRender | 自定义下拉框内容 | (menus: VNode) => VueNode | - |
 | prefix | 自定义前缀 | VueNode | - |
 | removeIcon | 自定义的多选框清除图标 | VueNode | - |
 | suffixIcon | 自定义的选择框后缀图标 | VueNode | - |

--- a/docs/src/pages/components/select/index.en-US.md
+++ b/docs/src/pages/components/select/index.en-US.md
@@ -64,7 +64,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | disabled | Whether disabled select | boolean | false | - | × |
 | dropdownClassName | The className of dropdown menu, **Deprecated. Use `classes.popup.root` instead** | string | - | - | × |
 | dropdownMatchSelectWidth | Determine whether the dropdown menu and the select input are the same width, **Deprecated. Use `popupMatchSelectWidth` instead** | boolean \| number | - | - | × |
-| dropdownRender | Customize dropdown content, **Deprecated. Use `popupRender` instead** | (originNode: VueNode) =&gt; VueNode | - | - | × |
+| dropdownRender | Customize dropdown content, **Deprecated. Use `popupRender` instead** | (originNode: VNode) =&gt; VueNode | - | - | × |
 | dropdownStyle | The style of dropdown menu, **Deprecated. Use `styles.popup.root` instead** | CSSProperties | - | - | × |
 | fieldNames | Customize node label, value, options, groupLabel field name | object | &#123; label: 'label', value: 'value', options: 'options', groupLabel: 'label' &#125; | - | × |
 | filterOption | If true, filter options by input, if function, filter options against it. The function will receive two arguments, `inputValue` and `option`, if the function returns true, the option will be included in the filtered set; Otherwise, it will be excluded | boolean \| (inputValue: string, option?: Option) =&gt; boolean | true | - | × |
@@ -88,7 +88,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | placement | The position where the selection box pops up | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft | - | × |
 | popupClassName | The className of dropdown menu, use `classes.popup.root` instead | string | - | - | × |
 | popupMatchSelectWidth | Determine whether the dropdown menu and the select input are the same width. Default set `min-width` same as input. Will ignore when value less than select width. `false` will disable virtual scroll | boolean \| number | true | - | × |
-| popupRender | Customize dropdown content | (originNode: VueNode) =&gt; VueNode | - | - | × |
+| popupRender | Customize dropdown content | (originNode: VNode) =&gt; VueNode | - | - | × |
 | prefix | The custom prefix | VueNode | - | - | × |
 | removeIcon | The custom remove icon | VueNode | - | - | ✓ |
 | searchValue | The current input "search" text | string | - | - | × |
@@ -130,7 +130,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | menuItemSelectedIcon | The custom menuItemSelected icon with multiple options | VueNode | - |
 | notFoundContent | Specify content to show when no result matches | VueNode | - |
 | optionRender | Customize the rendering dropdown options | (option: FlattenOptionData&lt;BaseOptionType&gt;, info: &#123; index: number &#125;) =&gt; VueNode | - |
-| popupRender | Customize dropdown content | (originNode: VueNode) =&gt; VueNode | - |
+| popupRender | Customize dropdown content | (originNode: VNode) =&gt; VueNode | - |
 | prefix | The custom prefix | VueNode | - |
 | removeIcon | The custom remove icon | VueNode | - |
 | suffixIcon | The custom suffix icon. Customize icon will not response click open to avoid icon designed to do other interactive. You can use `pointer-events: none` style to bypass | VueNode | - |

--- a/docs/src/pages/components/select/index.zh-CN.md
+++ b/docs/src/pages/components/select/index.zh-CN.md
@@ -65,7 +65,7 @@ demo:
 | disabled | 是否禁用 | boolean | false | - | × |
 | dropdownClassName | 下拉菜单的 className 属性，**已废弃，请使用 `classes.popup.root` 替换** | string | - | - | × |
 | dropdownMatchSelectWidth | 下拉菜单和选择器同宽，**已废弃，请使用 `popupMatchSelectWidth` 替换** | boolean \| number | - | - | × |
-| dropdownRender | 自定义下拉框内容，**已废弃，请使用 `popupRender` 替换** | (originNode: VueNode) =&gt; VueNode | - | - | × |
+| dropdownRender | 自定义下拉框内容，**已废弃，请使用 `popupRender` 替换** | (originNode: VNode) =&gt; VueNode | - | - | × |
 | dropdownStyle | 下拉菜单的 style 属性，**已废弃，请使用 `styles.popup.root` 替换** | CSSProperties | - | - | × |
 | fieldNames | 自定义节点 label、value、options、groupLabel 的字段 | object | &#123; label: 'label', value: 'value', options: 'options', groupLabel: 'label' &#125; | - | × |
 | filterOption | 是否根据输入项进行筛选。当其为一个函数时，会接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | boolean \| (inputValue: string, option?: Option) =&gt; boolean | true | - | × |
@@ -89,7 +89,7 @@ demo:
 | placement | 选择框弹出的位置 | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft | - | × |
 | popupClassName | 下拉菜单的 className 属性，使用 `classes.popup.root` 替换 | string | - | - | × |
 | popupMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`，当值小于选择框宽度时会被忽略。`false` 时会关闭虚拟滚动 | boolean \| number | true | - | × |
-| popupRender | 自定义下拉框内容 | (originNode: VueNode) =&gt; VueNode | - | - | × |
+| popupRender | 自定义下拉框内容 | (originNode: VNode) =&gt; VueNode | - | - | × |
 | prefix | 自定义前缀 | VueNode | - | - | × |
 | removeIcon | 自定义的多选框清除图标 | VueNode | - | - | ✓ |
 | searchValue | 控制搜索文本 | string | - | - | × |
@@ -131,7 +131,7 @@ demo:
 | menuItemSelectedIcon | 自定义多选时当前选中的条目图标 | VueNode | - |
 | notFoundContent | 当下拉列表为空时显示的内容 | VueNode | - |
 | optionRender | 自定义渲染下拉选项 | (option: FlattenOptionData&lt;BaseOptionType&gt;, info: &#123; index: number &#125;) =&gt; VueNode | - |
-| popupRender | 自定义下拉框内容 | (originNode: VueNode) =&gt; VueNode | - |
+| popupRender | 自定义下拉框内容 | (originNode: VNode) =&gt; VueNode | - |
 | prefix | 自定义前缀 | VueNode | - |
 | removeIcon | 自定义的多选框清除图标 | VueNode | - |
 | suffixIcon | 自定义的选择框后缀图标。以防止图标被用于其他交互，替换的图标默认不会响应展开、收缩事件，可以通过添加 `pointer-events: none` 样式透传 | VueNode | - |

--- a/docs/src/pages/components/tree-select/index.en-US.md
+++ b/docs/src/pages/components/tree-select/index.en-US.md
@@ -46,7 +46,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | defaultValue | To set the initial selected treeNode(s) | string \| string[] | - | - | × |
 | disabled | Disabled or not | boolean | false | - | × |
 | popupMatchSelectWidth | Determine whether the popup menu and the select input are the same width. Default set `min-width` same as input. Will ignore when value less than select width. `false` will disable virtual scroll | boolean \| number | true | - | × |
-| popupRender | Customize dropdown content | (menu: VueNode) =&gt; VueNode | - | - | × |
+| popupRender | Customize dropdown content | (menu: VNode) =&gt; VueNode | - | - | × |
 | fieldNames | Customize node label, value, children field name | object | &#123; label: `label`, value: `value`, children: `children` &#125; | - | × |
 | getPopupContainer | To set the container of the dropdown menu | (triggerNode: HTMLElement) =&gt; HTMLElement | () =&gt; document.body | - | × |
 | labelInValue | Whether to embed label in value, turn the format of value from `string` to &#123; value: string, label: VueNode, halfChecked: boolean &#125; | boolean | false | - | × |

--- a/docs/src/pages/components/tree-select/index.zh-CN.md
+++ b/docs/src/pages/components/tree-select/index.zh-CN.md
@@ -48,7 +48,7 @@ demo:
 | defaultValue | 指定默认选中的条目 | string \| string[] | - | - | × |
 | disabled | 是否禁用 | boolean | false | - | × |
 | popupMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`，当值小于选择框宽度时会被忽略。false 时会关闭虚拟滚动 | boolean \| number | true | - | × |
-| popupRender | 自定义下拉框内容 | (menu: VueNode) =&gt; VueNode | - | - | × |
+| popupRender | 自定义下拉框内容 | (menu: VNode) =&gt; VueNode | - | - | × |
 | fieldNames | 自定义节点 label、value、children 的字段 | object | &#123; label: `label`, value: `value`, children: `children` &#125; | - | × |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | (triggerNode: HTMLElement) =&gt; HTMLElement | () =&gt; document.body | - | × |
 | labelInValue | 是否把每个选项的 label 包装到 value 中，会把 value 类型从 `string` 变为 &#123; value: string, label: VueNode, halfChecked: boolean &#125; 的格式 | boolean | false | - | × |

--- a/packages/antdv-next/src/auto-complete/index.tsx
+++ b/packages/antdv-next/src/auto-complete/index.tsx
@@ -1,5 +1,5 @@
 import type { SelectProps as VcSelectProps } from '@v-c/select'
-import type { App, CSSProperties, SlotsType } from 'vue'
+import type { App, CSSProperties, SlotsType, VNode, VNodeChild } from 'vue'
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks'
 import type { InputStatus } from '../_util/statusUtils'
 import type { VueNode } from '../_util/type'
@@ -110,8 +110,8 @@ export interface AutoCompleteProps extends
   styles?: AutoCompleteStylesType
   classes?: AutoCompleteClassNamesType
   /** @deprecated Please use `popupRender` instead */
-  dropdownRender?: (menu: VueNode) => any
-  popupRender?: (menu: VueNode) => any
+  dropdownRender?: (menu: VNode) => VNodeChild
+  popupRender?: (menu: VNode) => VNodeChild
   /** @deprecated Please use `styles.popup.root` instead */
   dropdownStyle?: CSSProperties
   showSearch?: boolean | Pick<SearchConfig, 'filterOption' | 'onSearch'>

--- a/packages/antdv-next/src/cascader/index.tsx
+++ b/packages/antdv-next/src/cascader/index.tsx
@@ -1,5 +1,5 @@
 import type { DefaultOptionType, FieldNames, SearchConfig, CascaderProps as VcCascaderProps } from '@v-c/cascader'
-import type { App, CSSProperties, PublicProps, SlotsType } from 'vue'
+import type { App, CSSProperties, PublicProps, SlotsType, VNode, VNodeChild } from 'vue'
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks'
 import type { SelectCommonPlacement } from '../_util/motion'
 import type { InputStatus } from '../_util/statusUtils'
@@ -151,6 +151,7 @@ export interface CascaderProps<
     | 'onChange'
     | 'onSearch'
     | 'onPopupVisibleChange'
+    | 'popupRender'
     | 'multiple'
     | 'value'
   >,
@@ -180,8 +181,8 @@ export interface CascaderProps<
   /** @deprecated Please use `styles.popup.root` instead */
   dropdownStyle?: CSSProperties
   /** @deprecated Please use `popupRender` instead */
-  dropdownRender?: (menu: any) => any
-  popupRender?: (menu: any) => any
+  dropdownRender?: (menu: VNode) => VNodeChild
+  popupRender?: (menu: VNode) => VNodeChild
   /** @deprecated Please use `popupMenuColumnStyle` instead */
   dropdownMenuColumnStyle?: CSSProperties
   popupMenuColumnStyle?: CSSProperties
@@ -197,7 +198,7 @@ export interface CascaderProps<
 export interface CascaderSlots<OptionType extends DefaultOptionType = DefaultOptionType> {
   suffixIcon?: () => any
   notFoundContent?: () => any
-  popupRender?: (menu: any) => any
+  popupRender?: (menu: VNode) => VNodeChild
   displayRender?: (data: { labels: string[], selectedOptions?: OptionType[] }) => any
   optionRender?: (option: OptionType) => any
   expandIcon?: () => any

--- a/packages/antdv-next/src/dropdown/dropdown.tsx
+++ b/packages/antdv-next/src/dropdown/dropdown.tsx
@@ -1,6 +1,6 @@
 import type { MenuInfo, MenuProps as VcMenuProps } from '@v-c/menu'
 import type { AlignType } from '@v-c/trigger'
-import type { App, CSSProperties, SlotsType } from 'vue'
+import type { App, CSSProperties, SlotsType, VNode, VNodeChild } from 'vue'
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks'
 import type { AdjustOverflow } from '../_util/placements'
 import type { ComponentBaseProps } from '../config-provider/context'
@@ -84,7 +84,7 @@ export interface DropdownProps extends ComponentBaseProps,
   autoFocus?: boolean
   arrow?: boolean | DropdownArrowOptions
   trigger?: ('click' | 'hover' | 'contextmenu' | 'contextMenu')[]
-  popupRender?: (Vnode: any) => any
+  popupRender?: (node: VNode) => VNodeChild
   // onOpenChange?: (open: boolean, info: { source: 'trigger' | 'menu' }) => void;
   open?: boolean
   disabled?: boolean
@@ -116,7 +116,7 @@ export interface DropdownEmitsProps {
 }
 
 export interface DropdownSlots extends MenuSlots {
-  popupRender: (info: { open: boolean, source: 'trigger' | 'menu' }) => any
+  popupRender: (node: VNode) => VNodeChild
 }
 
 const defaults = {
@@ -313,8 +313,9 @@ const Dropdown = defineComponent<
         if (mergedPopupRender) {
           overlayNode = mergedPopupRender(overlayNode)
         }
-        const overlayFiltered = filterEmpty(Array.isArray(overlayNode) ? overlayNode : [overlayNode]).filter(Boolean)
-        overlayNode = overlayFiltered.length === 1 ? (typeof overlayFiltered[0] === 'string' ? <span>{overlayFiltered}</span> : overlayFiltered) : overlayFiltered
+        if (typeof overlayNode === 'string') {
+          overlayNode = <span>{overlayNode}</span>
+        }
 
         return (
           <OverrideProvider

--- a/packages/antdv-next/src/dropdown/tests/Dropdown.test.tsx
+++ b/packages/antdv-next/src/dropdown/tests/Dropdown.test.tsx
@@ -626,6 +626,26 @@ describe('dropdown', () => {
     expect(document.querySelector('.custom-popup')).toBeTruthy()
   })
 
+  it.each([
+    ['null', null],
+    ['text', 'Custom popup'],
+    ['number', 1],
+    ['array', ['First', 'Second']],
+  ])('should support popupRender returning %s', async (_, popup) => {
+    expect(() => mount(Dropdown, {
+      attachTo: document.body,
+      props: {
+        menu,
+        popupRender: () => popup,
+        open: true,
+        mouseEnterDelay: 0,
+        mouseLeaveDelay: 0,
+      },
+      slots: { default: () => <span>trigger</span> },
+    })).not.toThrow()
+    await flushDropdownTimer()
+  })
+
   it('should support popupRender slot', async () => {
     mount(Dropdown, {
       attachTo: document.body,

--- a/packages/antdv-next/src/select/index.tsx
+++ b/packages/antdv-next/src/select/index.tsx
@@ -1,5 +1,5 @@
 import type { BaseSelectRef, SelectProps as VcSelectProps } from '@v-c/select'
-import type { App, CSSProperties, SlotsType } from 'vue'
+import type { App, CSSProperties, SlotsType, VNode, VNodeChild } from 'vue'
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks'
 import type { SelectCommonPlacement } from '../_util/motion'
 import type { InputStatus } from '../_util/statusUtils'
@@ -51,7 +51,7 @@ export interface LabeledValue {
 export type SelectValue = RawValue | RawValue[] | LabeledValue | LabeledValue[] | undefined
 
 export interface InternalSelectProps
-  extends ComponentBaseProps, Omit<VcSelectProps, 'mode' | 'classNames' | 'className' | 'style' | 'prefix' | 'styles' | 'onPopupVisibleChange'> {
+  extends ComponentBaseProps, Omit<VcSelectProps, 'mode' | 'classNames' | 'className' | 'style' | 'prefix' | 'styles' | 'onPopupVisibleChange' | 'popupRender'> {
   prefix?: VueNode
   suffixIcon?: VueNode
   size?: SizeType
@@ -71,6 +71,7 @@ export interface InternalSelectProps
   variant?: Variant
   styles?: SelectStylesType
   classes?: SelectClassNamesType
+  popupRender?: (menu: VNode) => VNodeChild
 }
 
 export interface SelectSemanticClassNames {

--- a/packages/antdv-next/src/tree-select/index.tsx
+++ b/packages/antdv-next/src/tree-select/index.tsx
@@ -1,5 +1,5 @@
 import type { DataNode, TreeSelectProps as VcTreeSelectProps } from '@v-c/tree-select'
-import type { App, CSSProperties, PublicProps, SlotsType } from 'vue'
+import type { App, CSSProperties, PublicProps, SlotsType, VNode, VNodeChild } from 'vue'
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks'
 import type { SelectCommonPlacement } from '../_util/motion'
 import type { InputStatus } from '../_util/statusUtils'
@@ -126,6 +126,7 @@ interface BaseTreeSelectProps<ValueType = any, OptionType extends DataNode = Dat
     | 'onPopupScroll'
     | 'onPopupVisibleChange'
     | 'onSearch'
+    | 'popupRender'
   > {
   size?: SizeType
   disabled?: boolean
@@ -149,8 +150,8 @@ export interface TreeSelectProps<ValueType = any, OptionType extends DataNode = 
   /** @deprecated Please use `classNames.popup.root` instead */
   dropdownClassName?: string
   /** @deprecated Please use `popupRender` instead */
-  dropdownRender?: (menu: any) => any
-  popupRender?: (menu: any) => any
+  dropdownRender?: (menu: VNode) => VNodeChild
+  popupRender?: (menu: VNode) => VNodeChild
   /** @deprecated Please use `styles.popup.root` instead */
   dropdownStyle?: CSSProperties
   // /** @deprecated Please use `onOpenChange` instead */


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59207
- Upstream commit: `14e706cd861d3373857cb064fdc4fff4a6e402bf`
- Validation: all configured commands passed

Generated by RepoSync Hub.