### PR TITLE
fix(float-button): resolve menu flicker when using hover trigger

### DIFF
--- a/packages/antdv-next/src/float-button/style/group.ts
+++ b/packages/antdv-next/src/float-button/style/group.ts
@@ -14,28 +14,7 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
 
   const [varName, varRef] = genCssVar(antCls, 'float-btn')
 
-  // ==============================================================
-  // ==                       Hover Bridge                       ==
-  // ==============================================================
-  // The hover bridge is an invisible element that extends the hit area between the trigger and the popup.
-  // This prevents flickering when moving the mouse from the trigger to the popup, as it ensures that the mouse never crosses an un-owned gap.
   const bridgeGap = unit(token.calc(padding).mul(-1).equal())
-  const hoverBridgeStyle: CSSObject = {
-    content: '""',
-    position: 'absolute',
-  }
-  const topBottomHoverBridgeStyle: CSSObject = {
-    ...hoverBridgeStyle,
-    insetInlineStart: 0,
-    width: '100%',
-    height: unit(padding),
-  }
-  const leftRightHoverBridgeStyle: CSSObject = {
-    ...hoverBridgeStyle,
-    insetBlockStart: 0,
-    width: unit(padding),
-    height: '100%',
-  }
 
   return {
     [groupCls]: [
@@ -90,8 +69,16 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
         },
 
         // =========================== Menu ===========================
+        // The hover bridge is an invisible element that extends the hit area between the trigger and the popup.
+        // This prevents flickering when moving the mouse from the trigger to the popup, as it ensures that the mouse never crosses an un-owned gap.
         [`&-menu-mode ${listCls}`]: {
           position: 'absolute',
+
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            inset: 0,
+          },
         },
 
         // ========================== Motion ==========================
@@ -126,7 +113,7 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
             bottom: varRef('list-trigger-offset'),
 
             '&::after': {
-              ...topBottomHoverBridgeStyle,
+              top: '100%',
               bottom: bridgeGap,
             },
           },
@@ -138,8 +125,8 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
             top: varRef('list-trigger-offset'),
 
             '&::after': {
-              ...topBottomHoverBridgeStyle,
               top: bridgeGap,
+              bottom: '100%',
             },
           },
         },
@@ -150,7 +137,7 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
             right: varRef('list-trigger-offset'),
 
             '&::after': {
-              ...leftRightHoverBridgeStyle,
+              left: '100%',
               right: bridgeGap,
             },
           },
@@ -162,8 +149,8 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
             left: varRef('list-trigger-offset'),
 
             '&::after': {
-              ...leftRightHoverBridgeStyle,
               left: bridgeGap,
+              right: '100%',
             },
           },
         },

--- a/packages/antdv-next/src/float-button/style/group.ts
+++ b/packages/antdv-next/src/float-button/style/group.ts
@@ -14,6 +14,29 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
 
   const [varName, varRef] = genCssVar(antCls, 'float-btn')
 
+  // ==============================================================
+  // ==                       Hover Bridge                       ==
+  // ==============================================================
+  // The hover bridge is an invisible element that extends the hit area between the trigger and the popup.
+  // This prevents flickering when moving the mouse from the trigger to the popup, as it ensures that the mouse never crosses an un-owned gap.
+  const bridgeGap = unit(token.calc(padding).mul(-1).equal())
+  const hoverBridgeStyle: CSSObject = {
+    content: '""',
+    position: 'absolute',
+  }
+  const topBottomHoverBridgeStyle: CSSObject = {
+    ...hoverBridgeStyle,
+    insetInlineStart: 0,
+    width: '100%',
+    height: unit(padding),
+  }
+  const leftRightHoverBridgeStyle: CSSObject = {
+    ...hoverBridgeStyle,
+    insetBlockStart: 0,
+    width: unit(padding),
+    height: '100%',
+  }
+
   return {
     [groupCls]: [
       // ==============================================================
@@ -101,6 +124,11 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
         '&-top': {
           [listCls]: {
             bottom: varRef('list-trigger-offset'),
+
+            '&::after': {
+              ...topBottomHoverBridgeStyle,
+              bottom: bridgeGap,
+            },
           },
         },
 
@@ -108,6 +136,11 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
           [listCls]: {
             [varName('list-transform-start')]: `translate(0, calc(${unit(floatButtonSize)} * -1))`,
             top: varRef('list-trigger-offset'),
+
+            '&::after': {
+              ...topBottomHoverBridgeStyle,
+              top: bridgeGap,
+            },
           },
         },
 
@@ -115,6 +148,11 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
           [listCls]: {
             [varName('list-transform-start')]: `translate(${unit(floatButtonSize)}, 0)`,
             right: varRef('list-trigger-offset'),
+
+            '&::after': {
+              ...leftRightHoverBridgeStyle,
+              right: bridgeGap,
+            },
           },
         },
 
@@ -122,6 +160,11 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
           [listCls]: {
             [varName('list-transform-start')]: `translate(calc(${unit(floatButtonSize)} * -1), 0)`,
             left: varRef('list-trigger-offset'),
+
+            '&::after': {
+              ...leftRightHoverBridgeStyle,
+              left: bridgeGap,
+            },
           },
         },
       },


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 💄 Component style improvement

### 💡 Background and Solution

When `FloatButton.Group` uses `trigger="hover"` in menu mode, a gap exists between the trigger button and the popup list.

Moving the pointer through this gap temporarily leaves the group's hover area, causing the menu to close and reopen with a visible flicker.

### 📝 Fix:
This change adds an invisible `::after` hover bridge between the trigger and popup:

- Supports `top`, `bottom`, `left`, and `right` placements.
- Covers the existing gap without affecting layout or appearance.
- Shares common styles between vertical and horizontal placements.

#### Before:
<img width="1037" height="720" alt="1" src="https://github.com/user-attachments/assets/6010571c-4d89-4414-84e5-95a7666a9a0a" />

#### After:
<img width="978" height="720" alt="2" src="https://github.com/user-attachments/assets/57a0d105-5300-4d3c-aee3-5afccc2e3fce" />

