### PR TITLE
fix: [sync] add localized Carousel arrow labels

### DIFF
--- a/packages/antdv-next/src/locale/ar_EG.ts
+++ b/packages/antdv-next/src/locale/ar_EG.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'وسع',
     collapse: 'طي',
   },
+  Carousel: {
+    prevSlide: 'الشريحة السابقة',
+    nextSlide: 'الشريحة التالية',
+  },
   Form: {
     defaultValidateMessages: {
       default: 'خطأ في حقل الإدخال ${label}',

--- a/packages/antdv-next/src/locale/bg_BG.ts
+++ b/packages/antdv-next/src/locale/bg_BG.ts
@@ -131,6 +131,10 @@ const localeValues: Locale = {
     expand: 'Разширяване',
     collapse: 'Свиване',
   },
+  Carousel: {
+    prevSlide: 'Предишен слайд',
+    nextSlide: 'Следващ слайд',
+  },
   QRCode: {
     expired: 'QR кодът е изтекъл',
     refresh: 'Опресняване',

--- a/packages/antdv-next/src/locale/ca_ES.ts
+++ b/packages/antdv-next/src/locale/ca_ES.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Ampliar',
     collapse: 'Col·lapse',
   },
+  Carousel: {
+    prevSlide: 'Diapositiva anterior',
+    nextSlide: 'Diapositiva següent',
+  },
   Form: {
     optional: '(opcional)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/cs_CZ.ts
+++ b/packages/antdv-next/src/locale/cs_CZ.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Zvětšit',
     collapse: 'kolaps',
   },
+  Carousel: {
+    prevSlide: 'Předchozí snímek',
+    nextSlide: 'Další snímek',
+  },
   Form: {
     optional: '(nepovinné)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/da_DK.ts
+++ b/packages/antdv-next/src/locale/da_DK.ts
@@ -130,6 +130,10 @@ const localeValues: Locale = {
     expand: 'Udvid',
     collapse: 'Kollaps',
   },
+  Carousel: {
+    prevSlide: 'Forrige slide',
+    nextSlide: 'Næste slide',
+  },
   QRCode: {
     expired: 'QR-koden er udløbet',
     refresh: 'Opdater',

--- a/packages/antdv-next/src/locale/de_DE.ts
+++ b/packages/antdv-next/src/locale/de_DE.ts
@@ -81,6 +81,10 @@ const localeValues: Locale = {
     expand: 'Erweitern',
     collapse: 'Zusammenbruch',
   },
+  Carousel: {
+    prevSlide: 'Vorherige Folie',
+    nextSlide: 'Nächste Folie',
+  },
   Form: {
     defaultValidateMessages: {
       default: 'Feld-Validierungsfehler: ${label}',

--- a/packages/antdv-next/src/locale/el_GR.ts
+++ b/packages/antdv-next/src/locale/el_GR.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Ανάπτυξη',
     collapse: 'Σύμπτυξη',
   },
+  Carousel: {
+    prevSlide: 'Προηγούμενη διαφάνεια',
+    nextSlide: 'Επόμενη διαφάνεια',
+  },
   Form: {
     optional: '(προαιρετικό)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/en_GB.ts
+++ b/packages/antdv-next/src/locale/en_GB.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Expand',
     collapse: 'Collapse',
   },
+  Carousel: {
+    prevSlide: 'Previous slide',
+    nextSlide: 'Next slide',
+  },
   Form: {
     optional: '(optional)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/es_ES.ts
+++ b/packages/antdv-next/src/locale/es_ES.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Expandir',
     collapse: 'Colapso',
   },
+  Carousel: {
+    prevSlide: 'Diapositiva anterior',
+    nextSlide: 'Diapositiva siguiente',
+  },
   Form: {
     optional: '(opcional)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/et_EE.ts
+++ b/packages/antdv-next/src/locale/et_EE.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Laienda',
     collapse: 'Ahenda',
   },
+  Carousel: {
+    prevSlide: 'Eelmine slaid',
+    nextSlide: 'Järgmine slaid',
+  },
   Form: {
     optional: '(valikuline)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/fa_IR.ts
+++ b/packages/antdv-next/src/locale/fa_IR.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'توسعه',
     collapse: 'بستن',
   },
+  Carousel: {
+    prevSlide: 'اسلاید قبلی',
+    nextSlide: 'اسلاید بعدی',
+  },
   Form: {
     optional: '(اختیاری)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/fi_FI.ts
+++ b/packages/antdv-next/src/locale/fi_FI.ts
@@ -79,6 +79,10 @@ const localeValues: Locale = {
     expand: 'Näytä lisää',
     collapse: 'Kutista',
   },
+  Carousel: {
+    prevSlide: 'Edellinen dia',
+    nextSlide: 'Seuraava dia',
+  },
   QRCode: {
     expired: 'QR-koodi vanhentunut',
     refresh: 'Päivitä',

--- a/packages/antdv-next/src/locale/fr_BE.ts
+++ b/packages/antdv-next/src/locale/fr_BE.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Développer',
     collapse: 'Réduire',
   },
+  Carousel: {
+    prevSlide: 'Diapositive précédente',
+    nextSlide: 'Diapositive suivante',
+  },
   Form: {
     optional: '(optionnel)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/fr_CA.ts
+++ b/packages/antdv-next/src/locale/fr_CA.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Développer',
     collapse: 'Réduire',
   },
+  Carousel: {
+    prevSlide: 'Diapositive précédente',
+    nextSlide: 'Diapositive suivante',
+  },
   Form: {
     optional: '(optionnel)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/fr_FR.ts
+++ b/packages/antdv-next/src/locale/fr_FR.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Développer',
     collapse: 'Réduire',
   },
+  Carousel: {
+    prevSlide: 'Diapositive précédente',
+    nextSlide: 'Diapositive suivante',
+  },
   Form: {
     optional: '(optionnel)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/gl_ES.ts
+++ b/packages/antdv-next/src/locale/gl_ES.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'expandir',
     collapse: 'Colapsar',
   },
+  Carousel: {
+    prevSlide: 'Diapositiva anterior',
+    nextSlide: 'Diapositiva seguinte',
+  },
   Form: {
     defaultValidateMessages: {
       default: 'Error de validación do campo ${label}',

--- a/packages/antdv-next/src/locale/he_IL.ts
+++ b/packages/antdv-next/src/locale/he_IL.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'הרחב',
     collapse: 'התמוטט',
   },
+  Carousel: {
+    prevSlide: 'השקופית הקודמת',
+    nextSlide: 'השקופית הבאה',
+  },
   Form: {
     defaultValidateMessages: {
       default: 'ערך השדה שגוי ${label}',

--- a/packages/antdv-next/src/locale/hi_IN.ts
+++ b/packages/antdv-next/src/locale/hi_IN.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'विस्तार',
     collapse: 'पतन',
   },
+  Carousel: {
+    prevSlide: 'पिछली स्लाइड',
+    nextSlide: 'अगली स्लाइड',
+  },
   Form: {
     optional: '(ऐच्छिक)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/hr_HR.ts
+++ b/packages/antdv-next/src/locale/hr_HR.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Proširi',
     collapse: 'Sažimanje',
   },
+  Carousel: {
+    prevSlide: 'Prethodni slajd',
+    nextSlide: 'Sljedeći slajd',
+  },
   Form: {
     optional: '(neobavezno)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/hu_HU.ts
+++ b/packages/antdv-next/src/locale/hu_HU.ts
@@ -79,6 +79,10 @@ const localeValues: Locale = {
     expand: 'Bontsa ki',
     collapse: 'Összeomlás',
   },
+  Carousel: {
+    prevSlide: 'Előző dia',
+    nextSlide: 'Következő dia',
+  },
   QRCode: {
     expired: 'A QR kód lejárt',
     refresh: 'Frissítés',

--- a/packages/antdv-next/src/locale/id_ID.ts
+++ b/packages/antdv-next/src/locale/id_ID.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Perluas',
     collapse: 'Perkecil',
   },
+  Carousel: {
+    prevSlide: 'Slide sebelumnya',
+    nextSlide: 'Slide berikutnya',
+  },
   Form: {
     optional: '(optional)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/it_IT.ts
+++ b/packages/antdv-next/src/locale/it_IT.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'espandi',
     collapse: 'Crollo',
   },
+  Carousel: {
+    prevSlide: 'Diapositiva precedente',
+    nextSlide: 'Diapositiva successiva',
+  },
   Form: {
     optional: '(opzionale)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/ja_JP.ts
+++ b/packages/antdv-next/src/locale/ja_JP.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: '展開する',
     collapse: '折り畳む',
   },
+  Carousel: {
+    prevSlide: '前のスライド',
+    nextSlide: '次のスライド',
+  },
   Form: {
     optional: '(オプション)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/ko_KR.ts
+++ b/packages/antdv-next/src/locale/ko_KR.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: '확장',
     collapse: '접기',
   },
+  Carousel: {
+    prevSlide: '이전 슬라이드',
+    nextSlide: '다음 슬라이드',
+  },
   Form: {
     optional: '(선택사항)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/lt_LT.ts
+++ b/packages/antdv-next/src/locale/lt_LT.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Plačiau',
     collapse: 'Sutraukti',
   },
+  Carousel: {
+    prevSlide: 'Ankstesnė skaidrė',
+    nextSlide: 'Kita skaidrė',
+  },
   Form: {
     optional: '(neprivaloma)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/lv_LV.ts
+++ b/packages/antdv-next/src/locale/lv_LV.ts
@@ -79,6 +79,10 @@ const localeValues: Locale = {
     expand: 'Izvērst',
     collapse: 'Sakļaut',
   },
+  Carousel: {
+    prevSlide: 'Iepriekšējais slaids',
+    nextSlide: 'Nākamais slaids',
+  },
   QRCode: {
     expired: 'QR kods ir beidzies',
     refresh: 'Atsvaidzināt',

--- a/packages/antdv-next/src/locale/ms_MY.ts
+++ b/packages/antdv-next/src/locale/ms_MY.ts
@@ -85,6 +85,10 @@ const localeValues: Locale = {
     expand: 'Kembang',
     collapse: 'Runtuh',
   },
+  Carousel: {
+    prevSlide: 'Slaid sebelumnya',
+    nextSlide: 'Slaid seterusnya',
+  },
   Form: {
     optional: '(Opsional)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/nb_NO.ts
+++ b/packages/antdv-next/src/locale/nb_NO.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Utvid',
     collapse: 'Skjul',
   },
+  Carousel: {
+    prevSlide: 'Forrige lysbilde',
+    nextSlide: 'Neste lysbilde',
+  },
   Form: {
     optional: '(valgfritt)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/nl_BE.ts
+++ b/packages/antdv-next/src/locale/nl_BE.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Uitklappen',
     collapse: 'Samenvouwen',
   },
+  Carousel: {
+    prevSlide: 'Vorige dia',
+    nextSlide: 'Volgende dia',
+  },
   Form: {
     optional: '(optioneel)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/nl_NL.ts
+++ b/packages/antdv-next/src/locale/nl_NL.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Uitklappen',
     collapse: 'Samenvouwen',
   },
+  Carousel: {
+    prevSlide: 'Vorige dia',
+    nextSlide: 'Volgende dia',
+  },
   Form: {
     optional: '(optioneel)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/pl_PL.ts
+++ b/packages/antdv-next/src/locale/pl_PL.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Rozwiń',
     collapse: 'Zwiń',
   },
+  Carousel: {
+    prevSlide: 'Poprzedni slajd',
+    nextSlide: 'Następny slajd',
+  },
   Form: {
     optional: '(opcjonalne)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/pt_BR.ts
+++ b/packages/antdv-next/src/locale/pt_BR.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'expandir',
     collapse: 'Recolher',
   },
+  Carousel: {
+    prevSlide: 'Slide anterior',
+    nextSlide: 'Próximo slide',
+  },
   Form: {
     optional: '(opcional)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/pt_PT.ts
+++ b/packages/antdv-next/src/locale/pt_PT.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Expandir',
     collapse: 'Colapsar',
   },
+  Carousel: {
+    prevSlide: 'Diapositivo anterior',
+    nextSlide: 'Diapositivo seguinte',
+  },
   Form: {
     optional: '(opcional)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/ro_RO.ts
+++ b/packages/antdv-next/src/locale/ro_RO.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'extinde',
     collapse: 'Colaps',
   },
+  Carousel: {
+    prevSlide: 'Diapozitivul anterior',
+    nextSlide: 'Diapozitivul următor',
+  },
   Form: {
     optional: '(opțional)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/ru_RU.ts
+++ b/packages/antdv-next/src/locale/ru_RU.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Раскрыть',
     collapse: 'Свернуть',
   },
+  Carousel: {
+    prevSlide: 'Предыдущий слайд',
+    nextSlide: 'Следующий слайд',
+  },
   Form: {
     optional: '(необязательно)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/sk_SK.ts
+++ b/packages/antdv-next/src/locale/sk_SK.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Zväčšiť',
     collapse: 'kolaps',
   },
+  Carousel: {
+    prevSlide: 'Predchádzajúca snímka',
+    nextSlide: 'Ďalšia snímka',
+  },
   Form: {
     optional: '(nepovinné)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/sl_SI.ts
+++ b/packages/antdv-next/src/locale/sl_SI.ts
@@ -79,6 +79,10 @@ const localeValues: Locale = {
     expand: 'Razširi',
     collapse: 'Strni',
   },
+  Carousel: {
+    prevSlide: 'Prejšnja prosojnica',
+    nextSlide: 'Naslednja prosojnica',
+  },
   QRCode: {
     expired: 'Koda QR je potekla',
     refresh: 'Osveži',

--- a/packages/antdv-next/src/locale/sr_RS.ts
+++ b/packages/antdv-next/src/locale/sr_RS.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Proširi',
     collapse: 'Колапс',
   },
+  Carousel: {
+    prevSlide: 'Prethodni slajd',
+    nextSlide: 'Sledeći slajd',
+  },
   Form: {
     optional: '(opcionalno)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/sv_SE.ts
+++ b/packages/antdv-next/src/locale/sv_SE.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Expandera',
     collapse: 'Kollapsa',
   },
+  Carousel: {
+    prevSlide: 'Föregående bild',
+    nextSlide: 'Nästa bild',
+  },
   Form: {
     optional: '(valfritt)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/th_TH.ts
+++ b/packages/antdv-next/src/locale/th_TH.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'ขยาย',
     collapse: 'ย่อ',
   },
+  Carousel: {
+    prevSlide: 'สไลด์ก่อนหน้า',
+    nextSlide: 'สไลด์ถัดไป',
+  },
   Form: {
     optional: '(ไม่จำเป็น)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/tr_TR.ts
+++ b/packages/antdv-next/src/locale/tr_TR.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Genişlet',
     collapse: 'Daralt',
   },
+  Carousel: {
+    prevSlide: 'Önceki slayt',
+    nextSlide: 'Sonraki slayt',
+  },
   Form: {
     optional: '(opsiyonel)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/uk_UA.ts
+++ b/packages/antdv-next/src/locale/uk_UA.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Розширити',
     collapse: 'Згорнути',
   },
+  Carousel: {
+    prevSlide: 'Попередній слайд',
+    nextSlide: 'Наступний слайд',
+  },
   Form: {
     optional: '(опціонально)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/vi_VN.ts
+++ b/packages/antdv-next/src/locale/vi_VN.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: 'Mở rộng',
     collapse: 'Thu gọn',
   },
+  Carousel: {
+    prevSlide: 'Slide trước',
+    nextSlide: 'Slide tiếp theo',
+  },
   Form: {
     optional: '(Tùy chọn)',
     defaultValidateMessages: {

--- a/packages/antdv-next/src/locale/zh_HK.ts
+++ b/packages/antdv-next/src/locale/zh_HK.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: '展開',
     collapse: '收起',
   },
+  Carousel: {
+    prevSlide: '上一張幻燈片',
+    nextSlide: '下一張幻燈片',
+  },
   Form: {
     defaultValidateMessages: {
       default: '字段驗證錯誤${label}',

--- a/packages/antdv-next/src/locale/zh_TW.ts
+++ b/packages/antdv-next/src/locale/zh_TW.ts
@@ -84,6 +84,10 @@ const localeValues: Locale = {
     expand: '展開',
     collapse: '收合',
   },
+  Carousel: {
+    prevSlide: '上一張投影片',
+    nextSlide: '下一張投影片',
+  },
   Form: {
     optional: '（選填）',
     defaultValidateMessages: {


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59218
- Upstream commit: `a29b0f087b0c76db3bfdd8e40daba4f122f3a1a9`
- Validation: all configured commands passed

Generated by RepoSync Hub.