### PR TITLE
docs: fix zh/en docs parity for cascader, collapse, icon, input and layout

### DIFF
--- a/docs/src/pages/components/cascader/index.en-US.md
+++ b/docs/src/pages/components/cascader/index.en-US.md
@@ -18,6 +18,12 @@ demo:
 ## Examples {#examples}
 
 <demo-group>
+<demo src="./demo/basic.vue">Basic</demo>
+<demo src="./demo/default-value.vue">Default value</demo>
+<demo src="./demo/custom-trigger.vue">Custom trigger</demo>
+<demo src="./demo/hover.vue">Hover</demo>
+<demo src="./demo/disabled-option.vue">Disabled option</demo>
+<demo src="./demo/change-on-select.vue">Change on select</demo>
 <demo src="./demo/multiple.vue">Multiple</demo>
 <demo src="./demo/showCheckedStrategy.vue">ShowCheckedStrategy</demo>
 <demo src="./demo/size.vue">Size</demo>
@@ -61,7 +67,6 @@ Common props ref：[Common props](/docs/vue/common-props)
 | popupMenuColumnStyle | The style of the drop-down menu column | CSSProperties | - | - | × |
 | showCheckedStrategy | The way to show selected items in the box (only effective when `multiple` is `true`). `Cascader.SHOW_CHILD`: just show child treeNode. `Cascader.SHOW_PARENT`: just show parent treeNode (when all child treeNode under the parent treeNode are checked) | `Cascader.SHOW_PARENT` \| `Cascader.SHOW_CHILD` | `Cascader.SHOW_PARENT` | - | × |
 | showSearch | Whether show search input in single mode | boolean \| [Object](#showsearch) | false | - | × |
-| ~~searchValue~~ | Set search value, Need work with `showSearch` | string | - | - | × |
 | size | The input size | `large` \| `medium` \| `small` | `medium` | - | × |
 | status | Set validation status | 'error' \| 'warning' | - | - | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record&lt;[SemanticDOM](#semantic-dom), CSSProperties&gt; \| (info: \{ props \})=&gt; Record&lt;[SemanticDOM](#semantic-dom), CSSProperties&gt; | - | - | ✓ |

--- a/docs/src/pages/components/collapse/index.en-US.md
+++ b/docs/src/pages/components/collapse/index.en-US.md
@@ -79,10 +79,20 @@ Deprecated: when using items, prefer configuring panels with `items`.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| header | - | VueNode | - | - |
-| showArrow | - | boolean | true | - |
-| extra | - | VueNode | - | - |
 | collapsible | Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself | `header` \| `icon` \| `disabled` | - | - |
+| extra | The extra element in the corner | VueNode | - | - |
+| forceRender | Forced render of content on panel, instead of lazy rendering after clicking on header | boolean | false | - |
+| header | Title of the panel | VueNode | - | - |
+| key | Unique key identifying the panel from among its siblings | string \| number | - | - |
+| showArrow | If false, panel will not show arrow icon. If false, collapsible can't be set as icon | boolean | true | - |
+
+#### Slots {#collapsepanel-slots}
+
+| Slot | Description | Type | Version |
+| --- | --- | --- | --- |
+| default | Body area content | VueNode | - |
+| header | Title of the panel | VueNode | - |
+| extra | The extra element in the corner | VueNode | - |
 
 ## Types
 

--- a/docs/src/pages/components/collapse/index.zh-CN.md
+++ b/docs/src/pages/components/collapse/index.zh-CN.md
@@ -82,7 +82,9 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | collapsible | 是否可折叠或指定可折叠触发区域 | `header` \| `icon` \| `disabled` | - | - |
+| extra | 自定义渲染每个面板右上角的内容 | VueNode | - | - |
 | forceRender | 被隐藏时是否渲染 body 区域 DOM 结构 | boolean | false |  |
+| header | 面板标题 | VueNode | - | - |
 | key | 对应 activeKey | string \| number | - |  |
 | showArrow | 是否展示当前面板上的箭头（为 false 时，collapsible 不能设为 icon） | boolean | true |  |
 
@@ -90,6 +92,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 
 | 插槽 | 说明 | 类型 | 版本 |
 | --- | --- | --- | --- |
+| default | 面板内容 | VueNode | - |
 | header | 面板标题 | VueNode | - |
 | extra | 自定义渲染每个面板右上角的内容 | VueNode | - |
 
@@ -101,6 +104,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 | --- | --- | --- | --- | --- |
 | classes | 语义化结构 class | [`Record<header \| body, string>`](#semantic-dom) | - | - |
 | collapsible | 是否可折叠或指定可折叠触发区域 | `header` \| `icon` \| `disabled` | - |  |
+| content | 面板内容 | VueNode | - | - |
 | extra | 自定义渲染每个面板右上角的内容 | VueNode | - |  |
 | forceRender | 被隐藏时是否渲染 body 区域 DOM 结构 | boolean | false |  |
 | key | 对应 activeKey | string \| number | - |  |

--- a/docs/src/pages/components/icon/index.en-US.md
+++ b/docs/src/pages/components/icon/index.en-US.md
@@ -33,7 +33,7 @@ Before using icons, you need to install the [@antdv-next/icons](https://www.npmj
 
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
-| className | The className of Icon | string | - | | × |
+| class | The class name of the icon | string | - | | × |
 | rotate | Rotate by n degrees (not working in IE9) | number | - | | × |
 | spin | Rotate icon with animation | boolean | false | | × |
 | style | The style properties of icon, like `fontSize` and `color` | CSSProperties | - | | × |

--- a/docs/src/pages/components/input/index.en-US.md
+++ b/docs/src/pages/components/input/index.en-US.md
@@ -48,7 +48,10 @@ Common props ref：[Common props](/docs/vue/common-props)
 
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
+| ~~addonAfter~~ | The label text displayed after (on the right side of) the input field, please use Space.Compact instead | VueNode | - | - | × |
+| ~~addonBefore~~ | The label text displayed before (on the left side of) the input field, please use Space.Compact instead | VueNode | - | - | × |
 | allowClear | If allow to remove input content with clear icon | boolean \| &#123; clearIcon: VueNode &#125; | false | - | ✓ |
+| ~~bordered~~ | Whether has border style, please use `variant` instead | boolean | true | - | × |
 | classes | Customize class for each semantic structure inside the component. Supports object or function. | Record&lt;[SemanticDOM](#semantic-input), string&gt; \| (info: &#123; props &#125;) =&gt; Record&lt;[SemanticDOM](#semantic-input), string&gt; | - | - | ✓ |
 | count | Character count config | [CountConfig](#countconfig) | - | - | × |
 | defaultValue | The initial input content | string | - | - | × |
@@ -221,3 +224,34 @@ interface VisibilityToggle {
 ### InputOTP {#semantic-otp}
 
 <demo src="./demo/_semantic-otp.vue" simplify></demo>
+
+## Design Token
+
+<ComponentTokenTable component="Input"></ComponentTokenTable>
+
+See [Customize Theme](/docs/vue/customize-theme) to learn how to use Design Token.
+
+## FAQ
+
+### Why does Input lose focus when `prefix/suffix/showCount` is changed dynamically? {#faq-lose-focus}
+
+When Input dynamically adds or removes `prefix/suffix/showCount`, Vue will re-create the DOM structure and the new input is not focused. You can preset an empty `<span />` to keep the DOM structure unchanged:
+
+```vue
+<template>
+  <a-input>
+    <template #suffix>
+      <template v-if="condition">
+        <Icon type="smile" />
+      </template>
+      <template v-else>
+        <span />
+      </template>
+    </template>
+  </a-input>
+</template>
+```
+
+### Why can `value` exceed `maxLength` when TextArea is controlled? {#faq-textarea-exceed-max}
+
+When controlled, the component should display according to the controlled content, to prevent the displayed value from differing from the submitted value when used inside a form component.

--- a/docs/src/pages/components/input/index.zh-CN.md
+++ b/docs/src/pages/components/input/index.zh-CN.md
@@ -55,6 +55,7 @@ demo:
 | ~~bordered~~ | 是否有边框, 请使用 `variant` 替换 | boolean | true | - | × |
 | classes | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record&lt;[SemanticDOM](#semantic-input), string&gt; \| (info: &#123; props &#125;) =&gt; Record&lt;[SemanticDOM](#semantic-input), string&gt; | - | - | ✓ |
 | count | 字符计数配置 | [CountConfig](#countconfig) | - | - | × |
+| defaultValue | 输入框默认内容 | string | - | - | × |
 | disabled | 是否禁用状态，默认为 false | boolean | false | - | × |
 | id | 输入框的 id | string | - | - | × |
 | maxlength | 最大长度 | number | - | - | × |
@@ -154,6 +155,7 @@ Input 的其他属性和 Vue 自带的 [input](https://cn.vuejs.org/guide/essent
 | 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | classes | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record&lt;[SemanticDOM](#semantic-otp), string&gt; \| (info: &#123; props &#125;) =&gt; Record&lt;[SemanticDOM](#semantic-otp), string&gt; | - | - | ✓ |
+| defaultValue | 设置初始默认值 | string | - | - | × |
 | disabled | 是否禁用 | boolean | false | - | × |
 | formatter | 格式化展示，留空字段会被 ` ` 填充 | (value: string) =&gt; string | - | - | × |
 | separator | 分隔符，在指定索引的输入框后渲染分隔符 | VueNode \| ((i: number) =&gt; VueNode) | - | - | × |

--- a/docs/src/pages/components/layout/index.en-US.md
+++ b/docs/src/pages/components/layout/index.en-US.md
@@ -25,7 +25,7 @@ The first level navigation is left aligned near a logo, and the secondary menu i
 - When the current navigation item is collapsed, the style of the current navigation item is applied to its parent level;
 - The left side navigation bar has support for both the accordion and expanding styles; you can choose the one that fits your case the best.
 
-## Visualization rules
+### Visualization rules {#visualization-rules}
 
 Style of a navigation should conform to its level.
 
@@ -122,6 +122,12 @@ The sidebar.
 | --- | --- | --- | --- |
 | breakpoint | The callback function, executed when [breakpoints](/components/grid/#api) changed | (broken: boolean) => void | - |
 | collapse | The callback function, executed by clicking the trigger or activating the responsive layout | (collapsed: boolean, type: string) => void | - |
+
+#### Slots {#layoutsider-slots}
+
+| Slot | Description | Type | Version |
+| --- | --- | --- | --- |
+| trigger | Specify the customized trigger, set to null to hide the trigger | - | - |
 
 ## Types
 

--- a/docs/src/pages/components/layout/index.zh-CN.md
+++ b/docs/src/pages/components/layout/index.zh-CN.md
@@ -140,6 +140,7 @@ const breakpointWidth = {
   lg: '992px',
   xl: '1200px',
   xxl: '1600px',
+  xxxl: '1920px',
 }
 ```
 


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

None

### 💡 背景与方案

多个组件的中英文文档存在内容不对齐：英文档缺少部分 demo、API 行、小节，或保留了与源码不符的描述。本 PR 逐组件对齐中英文档，所有新增内容均已核对源码实现：

- **Cascader**：英文档补齐 6 个基础 demo（basic / default-value / custom-trigger / hover / disabled-option / change-on-select，标题沿用 antd 官方英文名）；移除主 Props 表中划线的 `searchValue` 行（该顶层 prop 在源码中不存在，仅作为 `showSearch` 对象字段有效，后者说明保留）。
- **Collapse**：zh-CN 的 ItemType 表补充源码中存在且被消费的 `content` 字段；中英文档为 CollapsePanel 补充 `header` / `extra` Props 行、`default` / `header` / `extra` 插槽行；英文档补齐 `forceRender` / `key` 行并填充空白描述。
- **Icon**：英文档 API 表将 `className` 更名为 `class`，与中文档及 Vue 的 attrs 语义一致（icons 包仅通过 `attrs.class` 接收类名）。
- **Input**：zh-CN 的 Input 与 InputOTP Props 表补充 `defaultValue` 行（源码均存在并消费）；英文档补充已废弃的 `addonAfter` / `addonBefore` / `bordered` 划线行（源码经 `warning.deprecated` 正式废弃，文案取 antd 官方英文措辞）；英文档补充缺失的 Design Token 与 FAQ 两节，锚点与中文档一致。
- **Layout**：英文档「Visualization rules」标题层级修正为 h3 并对齐锚点；英文档补充 LayoutSider 的 `trigger` 插槽表；zh-CN 的 breakpoint width 代码块补齐 `xxxl: '1920px'`（与英文档及 antd 官方文档一致）。

纯 Markdown 改动，不涉及任何运行时代码。已人工核验：新增 demo 引用的文件均存在、API 行与源码 Props/Emits/Slots 定义一一对应、中英锚点对齐。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |