### PR TITLE
fix: [sync] mark Steps progress icon as a progressbar

### DIFF
--- a/packages/antdv-next/src/steps/ProgressIcon.tsx
+++ b/packages/antdv-next/src/steps/ProgressIcon.tsx
@@ -27,11 +27,11 @@ const ProgressIcon = defineComponent<ProgressIconProps>(
             width="100%"
             height="100%"
             xmlns="http://www.w3.org/2000/svg"
+            role="progressbar"
             aria-valuemax={100}
             aria-valuemin={0}
             aria-valuenow={percent}
           >
-            <title>Progress</title>
             <circle class={clsx(circleCls, `${circleCls}-rail`)} />
             <circle
               class={clsx(circleCls, `${circleCls}-ptg`)}

--- a/packages/antdv-next/src/steps/tests/ProgressIcon.test.tsx
+++ b/packages/antdv-next/src/steps/tests/ProgressIcon.test.tsx
@@ -30,7 +30,7 @@ describe('progressIcon', () => {
     expect(circles[1]!.classes()).toContain('ant-steps-item-progress-icon-circle-ptg')
   })
 
-  it('should apply correct percent value', () => {
+  it('should expose the percent value as an unnamed progressbar', () => {
     const wrapper = mount(ProgressIcon, {
       props: {
         prefixCls: 'ant-steps',
@@ -39,9 +39,11 @@ describe('progressIcon', () => {
       },
     })
     const svg = wrapper.find('svg')
+    expect(svg.attributes('role')).toBe('progressbar')
     expect(svg.attributes('aria-valuenow')).toBe('75')
     expect(svg.attributes('aria-valuemin')).toBe('0')
     expect(svg.attributes('aria-valuemax')).toBe('100')
+    expect(svg.find('title').exists()).toBe(false)
   })
 
   it('should render slot content', () => {

--- a/packages/antdv-next/src/steps/tests/__snapshots__/ProgressIcon.test.tsx.snap
+++ b/packages/antdv-next/src/steps/tests/__snapshots__/ProgressIcon.test.tsx.snap
@@ -10,13 +10,11 @@ exports[`progressIcon > should match snapshot 1`] = `
     aria-valuenow="60"
     class="ant-steps-item-progress-icon-svg"
     height="100%"
+    role="progressbar"
     viewBox="0 0 100 100"
     width="100%"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>
-      Progress
-    </title>
     <circle
       class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
     />

--- a/packages/antdv-next/src/steps/tests/__snapshots__/Steps.test.tsx.snap
+++ b/packages/antdv-next/src/steps/tests/__snapshots__/Steps.test.tsx.snap
@@ -505,13 +505,11 @@ exports[`steps > should match snapshot with progress 1`] = `
           aria-valuenow="60"
           class="ant-steps-item-progress-icon-svg"
           height="100%"
+          role="progressbar"
           viewBox="0 0 100 100"
           width="100%"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title>
-            Progress
-          </title>
           <circle
             class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
           />

--- a/packages/antdv-next/src/steps/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/steps/tests/__snapshots__/demo.test.tsx.snap
@@ -5955,13 +5955,11 @@ exports[`steps demo > renders title-placement correctly 1`] = `
             aria-valuenow="60"
             class="ant-steps-item-progress-icon-svg"
             height="100%"
+            role="progressbar"
             viewBox="0 0 100 100"
             width="100%"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title>
-              Progress
-            </title>
             <circle
               class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
             />
@@ -6120,13 +6118,11 @@ exports[`steps demo > renders title-placement correctly 1`] = `
             aria-valuenow="80"
             class="ant-steps-item-progress-icon-svg"
             height="100%"
+            role="progressbar"
             viewBox="0 0 100 100"
             width="100%"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title>
-              Progress
-            </title>
             <circle
               class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
             />


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59073
- Upstream commit: `3614bef4194f6de3b5a526c3548d20b67c7fd7ba`
- Validation: all configured commands passed

Generated by RepoSync Hub.