### PR TITLE
fix(input): [sync] preserve custom enterButton handlers in Search

### DIFF
--- a/packages/antdv-next/src/input/Search.tsx
+++ b/packages/antdv-next/src/input/Search.tsx
@@ -286,13 +286,14 @@ const InternalSearch = defineComponent<
       const isNativeButton = isButtonVNode && (enterButtonNode.type as any) === 'button'
       if (isAntdButton || isNativeButton) {
         const enterButtonProps = (enterButtonNode as any)?.props ?? {}
+        // `cloneVNode` merges `on*` listeners with `mergeProps`, so the custom
+        // button's own `onMousedown` / `onClick` keep running before ours.
+        // Do not call them again here, otherwise they fire twice.
+        // sync ant-design#59180
         buttonNode = cloneVNode(enterButtonNode as any, {
           disabled: mergedDisabled.value || enterButtonProps.disabled || (!isAntdButton && props.loading),
           onMousedown: onMouseDown,
-          onClick: (e: MouseEvent) => {
-            enterButtonProps.onClick?.(e)
-            onSearchClick(e)
-          },
+          onClick: onSearchClick,
           class: clsx(enterButtonProps.class, btnClassName),
           ...(isAntdButton
             ? {

--- a/packages/antdv-next/src/input/tests/Search.test.tsx
+++ b/packages/antdv-next/src/input/tests/Search.test.tsx
@@ -187,6 +187,54 @@ describe('search', () => {
       expect(wrapper.find('button').attributes('disabled')).toBeDefined()
     })
 
+    it('should preserve custom Button mousedown and click handlers', async () => {
+      const onMousedown = vi.fn()
+      const onClick = vi.fn()
+      const onSearch = vi.fn()
+      const wrapper = mount(() => (
+        <Search
+          enterButton={(
+            <Button onMousedown={onMousedown} onClick={onClick}>
+              ok
+            </Button>
+          )}
+          onSearch={onSearch}
+        />
+      ))
+
+      const button = wrapper.find('button')
+      await button.trigger('mousedown')
+      expect(onMousedown).toHaveBeenCalledTimes(1)
+
+      await button.trigger('click')
+      expect(onClick).toHaveBeenCalledTimes(1)
+      expect(onSearch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should preserve custom native button mousedown and click handlers', async () => {
+      const onMousedown = vi.fn()
+      const onClick = vi.fn()
+      const onSearch = vi.fn()
+      const wrapper = mount(() => (
+        <Search
+          enterButton={(
+            <button type="button" onMousedown={onMousedown} onClick={onClick}>
+              ok
+            </button>
+          )}
+          onSearch={onSearch}
+        />
+      ))
+
+      const button = wrapper.find('button')
+      await button.trigger('mousedown')
+      expect(onMousedown).toHaveBeenCalledTimes(1)
+
+      await button.trigger('click')
+      expect(onClick).toHaveBeenCalledTimes(1)
+      expect(onSearch).toHaveBeenCalledTimes(1)
+    })
+
     it('should disable custom native button when loading prop is true', async () => {
       const onSearch = vi.fn()
       const wrapper = mount(() => (


### PR DESCRIPTION
[English template / 英文模板](https://github.com/antdv-next/antdv-next/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

- 上游 PR: https://github.com/ant-design/ant-design/pull/59180
- 上游 commit: `3eb4c6eb1d`

### 💡 背景与方案

同步 ant-design#59180（保留自定义 `enterButton` 的 `onMouseDown`）。

Vue 侧 `cloneVNode` 通过 `mergeProps` 会自动把自定义按钮自身的 `onMousedown` / `onClick` 与 Search 的监听串联执行，因此 `onMousedown` 本来就已保留。但原实现在包装函数里又显式调用了一次 `enterButtonProps.onClick`，导致用户的 `onClick` 触发两次。本 PR 去掉手动调用，仅依赖 `mergeProps` 合并，并为 antd Button 与原生 button 两种 `enterButton` 增加 `onMousedown` / `onClick` 各触发一次的测试。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Input.Search: fix custom `enterButton` `onClick` firing twice and keep its own `onMousedown`. |
| 🇨🇳 中文 | Input.Search: 修复自定义 `enterButton` 的 `onClick` 触发两次的问题，并保留其自身的 `onMousedown`。 |