### PR TITLE
fix(table): support pagination classes and styles configured via Table

### DIFF
--- a/packages/antdv-next/src/table/InternalTable.tsx
+++ b/packages/antdv-next/src/table/InternalTable.tsx
@@ -31,7 +31,7 @@ import pickAttrs from '@v-c/util/dist/pickAttrs'
 import { getAttrStyleAndClass } from '@v-c/util/dist/props-util'
 import { omit } from 'es-toolkit'
 import { computed, defineComponent, h, inject, provide, shallowRef, watch, watchEffect } from 'vue'
-import { useMergeSemantic, useSemanticRootStyle, useToArr, useToProps } from '../_util/hooks'
+import { mergeClassNames, mergeStyles, resolveStyleOrClass, useMergeSemantic, useSemanticRootStyle, useToArr, useToProps } from '../_util/hooks'
 import scrollTo from '../_util/scrollTo.ts'
 import { getSlotPropsFnRun, toPropsRefs } from '../_util/tools.ts'
 import { devUseWarning, isDev } from '../_util/warning.ts'
@@ -771,14 +771,18 @@ const InternalTable = defineComponent<
         const paginationProps = mergedPagination.value
         const paginationSize = getPaginationSize(paginationProps.size, mergedSize.value)
 
-        const tablePaginationClasses = mergedClassNames.value.pagination ?? {}
-        const tablePaginationStyles = mergedStyles.value.pagination ?? {}
+        const paginationClasses: TablePaginationConfig['classes'] = info =>
+          mergeClassNames(
+            {},
+            mergedClassNames.value.pagination,
+            resolveStyleOrClass(paginationProps.classes, info),
+          )
 
-        // Prefer pagination-level config; retain Table-level semantic config as a legacy fallback.
-        const paginationClasses = paginationProps.classes
-          ?? (Object.keys(tablePaginationClasses).length > 0 ? tablePaginationClasses : undefined)
-        const paginationStyles = paginationProps.styles
-          ?? (Object.keys(tablePaginationStyles).length > 0 ? tablePaginationStyles : undefined)
+        const paginationStyles: TablePaginationConfig['styles'] = info =>
+          mergeStyles(
+            resolveStyleOrClass(paginationProps.styles, info),
+            mergedStyles.value.pagination,
+          )
 
         return (
           <Pagination

--- a/packages/antdv-next/src/table/InternalTable.tsx
+++ b/packages/antdv-next/src/table/InternalTable.tsx
@@ -766,20 +766,33 @@ const InternalTable = defineComponent<
 
         return expandable
       })()
