### PR TITLE
docs: [sync] fix broken component documentation anchors

### DIFF
--- a/docs/src/pages/components/message/index.en-US.md
+++ b/docs/src/pages/components/message/index.en-US.md
@@ -155,4 +155,4 @@ Then `message.info`, `message.success` and other static methods will render with
 
 ### How to set static methods prefixCls? {#faq-set-prefix-cls}
 
-You can config with [`ConfigProvider.config`](/components/config-provider#configproviderconfig-4130).
+You can config with [`ConfigProvider.config`](/components/config-provider#config).

--- a/docs/src/pages/components/message/index.zh-CN.md
+++ b/docs/src/pages/components/message/index.zh-CN.md
@@ -156,4 +156,4 @@ ConfigProvider.config({
 
 ### 静态方法如何设置 prefixCls？ {#faq-set-prefix-cls}
 
-你可以通过 [`ConfigProvider.config`](/components/config-provider-cn#configproviderconfig-4130) 进行设置。
+你可以通过 [`ConfigProvider.config`](/components/config-provider-cn#config) 进行设置。

--- a/docs/src/pages/components/notification/index.en-US.md
+++ b/docs/src/pages/components/notification/index.en-US.md
@@ -185,7 +185,7 @@ Then `notification.open`, `notification.success` and other static methods will r
 
 ### How to set static methods prefixCls? {#faq-set-prefix-cls}
 
-You can config with [`ConfigProvider.config`](/components/config-provider#configproviderconfig-4130).
+You can config with [`ConfigProvider.config`](/components/config-provider#config).
 
 ### Why doesn't `style="width: max-content"` work on Notification? {#faq-notification-width}
 

--- a/docs/src/pages/components/notification/index.zh-CN.md
+++ b/docs/src/pages/components/notification/index.zh-CN.md
@@ -186,7 +186,7 @@ ConfigProvider.config({
 
 ### 静态方法如何设置 prefixCls？ {#faq-set-prefix-cls}
 
-你可以通过 [`ConfigProvider.config`](/components/config-provider-cn#configproviderconfig-4130) 进行设置。
+你可以通过 [`ConfigProvider.config`](/components/config-provider-cn#config) 进行设置。
 
 ### 为什么 `style="width: max-content"` 在 Notification 上不生效？ {#faq-notification-width}
 

--- a/docs/src/pages/components/upload/demo/style-class.vue
+++ b/docs/src/pages/components/upload/demo/style-class.vue
@@ -1,9 +1,9 @@
 <docs lang="zh-CN">
-通过 `classes` 和 `styles` 传入对象/函数可以自定义 Upload 的[语义化结构](#semantic-upload)样式。
+通过 `classes` 和 `styles` 传入对象/函数可以自定义 Upload 的[语义化结构](#semantic-dom)样式。
 </docs>
 
 <docs lang="en-US">
-You can customize the [semantic dom](#semantic-upload) style of Upload components by passing objects/functions through `classes` and `styles`.
+You can customize the [semantic dom](#semantic-dom) style of Upload components by passing objects/functions through `classes` and `styles`.
 </docs>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59220
- Upstream commit: `5b3d4a88addabc56ced59a7693f84f150ac0d97e`
- Validation: all configured commands passed

Generated by RepoSync Hub.