### PR TITLE
ci: exclude locale bundle files from size check

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -2,7 +2,7 @@ name: Size Report (Compute)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
     paths:
       - 'packages/antdv-next/src/**'
 
@@ -58,6 +58,11 @@ jobs:
           const TARGET_PACKAGE_NAME = 'antdv-next'
           const [command, firstArg, secondArg, thirdArg] = process.argv.slice(2)
 
+          function isLocaleFile(filePath) {
+            const normalized = filePath.split(sep).join('/')
+            return /\/locales?\//.test(normalized)
+          }
+
           function listFiles(dir, files = []) {
             if (!existsSync(dir))
               return files
@@ -67,7 +72,11 @@ jobs:
               if (entry.isDirectory()) {
                 listFiles(file, files)
               }
-              else if (entry.isFile() && /\.(?:js|css)$/.test(entry.name)) {
+              else if (
+                entry.isFile()
+                && /\.(?:js|css)$/.test(entry.name)
+                && !isLocaleFile(file)
+              ) {
                 files.push(file)
               }
             }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
如果你要提交新功能或修复 Bug，请基于 `main` 分支创建 feature/bugfix 分支后再提交。
在提交 Pull Request 前，请确认下方清单已完成。
Pull Request 会在至少一位协作者审核通过后合并。
谢谢！
-->

[English template / 英文模板](https://github.com/antdv-next/antdv-next/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [x] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

- None

### 💡 背景与方案

> - size-check 工作流会把 `/locale*` 目录下的语言包文件一并纳入包体积扫描并呈现在报告中；而语言包是独立 chunk、按需分发，无需呈现在核心包体积报告里，目前的统计会把它们一并计入。
> - 方案：在扫描函数中新增 `isLocaleFile()` 判断，先将文件路径归一化为 `/` 分隔后，用 `/\/locales?\//` 匹配 locale 目录，并在扫描时将其从结果中剔除，使报告只呈现需要展示的包体积。
> - 本次改动仅影响 CI 统计逻辑，不改变任何组件源码与构建产物。

### 📝 变更日志

> - 建议阅读 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)。
> - 变更日志应描述对开发者的影响，而不是实现过程。
> - 参考：https://www.antdv-next.com/components/changelog-cn

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |