### PR TITLE
docs(rate): add defaultValue to English API table

### DIFF
--- a/docs/src/pages/components/rate/index.en-US.md
+++ b/docs/src/pages/components/rate/index.en-US.md
@@ -40,6 +40,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | allowHalf | Whether to allow semi selection | boolean | false |  | × |
 | character | The custom character of rate | VueNode \| (RateProps) => VueNode | &lt;StarFilled /> | function(): 4.4.0 | × |
 | count | Star count | number | 5 |  | × |
+| defaultValue | Default value | number | 0 |  | × |
 | disabled | If read only, unable to interact | boolean | false |  | × |
 | keyboard | Support keyboard operation | boolean | true | 5.18.0 | × |
 | size | Star size | 'small' \| 'medium' \| 'large' | 'medium' |  | × |


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

N/A

### 💡 背景与方案

Rate 英文 API 文档遗漏了 `defaultValue` 属性。

在英文 Props 表中补充：

- `defaultValue`
- 类型：`number`
- 默认值：`0`
- 描述：`Default value`

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |