### PR TITLE
fix(breadcrumb): avoid mutating menu config

### DIFF
--- a/packages/antdv-next/src/breadcrumb/Breadcrumb.tsx
+++ b/packages/antdv-next/src/breadcrumb/Breadcrumb.tsx
@@ -244,15 +244,16 @@ const Breadcrumb = defineComponent<
           const itemProps: BreadcrumbItemProps = {}
           const isLastItem = index === mergedItems.value.length - 1
           if (menu) {
+            const mergedMenu = { ...menu }
             const menuLabelRender = slots?.menuLabelRender ?? props.menuLabelRender
             if (menuLabelRender) {
-              menu.labelRender = menuItem => menuLabelRender({ item, index, menu: menuItem })
+              mergedMenu.labelRender = menuItem => menuLabelRender({ item, index, menu: menuItem })
             }
             const menuExtraRender = slots?.menuExtraRender ?? props.menuExtraRender
             if (menuExtraRender) {
-              menu.extraRender = menuItem => menuExtraRender({ item, index, menu: menuItem })
+              mergedMenu.extraRender = menuItem => menuExtraRender({ item, index, menu: menuItem })
             }
-            itemProps.menu = menu
+            itemProps.menu = mergedMenu
           }
 
           let { href } = item

--- a/packages/antdv-next/src/breadcrumb/tests/Breadcrumb.test.tsx
+++ b/packages/antdv-next/src/breadcrumb/tests/Breadcrumb.test.tsx
@@ -198,6 +198,26 @@ describe('breadcrumb', () => {
     expect(wrapper.findAll('.ant-breadcrumb-link').length).toBe(3)
   })
 
+  it('should not mutate menu config when using menu render slots', () => {
+    const menu = {
+      items: [{ key: '1', label: 'App1' }],
+    }
+
+    mount(Breadcrumb, {
+      props: {
+        items: [{ title: 'Application', menu }],
+      },
+      slots: {
+        menuLabelRender: ({ menu: menuItem }: any) => menuItem.label,
+        menuExtraRender: ({ menu: menuItem }: any) => menuItem.key,
+      },
+    })
+
+    expect(menu).toEqual({
+      items: [{ key: '1', label: 'App1' }],
+    })
+  })
+
   it('should render dropdown icon when using BreadcrumbItem children with menu', () => {
     const wrapper = mount(() => (
       <Breadcrumb>


### PR DESCRIPTION
### 💡 Background and Solution

Breadcrumb previously assigned the generated render functions directly to `item.menu`. Since the menu object comes from the `items` prop, this modified the object owned by the caller.

### 📝 Change Log

- Clone the Breadcrumb item menu config before injecting `labelRender` and `extraRender`.
- Prevent `menuLabelRender` and `menuExtraRender` from mutating the user-provided `items` data.
- Add a regression test covering both menu render slots.
