### PR TITLE
fix(docs): correct DatePicker and TimePicker prefix demo usage

### DIFF
--- a/docs/src/pages/components/date-picker/demo/_semantic.vue
+++ b/docs/src/pages/components/date-picker/demo/_semantic.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { SmileOutlined } from '@antdv-next/icons'
-import { computed, ref } from 'vue'
+import { computed, h, ref } from 'vue'
 import { SemanticPreview } from '@/components/semantic'
 import { useComponentLocale } from '@/composables/use-locale'
 import { locales } from '../locales'
@@ -23,6 +23,7 @@ const semantics = computed(() => [
 
 const type = ref<'Single' | 'Multiple'>('Single')
 const divRef = ref<HTMLDivElement | null>(null)
+const prefixIcon = h(SmileOutlined)
 </script>
 
 <template>
@@ -44,11 +45,8 @@ const divRef = ref<HTMLDivElement | null>(null)
           :get-popup-container="() => divRef!"
           need-confirm
           :classes="classes"
-        >
-          <template #prefix>
-            <SmileOutlined />
-          </template>
-        </a-date-picker>
+          :prefix="prefixIcon"
+        />
         <a-range-picker
           v-else
           :z-index="1"
@@ -56,11 +54,8 @@ const divRef = ref<HTMLDivElement | null>(null)
           :get-popup-container="() => divRef!"
           need-confirm
           :classes="classes"
-        >
-          <template #prefix>
-            <SmileOutlined />
-          </template>
-        </a-range-picker>
+          :prefix="prefixIcon"
+        />
       </a-flex>
     </template>
   </SemanticPreview>

--- a/docs/src/pages/components/time-picker/demo/_semantic.vue
+++ b/docs/src/pages/components/time-picker/demo/_semantic.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { SmileOutlined } from '@antdv-next/icons'
-import { computed, ref } from 'vue'
+import { computed, h, ref } from 'vue'
 import { SemanticPreview } from '@/components/semantic'
 import { useComponentLocale } from '@/composables/use-locale'
 import { locales } from '../locales'
@@ -21,6 +21,7 @@ const semantics = computed(() => [
 
 const type = ref<'Single' | 'Multiple'>('Single')
 const divRef = ref<HTMLDivElement | null>(null)
+const prefixIcon = h(SmileOutlined)
 </script>
 
 <template>
@@ -42,11 +43,8 @@ const divRef = ref<HTMLDivElement | null>(null)
           :get-popup-container="() => divRef!"
           need-confirm
           :classes="classes"
-        >
-          <template #prefix>
-            <SmileOutlined />
-          </template>
-        </a-time-picker>
+          :prefix="prefixIcon"
+        />
         <a-time-range-picker
           v-else
           :z-index="1"
@@ -54,11 +52,8 @@ const divRef = ref<HTMLDivElement | null>(null)
           :get-popup-container="() => divRef!"
           need-confirm
           :classes="classes"
-        >
-          <template #prefix>
-            <SmileOutlined />
-          </template>
-        </a-time-range-picker>
+          :prefix="prefixIcon"
+        />
       </a-flex>
     </template>
   </SemanticPreview>

--- a/docs/src/pages/components/time-picker/demo/suffix.vue
+++ b/docs/src/pages/components/time-picker/demo/suffix.vue
@@ -10,10 +10,12 @@ Custom `prefix` and `suffixIcon`.
 import { SmileOutlined } from '@antdv-next/icons'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
+import { h } from 'vue'
 
 dayjs.extend(customParseFormat)
 
 const defaultOpenValue = dayjs('00:00:00', 'HH:mm:ss')
+const prefixIcon = h(SmileOutlined)
 
 function onChange(time: any, timeString: string) {
   console.log(time, timeString)
@@ -30,15 +32,7 @@ function onChange(time: any, timeString: string) {
         <SmileOutlined />
       </template>
     </a-time-picker>
-    <a-time-picker>
-      <template #prefix>
-        <SmileOutlined />
-      </template>
-    </a-time-picker>
-    <a-time-range-picker>
-      <template #prefix>
-        <SmileOutlined />
-      </template>
-    </a-time-range-picker>
+    <a-time-picker :prefix="prefixIcon" />
+    <a-time-range-picker :prefix="prefixIcon" />
   </a-space>
 </template>

--- a/packages/antdv-next/src/date-picker/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/date-picker/tests/__snapshots__/demo.test.tsx.snap
@@ -65,7 +65,29 @@ exports[`date-picker demo > renders _semantic correctly 1`] = `
         <div
           class="ant-picker ant-picker-outlined css-var-v-0 ant-picker-css-var semantic-mark-root"
         >
-          <!---->
+          <div
+            class="ant-picker-prefix semantic-mark-prefix"
+          >
+            <span
+              aria-label="smile"
+              class="anticon anticon-smile"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="smile"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                />
+              </svg>
+            </span>
+          </div>
           <div
             class="ant-picker-input"
           >

--- a/packages/antdv-next/src/time-picker/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/time-picker/tests/__snapshots__/demo.test.tsx.snap
@@ -65,7 +65,29 @@ exports[`time-picker demo > renders _semantic correctly 1`] = `
         <div
           class="ant-picker ant-picker-outlined css-var-v-0 ant-picker-css-var semantic-mark-root"
         >
-          <!---->
+          <div
+            class="ant-picker-prefix semantic-mark-prefix"
+          >
+            <span
+              aria-label="smile"
+              class="anticon anticon-smile"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="smile"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                />
+              </svg>
+            </span>
+          </div>
           <div
             class="ant-picker-input"
           >
@@ -2724,7 +2746,29 @@ exports[`time-picker demo > renders suffix correctly 1`] = `
     <div
       class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
     >
-      <!---->
+      <div
+        class="ant-picker-prefix"
+      >
+        <span
+          aria-label="smile"
+          class="anticon anticon-smile"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="smile"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+            />
+          </svg>
+        </span>
+      </div>
       <div
         class="ant-picker-input"
       >
@@ -2775,7 +2819,29 @@ exports[`time-picker demo > renders suffix correctly 1`] = `
     <div
       class="ant-picker ant-picker-range ant-picker-outlined css-var-root ant-picker-css-var"
     >
-      <!---->
+      <div
+        class="ant-picker-prefix"
+      >
+        <span
+          aria-label="smile"
+          class="anticon anticon-smile"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="smile"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+            />
+          </svg>
+        </span>
+      </div>
       <div
         class="ant-picker-input ant-picker-input-start"
       >


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [x] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 💡 背景与方案

当前 `DatePicker` 和 `TimePicker` 组件将 `prefix` 定义为 `VueNode` 类型的属性，但没有将其定义为具名插槽。

相关示例使用了不受支持的写法：

```vue
<template #prefix>
  <SmileOutlined />
</template>
```

由于组件实现没有读取 `prefix` 插槽，因此该写法不会渲染前缀内容，对应快照中仅存在空注释节点：

```html
<!---->
```

<img width="2224" height="908" alt="image" src="https://github.com/user-attachments/assets/ccda1c2a-7067-4537-8c07-3ced1c3dbde4" />


<img width="1153" height="487" alt="image" src="https://github.com/user-attachments/assets/7657126c-fe63-4de4-9acc-89c8f16c3e31" />

<img width="2091" height="801" alt="image" src="https://github.com/user-attachments/assets/340cdeee-8e73-4722-b91c-bd39f0008a3f" />


本次变更修正「语义化 DOM」预览 `prefix` 失效问题，及通过 `h()` 创建图标节点，并使用组件支持的 `prefix` 属性传入：

```vue
<script setup lang="ts">
import { SmileOutlined } from '@antdv-next/icons'
import { h } from 'vue'

const prefixIcon = h(SmileOutlined)
</script>

<template>
  <a-time-picker :prefix="prefixIcon" />
  <a-time-range-picker :prefix="prefixIcon" />
</template>
```

<img width="2241" height="952" alt="image" src="https://github.com/user-attachments/assets/98f5bd71-74f6-48ac-a389-090dd8716114" />

<img width="1126" height="572" alt="image" src="https://github.com/user-attachments/assets/fd3f9ca4-8470-4eeb-b84c-1f881804e40c" />

<img width="2224" height="958" alt="image" src="https://github.com/user-attachments/assets/2b01bdb8-c45d-4fc2-b0be-c7ddc9d58498" />


| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 |     Fixed DatePicker and TimePicker demos to use the supported `prefix` prop instead of the unsupported `prefix` slot.     |
| 🇨🇳 中文 |    修复 DatePicker 和 TimePicker 示例，使用支持的 `prefix` 属性替代不支持的 `prefix` 插槽。      |