### PR TITLE
test(layout): [sync] treat undefined collapsed as uncontrolled

### DIFF
--- a/packages/antdv-next/src/layout/tests/Layout.test.tsx
+++ b/packages/antdv-next/src/layout/tests/Layout.test.tsx
@@ -350,6 +350,22 @@ describe('layout', () => {
         expect(wrapper.find('.ant-layout-sider').attributes('style')).toContain('width: 80px')
       })
 
+      // sync ant-design#59175
+      it('should treat undefined collapsed as uncontrolled', async () => {
+        const onCollapse = vi.fn()
+        const wrapper = mount(() => (
+          <Layout>
+            <LayoutSider collapsible collapsed={undefined} onCollapse={onCollapse}>
+              {{ default: () => 'Sider', trigger: () => <span>T</span> }}
+            </LayoutSider>
+          </Layout>
+        ))
+
+        await wrapper.find('.ant-layout-sider-trigger').trigger('click')
+        expect(wrapper.find('.ant-layout-sider-collapsed').exists()).toBe(true)
+        expect(onCollapse).toHaveBeenCalledWith(true, 'clickTrigger')
+      })
+
       it('should not toggle internally in controlled mode', async () => {
         const wrapper = mount(() => (
           <Layout>


### PR DESCRIPTION
[English template / 英文模板](https://github.com/antdv-next/antdv-next/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [x] ✅ 测试用例

### 🔗 相关 Issue

- 上游 PR: https://github.com/ant-design/ant-design/pull/59175
- 上游 commit: `78e3a0a68663a0b9419cb20045d862bfe181c557`

### 💡 背景与方案

同步 ant-design#59175。Vue 版 `Layout.Sider` 已将 `collapsed === undefined` 视为非受控（点击 trigger 会切换并触发 `collapse(true, 'clickTrigger')`），行为与上游修复后一致。本 PR 仅补充上游新增的测试用例。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | N/A（仅测试） |
| 🇨🇳 中文 | N/A（仅测试） |