### PR TITLE
docs(breadcrumb): correct itemRender slot signature

### DIFF
--- a/docs/src/pages/components/breadcrumb/index.en-US.md
+++ b/docs/src/pages/components/breadcrumb/index.en-US.md
@@ -54,7 +54,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 
 | Slot | Description | Type | Version |
 | --- | --- | --- | --- |
-| itemRender | Custom item renderer, work with vue-router | (route: ItemType, params: AnyObject, routes: ItemType[], paths: string[]) =&gt; any | - |
+| itemRender | Custom item renderer, work with vue-router | (context: \{ route: ItemType, params: AnyObject, routes: ItemType[], paths: string[] \}) =&gt; any | - |
 | titleRender | Custom title renderer | (params: \{ item: ItemType, index: number \}) =&gt; any | - |
 | separator | Custom separator | () =&gt; any | - |
 | menuLabelRender | Custom menu label renderer | (params: \{ item: ItemType, index: number, menu: MenuItem \}) =&gt; any | - |

--- a/docs/src/pages/components/breadcrumb/index.zh-CN.md
+++ b/docs/src/pages/components/breadcrumb/index.zh-CN.md
@@ -55,7 +55,7 @@ demo:
 
 | 插槽 | 说明 | 类型 | 版本 |
 | --- | --- | --- | --- |
-| itemRender | 自定义链接函数，和 vue-router 配置使用 | (route: ItemType, params: AnyObject, routes: ItemType[], paths: string[]) =&gt; any | - |
+| itemRender | 自定义链接函数，和 vue-router 配置使用 | (context: \{ route: ItemType, params: AnyObject, routes: ItemType[], paths: string[] \}) =&gt; any | - |
 | titleRender | 自定义标题渲染 | (params: \{ item: ItemType, index: number \}) =&gt; any | - |
 | separator | 分隔符自定义 | () =&gt; any | - |
 | menuLabelRender | 自定义菜单标签渲染 | (params: \{ item: ItemType, index: number, menu: MenuItem \}) =&gt; any | - |


### PR DESCRIPTION
## Summary

- Update the `itemRender` slot signature in the English and Chinese documentation.
- Clarify that the scoped slot receives a single context object containing `route`, `params`, `routes`, and `paths`.
- Keep the `itemRender` prop signature unchanged.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     (context: \{ route: ItemType, params: AnyObject, routes: ItemType[], paths: string[] \}) =&gt; any      |
| 🇨🇳 Chinese |     (context: \{ route: ItemType, params: AnyObject, routes: ItemType[], paths: string[] \}) =&gt; any      |
