### PR TITLE
fix(docs): prevent sponsor popovers when payment buttons are disabled

### DIFF
--- a/docs/src/pages/sponsor/index.vue
+++ b/docs/src/pages/sponsor/index.vue
@@ -1019,7 +1019,7 @@ watch(scanPayVisible, (visible) => {
                   @{{ member.github }}
                 </a>
                 <div class="flex items-center justify-center gap-2 mt-3">
-                  <a-popover trigger="hover" placement="bottom">
+                  <a-popover trigger="hover" placement="bottom" :disabled="!member.alipayCode">
                     <template #content>
                       <a-qrcode
                         :value="member.alipayCode || 'not-available'"
@@ -1036,7 +1036,7 @@ watch(scanPayVisible, (visible) => {
                       支付宝
                     </button>
                   </a-popover>
-                  <a-popover trigger="hover" placement="bottom">
+                  <a-popover trigger="hover" placement="bottom" :disabled="!member.wxCode">
                     <template #content>
                       <a-qrcode
                         :value="member.wxCode || 'not-available'"


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

N/A

### 💡 背景与方案

赞助页（个人赞助 Tab）中，支付宝 / 微信两个 `a-popover` 包裹的按钮在成员缺少对应收款码时会 `disabled`，但 popover 本身未禁用，导致悬停禁用按钮时二维码弹层依然弹出。
<img width="1017" height="719" alt="sponsor-qr-code-1" src="https://github.com/user-attachments/assets/eb7b50bc-de7c-4e60-ad9c-395701d72e6c" />


解决方案：为两个 `a-popover` 增加与内部按钮一致的 `disabled` 条件。
<img width="1017" height="719" alt="sponsor-qr-code-2" src="https://github.com/user-attachments/assets/353fd639-d3c3-48f8-96b7-ab46c0da11af" />


变更仅涉及站点赞助页，不影响组件库 API 与交互。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required (site-only fix) |
| 🇨🇳 中文 | 无需更新日志（仅站点页面修复） |