### PR TITLE
fix(date-picker): [sync] use German field date formats

### DIFF
--- a/packages/antdv-next/src/date-picker/locale/de_DE.ts
+++ b/packages/antdv-next/src/date-picker/locale/de_DE.ts
@@ -32,6 +32,8 @@ const locale: PickerLocale = {
       'Dez',
     ],
     ...CalendarLocale,
+    fieldDateFormat: 'DD.MM.YYYY',
+    fieldDateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
   },
   timePickerLocale: {
     ...TimePickerLocale,

--- a/packages/antdv-next/src/date-picker/tests/other.test.tsx
+++ b/packages/antdv-next/src/date-picker/tests/other.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { h, nextTick } from 'vue'
 import DatePicker from '..'
 import ConfigProvider from '../../config-provider'
+import deDE from '../../locale/de_DE'
 import jaJP from '../../locale/ja_JP'
 import zhCN from '../../locale/zh_CN'
 import zhTW from '../locale/zh_TW'
@@ -61,6 +62,23 @@ describe('date-picker.other', () => {
       render: () => h(ConfigProvider, { locale: myLocale as any }, { default: () => h(WeekPicker) }),
     })
     expect(weekWrapper.find('input').attributes('placeholder')).toBe('自定义周占位')
+  })
+
+  it('should use the German date formats', () => {
+    const date = dayjs('2000-01-01 00:00:00')
+    const dateWrapper = mount({
+      render: () => h(ConfigProvider, { locale: deDE }, {
+        default: () => h(DatePicker, { value: date }),
+      }),
+    })
+    expect(dateWrapper.find('input').element.value).toBe('01.01.2000')
+
+    const dateTimeWrapper = mount({
+      render: () => h(ConfigProvider, { locale: deDE }, {
+        default: () => h(DatePicker, { value: date, showTime: true }),
+      }),
+    })
+    expect(dateTimeWrapper.find('input').element.value).toBe('01.01.2000 00:00:00')
   })
 
   it('should render MonthPicker dropdown when open', async () => {


### PR DESCRIPTION
[English template / 英文模板](https://github.com/antdv-next/antdv-next/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [x] 🌐 国际化
- [x] 🐞 Bug 修复

### 🔗 相关 Issue

- 上游 PR: https://github.com/ant-design/ant-design/pull/59151
- 上游 commit: `9e9d2d506bc660799d3e186a2b545ac5de733322`

### 💡 背景与方案

同步 ant-design#59151。de_DE 的 DatePicker locale 缺少 `fieldDateFormat` / `fieldDateTimeFormat`，在德语 ConfigProvider 下输入框仍显示 `YYYY-MM-DD`。补充为 `DD.MM.YYYY` 与 `DD.MM.YYYY HH:mm:ss`，并在 `date-picker/tests/other.test.tsx` 增加断言。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | DatePicker: use German date formats (`DD.MM.YYYY`) under the `de_DE` locale. |
| 🇨🇳 中文 | DatePicker: 在 `de_DE` 语言下使用德语日期格式（`DD.MM.YYYY`）。 |