-      const renderPagination = (placement: 'start' | 'end' | 'center' = 'end') => (
-        <Pagination
-          {...mergedPagination.value as any}
-          classes={mergedClassNames.value.pagination}
-          styles={mergedStyles.value.pagination}
-          class={clsx(
-            `${prefixCls.value}-pagination`,
-            `${prefixCls.value}-pagination-${placement}`,
-            (mergedPagination.value as any).class,
-            (mergedPagination.value as any).className,
-          )}
-          size={getPaginationSize(mergedPagination.value.size, mergedSize.value)}
-        />
-      )
+
+      const renderPagination = (placement: 'start' | 'end' | 'center' = 'end') => {
+        const paginationProps = mergedPagination.value
+        const paginationSize = getPaginationSize(paginationProps.size, mergedSize.value)
+
+        const tablePaginationClasses = mergedClassNames.value.pagination ?? {}
+        const tablePaginationStyles = mergedStyles.value.pagination ?? {}
+
+        // Prefer pagination-level config; retain Table-level semantic config as a legacy fallback.
+        const paginationClasses = paginationProps.classes
+          ?? (Object.keys(tablePaginationClasses).length > 0 ? tablePaginationClasses : undefined)
+        const paginationStyles = paginationProps.styles
+          ?? (Object.keys(tablePaginationStyles).length > 0 ? tablePaginationStyles : undefined)
+
+        return (
+          <Pagination
+            {...paginationProps}
+            classes={paginationClasses}
+            styles={paginationStyles}
+            class={clsx(
+              `${prefixCls.value}-pagination`,
+              `${prefixCls.value}-pagination-${placement}`,
+            )}
+            size={paginationSize}
+          />
+        )
+      }
       const paginationNodes = (() => {
         if (props.pagination === false || !mergedPagination.value.total) {
           return { top: null, bottom: null }

--- a/packages/antdv-next/src/table/tests/Table.pagination.test.tsx
+++ b/packages/antdv-next/src/table/tests/Table.pagination.test.tsx
@@ -252,25 +252,48 @@ describe('table pagination', () => {
     wrapper.unmount()
   })
 
-  it('should prefer pagination config classes/styles when both APIs are used', () => {
+  it('should merge pagination config classes/styles when both APIs are used', () => {
     const wrapper = mount(() => (
       <Table
         columns={columns}
         dataSource={generateData(20)}
         pagination={{
-          classes: { root: 'config-pagination-cls' },
-          styles: { root: { marginBottom: '4px' } },
+          pageSize: 1,
+          classes: {
+            root: 'config-pagination-cls',
+            item: 'config-pagination-item-cls',
+          },
+          styles: {
+            root: { marginBottom: '4px', color: 'red' },
+            item: { color: 'red' },
+          },
         }}
-        classes={{ pagination: { root: 'table-pagination-cls' } }}
-        styles={{ pagination: { root: { marginTop: '8px' } } }}
+        classes={{
+          pagination: {
+            root: 'table-pagination-cls',
+            item: 'table-pagination-item-cls',
+          },
+        }}
+        styles={{
+          pagination: {
+            root: { marginTop: '8px', color: 'blue' },
+            item: { color: 'blue' },
+          },
+        }}
       />
     ), { attachTo: document.body })
 
     const pager = wrapper.find('.ant-pagination')
+    const paginationItem = wrapper.find('.ant-pagination-item')
+
     expect(pager.classes()).toContain('config-pagination-cls')
-    expect(pager.classes()).not.toContain('table-pagination-cls')
+    expect(pager.classes()).toContain('table-pagination-cls')
     expect((pager.element as HTMLElement).style.marginBottom).toBe('4px')
-    expect((pager.element as HTMLElement).style.marginTop).toBe('')
+    expect((pager.element as HTMLElement).style.marginTop).toBe('8px')
+    expect((pager.element as HTMLElement).style.color).toBe('blue')
+    expect(paginationItem.classes()).toContain('config-pagination-item-cls')
+    expect(paginationItem.classes()).toContain('table-pagination-item-cls')
+    expect((paginationItem.element as HTMLElement).style.color).toBe('blue')
     wrapper.unmount()
   })
 })

--- a/packages/antdv-next/src/table/tests/Table.pagination.test.tsx
+++ b/packages/antdv-next/src/table/tests/Table.pagination.test.tsx
@@ -191,4 +191,86 @@ describe('table pagination', () => {
     })
     expect(wrapper.find('.ant-pagination-mini').exists()).toBe(true)
   })
+
+  // https://github.com/antdv-next/antdv-next/issues/780
+  it('should forward pagination config classes/styles when Table-level semantic is absent', () => {
+    const wrapper = mount(() => (
+      <Table
+        columns={columns}
+        dataSource={generateData(20)}
+        pagination={{
+          total: 20,
+          classes: { root: 'cfg-pagination-cls' },
+          styles: { root: { marginBottom: '0px' } },
+        }}
+      />
+    ), { attachTo: document.body })
+
+    const pager = wrapper.find('.ant-pagination')
+    expect(pager.exists()).toBe(true)
+    expect(pager.classes()).toContain('cfg-pagination-cls')
+    expect((pager.element as HTMLElement).style.marginBottom).toBe('0px')
+    wrapper.unmount()
+  })
+
+  it('should keep pagination config classes/styles when Table classes/styles target the table root', () => {
+    const wrapper = mount(() => (
+      <Table
+        columns={columns}
+        dataSource={generateData(20)}
+        pagination={{
+          total: 20,
+          classes: { root: 'cfg-pagination-cls' },
+          styles: { root: { marginBottom: '0px' } },
+        }}
+        classes={{ root: 'table-root-cls' }}
+        styles={{ root: { marginTop: '8px' } }}
+      />
+    ), { attachTo: document.body })
+
+    const pager = wrapper.find('.ant-pagination')
+    expect(pager.classes()).toContain('cfg-pagination-cls')
+    expect((pager.element as HTMLElement).style.marginBottom).toBe('0px')
+    expect(wrapper.find('.ant-table-wrapper').classes()).toContain('table-root-cls')
+    expect((wrapper.find('.ant-table-wrapper').element as HTMLElement).style.marginTop).toBe('8px')
+    wrapper.unmount()
+  })
+
+  it('should keep supporting Table-level pagination classes/styles', () => {
+    const wrapper = mount(() => (
+      <Table
+        columns={columns}
+        dataSource={generateData(20)}
+        classes={{ pagination: { root: 'table-pagination-cls' } }}
+        styles={{ pagination: { root: { marginTop: '8px' } } }}
+      />
+    ), { attachTo: document.body })
+
+    const pager = wrapper.find('.ant-pagination')
+    expect(pager.classes()).toContain('table-pagination-cls')
+    expect((pager.element as HTMLElement).style.marginTop).toBe('8px')
+    wrapper.unmount()
+  })
+
+  it('should prefer pagination config classes/styles when both APIs are used', () => {
+    const wrapper = mount(() => (
+      <Table
+        columns={columns}
+        dataSource={generateData(20)}
+        pagination={{
+          classes: { root: 'config-pagination-cls' },
+          styles: { root: { marginBottom: '4px' } },
+        }}
+        classes={{ pagination: { root: 'table-pagination-cls' } }}
+        styles={{ pagination: { root: { marginTop: '8px' } } }}
+      />
+    ), { attachTo: document.body })
+
+    const pager = wrapper.find('.ant-pagination')
+    expect(pager.classes()).toContain('config-pagination-cls')
+    expect(pager.classes()).not.toContain('table-pagination-cls')
+    expect((pager.element as HTMLElement).style.marginBottom).toBe('4px')
+    expect((pager.element as HTMLElement).style.marginTop).toBe('')
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close #780

### 💡 Background and Solution

The Table component used the semantic configurations from `classes.pagination` and `styles.pagination` to override `pagination.classes` and `pagination.styles`.

As a result, the following configuration did not take effect correctly:

```vue
<a-table
  :pagination="{
    classes: { root: 'custom-pagination' },
    styles: { root: { marginTop: '8px' } },
  }"
/>
```

This change merges the semantic configuration from both levels. Classes from both sources are preserved. Styles are also merged, while the existing precedence of Table-level `styles.pagination` is retained for conflicting properties. Corresponding tests have been added.

### 📝 Change Log

- Classes from both sources are preserved.
- Styles from both sources are merged.
- For conflicting style properties, Table-level `styles.pagination` retains precedence.
- Corresponding test coverage has been added.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix the issue where Table ignores the semantic configuration from `pagination.classes` and `pagination.styles`. |
| 🇨🇳 Chinese | 修复 Table 忽略 `pagination.classes` 和 `pagination.styles` 的语义化配置问题。 |
