### PR TITLE
fix: [sync] avoid mutating user mask configuration

### DIFF
--- a/packages/antdv-next/src/_util/hooks/useMergedMask.ts
+++ b/packages/antdv-next/src/_util/hooks/useMergedMask.ts
@@ -12,7 +12,8 @@ export function normalizeMaskConfig(mask?: MaskType, maskClosable?: boolean): Ma
   let maskConfig: MaskConfig = {}
 
   if (mask && typeof mask === 'object') {
-    maskConfig = mask
+    // Copy so that filling `closable` below never writes back to the user's `mask` object
+    maskConfig = { ...mask }
   }
   if (typeof mask === 'boolean') {
     maskConfig = {

--- a/packages/antdv-next/src/modal/tests/Modal.test.tsx
+++ b/packages/antdv-next/src/modal/tests/Modal.test.tsx
@@ -1,3 +1,4 @@
+import type { MaskType } from '../../_util/hooks'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, onMounted } from 'vue'
 import Modal from '..'
@@ -41,6 +42,36 @@ describe('modal static', () => {
     await waitFakeTimer(1, 5)
 
     expect(document.querySelectorAll('.ant-modal-confirm-btns .ant-btn')).toHaveLength(2)
+  })
+
+  it('should not mutate the mask config object', async () => {
+    const mask: MaskType = { blur: true }
+
+    Modal.confirm({ mask })
+    await waitFakeTimer(1, 5)
+
+    expect(mask).toEqual({ blur: true })
+  })
+
+  it('should keep mask closable when the mask config object is reused', async () => {
+    const mask: MaskType = { blur: true }
+    Modal.confirm({ mask })
+    await waitFakeTimer(1, 5)
+    Modal.destroyAll()
+    await waitFakeTimer(1, 5)
+
+    const onCancel = vi.fn()
+    mount(Modal, {
+      attachTo: document.body,
+      props: { open: true, mask, onCancel },
+    })
+    await waitFakeTimer(20, 10)
+
+    const wrap = document.querySelector<HTMLElement>('.ant-modal-wrap')!
+    wrap.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    wrap.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(onCancel).toHaveBeenCalled()
   })
 
   it('modal.confirm should support locale from holderRender config', async () => {


### PR DESCRIPTION
## Summary

Synchronized from upstream ant-design/ant-design.

- Upstream PR: https://github.com/ant-design/ant-design/pull/59233
- Upstream commit: `23207f0c626a30daf23ddd43d8ec29f71c467fbb`
- Validation: all configured commands passed

Generated by RepoSync Hub.