### PR TITLE
docs: align zh-CN and en-US component documentation

### DIFF
--- a/docs/src/pages/components/masonry/index.zh-CN.md
+++ b/docs/src/pages/components/masonry/index.zh-CN.md
@@ -25,6 +25,7 @@ demo:
     <demo src="./demo/image.vue">图片</demo>
     <demo src="./demo/dynamic.vue">动态更新</demo>
     <demo src="./demo/style-class.vue">自定义语义结构的样式和类</demo>
+    <demo src="./demo/fresh.vue" debug>持续监听尺寸变化</demo>
 </demo-group>
 
 ## API

--- a/docs/src/pages/components/menu/index.zh-CN.md
+++ b/docs/src/pages/components/menu/index.zh-CN.md
@@ -126,8 +126,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | label | 菜单项标题 | VueNode | - | - |
 | popupClassName | 子菜单样式，`mode="inline"` 时无效 | string | - | - |
 | popupOffset | 子菜单偏移量，`mode="inline"` 时无效 | [number, number] | - | - |
-| onTitleClick | 点击子菜单标题 | (info: { key: string; domEvent: MouseEvent }) => void | - | - |
 | theme | 设置子菜单的主题，默认从 Menu 上继承 | `light` \| `dark` | - | - |
+| onTitleClick | 点击子菜单标题 | (info: { key: string; domEvent: MouseEvent }) => void | - | - |
 | popupRender | 自定义当前子菜单的弹出框 | (node: VueNode, info: { item: SubMenuProps; keys: string[] }) => VueNode | - | - |
 
 #### MenuItemGroupType

--- a/docs/src/pages/components/modal/index.en-US.md
+++ b/docs/src/pages/components/modal/index.en-US.md
@@ -63,7 +63,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | keyboard | Whether support press esc to close | boolean | true | - | × |
 | loading | Show the skeleton | boolean | false | - | × |
 | mask | Mask effect | boolean \| `{enabled?: boolean, blur?: boolean, closable?: boolean}` | true | mask.closable: 1.0.3 | ✓ |
-| ~~maskClosable~~ | Whether to close the modal dialog when the mask (area outside the modal) is clicked | boolean | true |  | × |
+| ~~maskClosable~~ | Whether to close the modal dialog when the mask (area outside the modal) is clicked. Please use `mask.closable` instead. | boolean | true |  | × |
 | modalRender | Custom modal content render | (node: any) => any | - | - | × |
 | mousePosition | Set animation start position | MousePosition | - | - | × |
 | okButtonProps | The ok button props | ButtonProps | - | - | ✓ |
