### PR TITLE
fix(config-provider): preserve zeroRuntime in isolated themes

### DIFF
--- a/packages/antdv-next/src/config-provider/hooks/useTheme.ts
+++ b/packages/antdv-next/src/config-provider/hooks/useTheme.ts
@@ -19,6 +19,7 @@ export function useTheme(
         ...defaultConfig,
         hashed: parentTheme?.value?.hashed ?? defaultConfig.hashed,
         cssVar: parentTheme?.value?.cssVar,
+        zeroRuntime: parentTheme?.value?.zeroRuntime,
       }
     }
     return parentTheme.value

--- a/packages/antdv-next/src/config-provider/tests/zero-runtime.test.tsx
+++ b/packages/antdv-next/src/config-provider/tests/zero-runtime.test.tsx
@@ -48,6 +48,26 @@ describe('configProvider theme.zeroRuntime', () => {
     wrapper.unmount()
   })
 
+  it('inherits zeroRuntime through nested themes with inheritance disabled', async () => {
+    const wrapper = mount(
+      () => h(
+        ConfigProvider,
+        { theme: { zeroRuntime: true } },
+        {
+          default: () => h(
+            ConfigProvider,
+            { theme: { inherit: false } },
+            { default: () => h(SmileOutlined) },
+          ),
+        },
+      ),
+      { attachTo: document.body },
+    )
+    await flush()
+    expect(document.head.querySelector(ICON_STYLE_SELECTOR)).toBeFalsy()
+    wrapper.unmount()
+  })
+
   // https://github.com/ant-design/ant-design/pull/58559
   it('does not rewrite icon runtime style when cssinjs layer is enabled', async () => {
     const wrapper = mount(


### PR DESCRIPTION
### 🤔 This is a ...
- [x] 🐞 Bug fix

### 🔗 Related Issues

ref [ant-design/ant-design #59250](https://github.com/ant-design/ant-design/pull/59250)
ref [ant-design/ant-design #59247](https://github.com/ant-design/ant-design/issues/59247)

## 🔁 Steps to Reproduce
- Home -> Components -> FloatButton -> Semantic DOM

<img width="261" height="388" alt="image" src="https://github.com/user-attachments/assets/ed6ee701-55ca-48a3-8e09-af75024fa3bc" />


### 💡 Background and Solution

When the parent `ConfigProvider` enables `theme.zeroRuntime: true`, a nested
`ConfigProvider` with `theme.inherit: false` loses the parent `zeroRuntime`
setting if it does not explicitly define its own value.

This causes the nested theme to generate styles at runtime again, allowing
runtime-injected styles to coexist with and potentially override the
prebuilt CSS. The issue can occur in theme previews and SPA navigation flows.

### 📝 Change Log

- Preserve the parent `zeroRuntime` value in the `inherit: false` branch of
  `useTheme`.
- Keep explicit child configuration precedence:
  - `zeroRuntime: true` remains `true`
  - `zeroRuntime: false` remains `false`
- Add a regression test covering a nested `ConfigProvider` where the parent
  enables zero-runtime mode and the child disables theme inheritance without
  specifying `zeroRuntime`

### ✅ Verification
- pnpm build:site
- pnpm -F docs preview
- All theme switching tests passed

<img width="207" height="376" alt="image" src="https://github.com/user-attachments/assets/487d0beb-facb-452b-b19f-559e28d80514" />

