### PR TITLE
fix(docs): fix press-enter event

### DIFF
--- a/docs/src/pages/components/tag/demo/control.vue
+++ b/docs/src/pages/components/tag/demo/control.vue
@@ -112,7 +112,7 @@ const tagPlusStyle: CSSProperties = {
         type="text" size="small"
         :style="tagInputStyle"
         @blur="handleInputConfirm"
-        @press.enter="handleInputConfirm"
+        @press-enter="handleInputConfirm"
       />
     </template>
     <template v-else>


### PR DESCRIPTION

### 🤔 This is a ...

- [x] 🐞 Bug fix

## 🧭 Background

The Tag control demo uses unsupported `@press.enter` syntax for `a-input`.

## 🛠️ Solution

- Replace `@press.enter` with `@press-enter` in the Tag control demo.
- Align the demo with the event contract exposed by `a-input`.
- Keep the behavior unchanged: pressing Enter confirms the input value.
