### PR TITLE
docs(divider): correct plain default value in en-US API table

### DIFF
--- a/docs/src/pages/components/divider/index.en-US.md
+++ b/docs/src/pages/components/divider/index.en-US.md
@@ -39,7 +39,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | --- | --- | --- | --- | --- |
 | dashed | Whether line is dashed | boolean | false | × |
 | orientation | Whether line is horizontal or vertical | `horizontal` \| `vertical` | `horizontal` | × |
-| plain | Divider text show as plain style | boolean | true | × |
+| plain | Divider text show as plain style | boolean | false | × |
 | size | The size of divider. Only valid for horizontal layout | `small` \| `medium` \| `large` | - | × |
 | titlePlacement | The position of title inside divider | `start` \| `end` \| `center` | `center` | × |
 | variant | Whether line is dashed, dotted or solid | `dashed` \| `dotted` \| `solid` | `solid` | × |


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

None

### 💡 背景与方案

Divider 英文文档的 API 表中，`plain` 属性默认值误标为 `true`，而实现（`packages/antdv-next/src/divider/index.tsx`）仅在 `plain` 显式为真时添加 `ant-divider-plain` 类，默认值实为 `false`；中文文档的标注是正确的。英文用户会误以为普通正文样式默认启用，实际默认仍是强调标题样式。

本 PR 将 `docs/src/pages/components/divider/index.en-US.md` 中 `plain` 的默认值由 `true` 改为 `false`，与实现及中文文档对齐。仅文档修正，不涉及任何代码、API 或交互变化。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |