### PR TITLE
fix(docs): remove Chinese from Card English demo title

### DIFF
--- a/docs/src/pages/components/card/index.en-US.md
+++ b/docs/src/pages/components/card/index.en-US.md
@@ -14,7 +14,7 @@ A card can be used to display content related to a single subject. The content c
 ## Examples {#examples}
 
 <demo-group>
-  <demo src="./demo/basic.vue">Basic card片</demo>
+  <demo src="./demo/basic.vue">Basic card</demo>
   <demo src="./demo/border-less.vue" background="grey">No border</demo>
   <demo src="./demo/simple.vue">Simple card</demo>
   <demo src="./demo/flexible-content.vue">Customized content</demo>


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 💡 Background and Solution

The English Card documentation contained a stray Chinese character in the basic demo title: `Basic card片`. This updates it to `Basic card`.

No API or runtime behavior is affected.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Basic card      |
| 🇨🇳 Chinese |    典型卡片       |
