### PR TITLE
fix(Tag): allow controlled null to clear selection

### DIFF
--- a/packages/antdv-next/src/tag/CheckableTagGroup.tsx
+++ b/packages/antdv-next/src/tag/CheckableTagGroup.tsx
@@ -97,7 +97,7 @@ const CheckableTagGroup = defineComponent<
       emit('update:value', value)
     },
     get() {
-      return props.value ?? _mergedValue.value
+      return props.value !== undefined ? props.value : _mergedValue.value
     },
   })
   const handleChange = (checked: boolean, option: CheckableTagOption) => {

--- a/packages/antdv-next/src/tag/tests/Tag.test.tsx
+++ b/packages/antdv-next/src/tag/tests/Tag.test.tsx
@@ -849,6 +849,16 @@ describe('checkable-tag-group', () => {
     expect(tags[0]!.classes()).not.toContain(`${prefixCls}-checkable-checked`)
   })
 
+  it('should clear the selected value when controlled value becomes null', async () => {
+    const wrapper = mount(CheckableTagGroup, {
+      props: { options, value: 'a' },
+    })
+
+    await wrapper.setProps({ value: null })
+
+    expect(wrapper.find(`.${prefixCls}-checkable-checked`).exists()).toBe(false)
+  })
+
   // ===================== multiple mode =====================
 
   it('should support multiple selection', async () => {


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

N/A

### 💡 背景与方案

CheckableTagGroup 单选模式允许将受控 `value` 设置为 `null`，但原有状态合并逻辑会将 `null` 误认为未受控状态并回退到内部值，导致已选标签无法清空。

本次变更仅在 `value` 为 `undefined` 时回退到内部状态，使 `null` 正确保留“无选中项”的受控语义，并添加从非空值更新为 `null` 的回归测试。不涉及公开 API 变化。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Fix CheckableTagGroup not clearing the selection when its controlled value becomes `null` |
| 🇨🇳 中文 | 修复 CheckableTagGroup 受控值变为 `null` 时无法清空选择的问题 |