### PR TITLE
docs: fix pro-components link and sync awesome page

### DIFF
--- a/docs/src/pages/docs/vue/awesome.en-US.md
+++ b/docs/src/pages/docs/vue/awesome.en-US.md
@@ -24,4 +24,5 @@ title: Awesome
 | ---- | ---- |
 | [Fantastic-admin](https://fantastic-admin.hurui.me/) | AI-oriented admin system framework |
 | [antdv-next-tiptap](https://pengyinghao.github.io/antdv-next-tiptap/) | A rich text editor built with Vue3, antdv-next, and tiptap |
+| [antdv-next-pro-components](https://github.com/lucasjeke/pro-components/) | A component library based on antdv-next with enterprise-level components |
 | [Naive Admin](https://naiveadmin.com) | Out-of-the-box front-end and back-end framework |

--- a/docs/src/pages/docs/vue/awesome.zh-CN.md
+++ b/docs/src/pages/docs/vue/awesome.zh-CN.md
@@ -24,5 +24,5 @@ title: 社区生态
 | ---- | ---- |
 | [Fantastic-admin](https://fantastic-admin.hurui.me/) | 面向AI的管理系统框架 |
 | [antdv-next-tiptap](https://pengyinghao.github.io/antdv-next-tiptap/) | 基于vue3+antdv-next+tiptap 封装的富文本编辑器 |
-| [antdv-next-pro-components](https://github.com/archiesong/pro-components/) | 基于antdv-next的组件库，包含企业级组件 |
+| [antdv-next-pro-components](https://github.com/lucasjeke/pro-components/) | 基于antdv-next的组件库，包含企业级组件 |
 | [Naive Admin](https://naiveadmin.com) | 开箱即用前后端框架 |


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 📝 站点 / 文档改进

### 🔗 相关 Issue

N/A

### 💡 背景与方案

社区生态页（/docs/vue/awesome-cn）中 `antdv-next-pro-components` 的仓库已由 `archiesong/pro-components` 转移至 `lucasjeke/pro-components`，原链接目前仅依赖 GitHub 的转移重定向。本次变更：

- 中文版页面：将 pro-components 链接更新为转移后的新地址；
- 英文版页面：补充此前缺失的 `antdv-next-pro-components` 条目（该条目此前仅中文版收录），使中英文内容一致。

所有链接已逐一验证可访问（HTTP 200）。改动仅涉及文档 Markdown，不影响组件代码与公开 API。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |