### PR TITLE
test(checkbox): [sync] cover undefined group value as uncontrolled

### DIFF
--- a/packages/antdv-next/src/checkbox/tests/Checkbox.test.tsx
+++ b/packages/antdv-next/src/checkbox/tests/Checkbox.test.tsx
@@ -282,6 +282,30 @@ describe('checkboxGroup', () => {
     expect(items![0]!.text()).toBe('1')
   })
 
+  // sync ant-design#59217
+  describe('value is undefined', () => {
+    it('should use defaultValue when value is undefined', () => {
+      const wrapper = mount(CheckboxGroup, {
+        props: { defaultValue: ['A'], value: undefined, options: ['A'] },
+      })
+      expect(wrapper.findAll('.ant-checkbox-checked')).toHaveLength(1)
+    })
+
+    it('should update value when value is undefined', async () => {
+      const onChange = vi.fn()
+      const wrapper = mount(CheckboxGroup, {
+        props: { defaultValue: ['A'], value: undefined, options: ['A', 'B'], onChange },
+      })
+      const inputs = wrapper.findAll('input')
+      expect((inputs[0]!.element as HTMLInputElement).checked).toBe(true)
+
+      await inputs[1]!.trigger('change')
+      expect((inputs[0]!.element as HTMLInputElement).checked).toBe(true)
+      expect((inputs[1]!.element as HTMLInputElement).checked).toBe(true)
+      expect(onChange).toHaveBeenCalledWith(['A', 'B'])
+    })
+  })
+
   it('should ignore options with nullish values', async () => {
     const onChange = vi.fn()
     const wrapper = mount(CheckboxGroup, {


### PR DESCRIPTION
[English template / 英文模板](https://github.com/antdv-next/antdv-next/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [x] ✅ 测试用例

### 🔗 相关 Issue

- 上游 PR: https://github.com/ant-design/ant-design/pull/59217
- 上游 commit: `89d0b038132adb6e1dfc84a4f2104f4fe7c7910d`

### 💡 背景与方案

同步 ant-design#59217。Vue 版 `Checkbox.Group` 已将 `value === undefined` 视为非受控（初始取 `defaultValue`，切换时更新内部状态），行为与上游修复后一致。本 PR 仅补充上游新增的两条测试用例，锁定该行为。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | N/A（仅测试） |
| 🇨🇳 中文 | N/A（仅测试） |