### PR TITLE
fix(Skeleton): hide decorative image placeholder from assistive technology

### DIFF
--- a/packages/antdv-next/src/skeleton/Image.tsx
+++ b/packages/antdv-next/src/skeleton/Image.tsx
@@ -19,6 +19,8 @@ const SkeletonImage = defineComponent<SkeletonImageProps>(
             viewBox="0 0 1098 1024"
             xmlns="http://www.w3.org/2000/svg"
             class={`${prefixCls.value}-image-svg`}
+            aria-hidden="true"
+            focusable="false"
           >
             <title>Image placeholder</title>
             <path d={path} class={`${prefixCls.value}-image-path`} />

--- a/packages/antdv-next/src/skeleton/tests/Skeleton.test.tsx
+++ b/packages/antdv-next/src/skeleton/tests/Skeleton.test.tsx
@@ -592,6 +592,15 @@ describe('skeleton', () => {
       expect(wrapper.find('.ant-skeleton-image-path').exists()).toBe(true)
     })
 
+    it('should hide the placeholder illustration from assistive technology', () => {
+      const wrapper = mount(Skeleton.Image)
+      const illustration = wrapper.find('.ant-skeleton-image-svg')
+
+      expect(illustration.attributes('aria-hidden')).toBe('true')
+      expect(illustration.attributes('focusable')).toBe('false')
+      expect(illustration.element).not.toHaveAccessibleName()
+    })
+
     it('should not render ant-skeleton-node when using Image', () => {
       const wrapper = mount(Skeleton.Image)
       expect(wrapper.find('.ant-skeleton-node').exists()).toBe(false)

--- a/packages/antdv-next/src/skeleton/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/skeleton/tests/__snapshots__/demo.test.tsx.snap
@@ -1469,7 +1469,9 @@ exports[`skeleton demo > renders element correctly 1`] = `
           class="ant-skeleton-image"
         >
           <svg
+            aria-hidden="true"
             class="ant-skeleton-image-svg"
+            focusable="false"
             viewBox="0 0 1098 1024"
             xmlns="http://www.w3.org/2000/svg"
           >


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [x] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

ref https://github.com/ant-design/ant-design/pull/59107

### 💡 背景与方案

`Skeleton.Image` 的占位 SVG 包含 `<title>Image placeholder</title>`，导致屏幕阅读器可能朗读这张纯装饰性图片。

本次为 SVG 添加 `aria-hidden="true"` 和 `focusable="false"`，将其从辅助技术和键盘焦点中排除，并补充无障碍回归测试及对应快照。该变更不涉及公开 API 或视觉效果变化。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Hide the decorative Skeleton.Image placeholder from assistive technologies. |
| 🇨🇳 中文 | 避免辅助技术朗读 Skeleton.Image 的装饰性占位图。 |