@@ -136,7 +136,7 @@ The items listed above are all functions, expecting a settings object as paramet
 | icon | Custom icon | VueNode | &lt;ExclamationCircleFilled /> | - |
 | keyboard | Whether support press esc to close | boolean | true | - |
 | mask | Mask effect | boolean \| [MaskType](#masktype) | true | - |
-| maskClosable | Whether to close the modal dialog when the mask is clicked | boolean | false | - |
+| ~~maskClosable~~ | Whether to close the modal dialog when the mask is clicked. Please use `mask.closable` instead. | boolean | false | - |
 | okButtonProps | The ok button props | ButtonProps | - | - |
 | okText | Text of the OK button | string | `OK` | - |
 | okType | Button `type` of the OK button | LegacyButtonType | `primary` | - |

--- a/docs/src/pages/components/modal/index.zh-CN.md
+++ b/docs/src/pages/components/modal/index.zh-CN.md
@@ -63,8 +63,8 @@ demo:
 | getContainer | 指定 Modal 挂载的节点，但依旧为全屏展示，`false` 为挂载在当前位置 | string \| HTMLElement \| (() => HTMLElement) \| false | document.body | - | × |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true | - | × |
 | loading | 显示骨架屏 | boolean | false | - | × |
-| mask | 遮罩效果 | boolean \| `{enabled?: boolean, blur?: boolean, closable?: boolean}` | true | - | ✓ |
-| maskClosable | 点击蒙层是否允许关闭 | boolean | true | - | × |
+| mask | 遮罩效果 | boolean \| `{enabled?: boolean, blur?: boolean, closable?: boolean}` | true | mask.closable: 1.0.3 | ✓ |
+| ~~maskClosable~~ | 点击蒙层是否允许关闭。请使用 `mask.closable` 替代。 | boolean | true | - | × |
 | modalRender | 自定义渲染对话框 | (node: any) => any | - | - | × |
 | mousePosition | 设置动画起点位置 | MousePosition | - | - | × |
 | okButtonProps | ok 按钮 props | ButtonProps | - | - | ✓ |
@@ -137,7 +137,7 @@ demo:
 | icon | 自定义图标 | VueNode | &lt;ExclamationCircleFilled /> | - |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true | - |
 | mask | 遮罩效果 | boolean \| [MaskType](#masktype) | true |  |
-| ~~maskClosable~~ | 点击蒙层是否允许关闭 | boolean | false |  |
+| ~~maskClosable~~ | 点击蒙层是否允许关闭。请使用 `mask.closable` 替代。 | boolean | false |  |
 | okButtonProps | ok 按钮 props | ButtonProps | - | - |
 | okText | 确认按钮文字 | string | `确定` | - |
 | okType | 确认按钮类型 | LegacyButtonType | `primary` | - |

--- a/docs/src/pages/components/pagination/index.en-US.md
+++ b/docs/src/pages/components/pagination/index.en-US.md
@@ -94,11 +94,6 @@ Common props ref：[Common props](/docs/vue/common-props)
 
 <demo src="./demo/_semantic.vue" simplify></demo>
 
-| Name | Description |
-| --- | --- |
-| root | Root element, set flex layout, alignment, wrap and list styles |
-| item | Item element, set size, padding, border, background color, hover and active styles |
-
 ## Design Token {#design-token}
 
 <ComponentTokenTable component="Pagination"></ComponentTokenTable>

--- a/docs/src/pages/components/table/index.en-US.md
+++ b/docs/src/pages/components/table/index.en-US.md
@@ -121,6 +121,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | components | Override default table elements | [components](#components) | - | - | × |
 | dataSource | Data record array to be displayed | object[] | - | - | × |
 | expandable | Config expandable content | [expandable](#expandable) | - |  | ✓ |
+| footer | Table footer renderer. You can also use the `#footer` slot. | VueNode \| function(currentPageData) | - | - | × |
 | getPopupContainer | The render container of dropdowns in table| (triggerNode) => HTMLElement | () => TableHtmlElement | - | × |
 | loading | Loading status of table | boolean \| [Spin Props](/components/spin/#props) | false | - | × |
 | locale | The i18n text including filter, sort, empty text, etc | object | [默认值](https://github.com/ant-design/ant-design/blob/6dae4a7e18ad1ba193aedd5ab6867e1d823e2aa4/components/locale/zh_CN.tsx#L20-L37) | - | × |
@@ -316,6 +317,7 @@ Properties for row selection.
 | preserveSelectedRowKeys | Keep selection `key` even when it removed from `dataSource` | boolean | - | - |
 | renderCell | Renderer of the table cell. Same as `render` in column | (checked: boolean, record: T, index: number, originNode: VueNode): VueNode | - | - |
 | selectedRowKeys | Controlled selected row keys | string\[] \| number\[] | \[] | - |
+| defaultSelectedRowKeys | Default selected row keys | string\[] \| number\[] | \[] | - |
 | selections | Custom selection [config](#selection), only displays default selections when set to `true` | object\[] \| boolean | - | - |
 | type | `checkbox` or `radio` | `checkbox` \| `radio` | `checkbox` | - |
 | onCell | Set props on per cell. Same as `onCell` in column | function(record, rowIndex) | - | - |

--- a/docs/src/pages/components/timeline/index.en-US.md
+++ b/docs/src/pages/components/timeline/index.en-US.md
@@ -18,18 +18,18 @@ demo:
 
 <demo-group>
 <demo src="./demo/basic.vue">Basic</demo>
+<demo src="./demo/variant.vue">Variant</demo>
+<demo src="./demo/pending.vue">Pending</demo>
 <demo src="./demo/alternate.vue">Alternate</demo>
+<demo src="./demo/horizontal.vue">Horizontal</demo>
 <demo src="./demo/custom.vue">Custom</demo>
 <demo src="./demo/dot-render.vue">Dot render</demo>
 <demo src="./demo/sfc.vue">SFC Mode</demo>
-<demo src="./demo/pending.vue">Pending</demo>
-<demo src="./demo/title.vue">Label</demo>
-<demo src="./demo/variant.vue">Variant</demo>
 <demo src="./demo/end.vue">Right Alternate</demo>
-<demo src="./demo/horizontal.vue">Horizontal</demo>
+<demo src="./demo/title.vue">Label</demo>
 <demo src="./demo/title-span.vue">Title Offset</demo>
-<demo src="./demo/semantic.vue">Semantic Sample</demo>
 <demo src="./demo/style-class.vue">Custom semantic dom styling</demo>
+<demo src="./demo/semantic.vue">Semantic Sample</demo>
 </demo-group>
 
 ## API

--- a/docs/src/pages/components/tooltip/index.zh-CN.md
+++ b/docs/src/pages/components/tooltip/index.zh-CN.md
@@ -25,6 +25,7 @@ demo:
   <demo src="./demo/shift.vue" iframe="300">贴边偏移</demo>
   <demo src="./demo/colorful.vue">多彩文字提示</demo>
   <demo src="./demo/disabled.vue">禁用</demo>
+  <demo src="./demo/disabled-children.vue" debug>禁用子组件</demo>
   <demo src="./demo/wrap-custom-component.vue">自定义子组件</demo>
   <demo src="./demo/style-class.vue">自定义语义结构的样式和类</demo>
 </demo-group>

--- a/docs/src/pages/components/tour/index.zh-CN.md
+++ b/docs/src/pages/components/tour/index.zh-CN.md
@@ -52,6 +52,8 @@ demo:
 | getPopupContainer | 设置 Tour 浮层的渲染节点，默认是 body | (node: HTMLElement) =&gt; HTMLElement | () =&gt; document.body | - | × |
 | classes | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | TourClassNamesType | - | - | ✓ |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | TourStylesType | - | - | ✓ |
+| rootClass | 根容器类名 | string | - | - | × |
+| prefixCls | - | string | - | - | × |
 
 ### 事件 {#events}
 

--- a/docs/src/pages/components/tree-select/index.en-US.md
+++ b/docs/src/pages/components/tree-select/index.en-US.md
@@ -42,6 +42,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | allowClear | Show clear button | boolean \| &#123; clearIcon?: VueNode &#125; | false | - | × |
 | classes | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | - | ✓ |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | - | ✓ |
+| rootClass | Root container class | string | - | - | × |
 | defaultOpen | Initial open state of dropdown | boolean | - | - | × |
 | defaultValue | To set the initial selected treeNode(s) | string \| string[] | - | - | × |
 | disabled | Disabled or not | boolean | false | - | × |

--- a/docs/src/pages/components/typography/index.zh-CN.md
+++ b/docs/src/pages/components/typography/index.zh-CN.md
@@ -51,11 +51,14 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 | disabled | 禁用文本 | boolean | false |  | × |
 | editable | 是否可编辑，为对象时可对编辑进行控制 | boolean \| [editable](#editable) | false |  | × |
 | ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| [ellipsis](#ellipsis) | false |  | × |
-| level | 重要程度，相当于 `h1`、`h2`、`h3`、`h4`、`h5` | number: 1, 2, 3, 4, 5 | 1 |  | × |
+| keyboard | 键盘样式 | boolean | false |  | × |
 | mark | 添加标记样式 | boolean | false |  | × |
+| strong | 是否加粗 | boolean | false |  | × |
 | italic | 是否斜体 | boolean | false |  | × |
 | type | 文本类型 | `secondary` \| `success` \| `warning` \| `danger` | - | | × |
 | underline | 添加下划线样式 | boolean | false |  | × |
+| classes | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | TypographyClassNamesType | - | - | ✓ |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | TypographyStylesType | - | - | ✓ |
 
 #### 事件 {#typographytext-events}
 

--- a/docs/src/pages/components/upload/index.en-US.md
+++ b/docs/src/pages/components/upload/index.en-US.md
@@ -53,7 +53,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
-| accept | File types that can be accepted. See [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string \| [AcceptObject](#acceptobject) | - | - | ✓ |
+| accept | File types that can be accepted. See [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string \| [AcceptConfig](#acceptconfig) | - | - | ✓ |
 | action | Uploading URL | string \| (file) => Promise&lt;string> | - | - | × |
 | beforeUpload | Hook function which will be executed before uploading. Uploading will be stopped with `false` or a rejected Promise returned. When returned value is `Upload.LIST_IGNORE`, the list of files that have been uploaded will ignore it. **Warning：this function is not supported in IE9** | (file: [VcFile](#vcfile), fileList: [VcFile[]](#vcfile)) => boolean \| Promise&lt;File> \| `Upload.LIST_IGNORE` | - | - | × |
 | customRequest | Override for the default xhr behavior allowing for additional customization and the ability to implement your own XMLHttpRequest | ( options: [RequestOptions](#request-options), info: \{ defaultRequest: (option: [RequestOptions](#request-options)) => void; \} ) => void | - | defaultRequest: - | ✓ |
@@ -167,7 +167,7 @@ When uploading state change, it returns:
 
 3. `event` response from the server, including uploading progress, supported by advanced browsers.
 
-### AcceptObject {#acceptobject}
+### AcceptConfig {#acceptconfig}
 
 ```ts
 {

--- a/docs/src/pages/components/upload/index.zh-CN.md
+++ b/docs/src/pages/components/upload/index.zh-CN.md
@@ -54,7 +54,7 @@ demo:
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
 | --- | --- | --- | --- | --- | --- |
-| accept | 接受上传的文件类型，详见 [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string \| [AcceptObject](#acceptobject) | - |  | ✓ |
+| accept | 接受上传的文件类型，详见 [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string \| [AcceptConfig](#acceptconfig) | - |  | ✓ |
 | action | 上传的地址 | string \| (file) => Promise&lt;string> | - |  | × |
 | beforeUpload | 上传文件之前的钩子，参数为上传的文件，若返回 `false` 则停止上传。支持返回一个 Promise 对象，Promise 对象 reject 时则停止上传，resolve 时开始上传（ resolve 传入 `File` 或 `Blob` 对象则上传 resolve 传入对象）；也可以返回 `Upload.LIST_IGNORE`，此时列表中将不展示此文件。 **注意：IE9 不支持该方法** | (file: [RcFile](#rcfile), fileList: [RcFile[]](#rcfile)) => boolean \| Promise&lt;File> \| `Upload.LIST_IGNORE` | - |  | × |
 | customRequest | 通过覆盖默认的上传行为，可以自定义自己的上传实现 | ( options: [RequestOptions](#request-options), info: \{ defaultRequest: (option: [RequestOptions](#request-options)) => void; \} ) => void | - | - | ✓ |

--- a/packages/antdv-next/src/modal/interface.ts
+++ b/packages/antdv-next/src/modal/interface.ts
@@ -173,6 +173,7 @@ export interface ModalFuncProps extends ModalCommonProps {
   cancelText?: VueNode
   icon?: VueNode
   mask?: MaskType
+  /** @deprecated Please use `mask.closable` instead */
   maskClosable?: boolean
   zIndex?: number
   okCancel?: boolean


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

N/A

### 💡 背景与方案

部分组件的中英文文档在 Demo 列表、API 属性、类型名称和语义化 DOM 说明上存在差异，部分内容也未与当前 Vue 实现及上游 Ant Design 保持一致。

本次变更：

- 对齐 Masonry、Timeline 和 Tooltip 的中英文 Demo 列表及顺序。
- 对齐 Menu、Table、Tour、TreeSelect 和 Typography 的中英文 API 文档。
- 删除 Pagination 英文文档中由 `SemanticPreview` 重复呈现的手写语义化 DOM 表格。
- 将 Upload 文档中的 `AcceptObject` 更正为源码实际使用的 `AcceptConfig`，并修复相关锚点。
- 补充 Modal `maskClosable` 的废弃说明，引导使用 `mask.closable`，同时完善 `Modal.method()` 的 TypeScript 废弃标记。
- 本次变更不影响组件运行时行为和视觉表现。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | 📝 Align bilingual documentation for Masonry, Menu, Modal, Pagination, Table, Timeline, Tooltip, Tour, TreeSelect, Typography, and Upload, including Modal `maskClosable` deprecation guidance. |
| 🇨🇳 中文 | 📝 对齐 Masonry、Menu、Modal、Pagination、Table、Timeline、Tooltip、Tour、TreeSelect、Typography 和 Upload 的中英文文档，并补充 Modal `maskClosable` 废弃指引。 |