### PR TITLE
fix(color-picker): avoid mutating preset items

### DIFF
--- a/packages/antdv-next/src/color-picker/components/ColorPresets.tsx
+++ b/packages/antdv-next/src/color-picker/components/ColorPresets.tsx
@@ -26,10 +26,10 @@ export function isBright(value: AggregationColor, bgColorToken: string) {
 }
 
 function genPresetColor(list: PresetsItem[]) {
-  return list.map((value) => {
-    value.colors = value.colors.map(generateColor)
-    return value
-  })
+  return list.map(value => ({
+    ...value,
+    colors: value.colors.map(generateColor),
+  }))
 }
 
 function genCollapsePanelKey(preset: PresetsItem, index: number) {

--- a/packages/antdv-next/src/color-picker/tests/index.test.tsx
+++ b/packages/antdv-next/src/color-picker/tests/index.test.tsx
@@ -64,6 +64,23 @@ describe('color-picker', () => {
     expect(style).toContain('background: rgb(0, 0, 0)')
   })
 
+  it('does not mutate preset items', () => {
+    const preset = {
+      label: 'Brand',
+      colors: ['#1677ff'],
+    }
+    Object.freeze(preset)
+
+    expect(() => mount(ColorPicker, {
+      attachTo: document.body,
+      props: {
+        open: true,
+        presets: [preset],
+      },
+    })).not.toThrow()
+    expect(preset.colors).toEqual(['#1677ff'])
+  })
+
   it('supports custom trigger slot', async () => {
     mount(ColorPicker, {
       attachTo: document.body,


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

N/A

参考上游 PR：https://github.com/ant-design/ant-design/pull/59272

### 💡 背景与方案

ColorPicker 的 preset 处理逻辑会直接修改用户传入的 preset 对象。当用户传入冻结或只读的 preset 配置时，打开 ColorPicker 会抛出异常。

本次改动改为创建新的 preset 对象，避免修改用户传入的配置。同时增加回归测试，验证冻结的 preset 可以正常渲染且保持原值不变。

### 📝 变更日志

| 语言 | 变更日志 |
| --- | --- |
| 🇺🇸 English | Fixed ColorPicker preset items being mutated during rendering. |
| 🇨🇳 中文 | 修复 ColorPicker 渲染 preset 时修改用户传入配置的问题。 |