### PR TITLE
fix(input): keep borderless border box to avoid flash on variant switch

### DIFF
--- a/packages/antdv-next/src/input-number/style/index.ts
+++ b/packages/antdv-next/src/input-number/style/index.ts
@@ -103,19 +103,6 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
         }),
         ...genBorderlessStyle(token),
 
-        [`&${componentCls}-borderless`]: {
-          paddingBlock: 0,
-          [varName('input-padding-block')]: unit(token.calc(paddingBlock).add(lineWidth).equal()),
-        },
-        [`&${componentCls}-borderless${componentCls}-sm`]: {
-          paddingBlock: 0,
-          [varName('input-padding-block')]: unit(token.calc(paddingBlockSM).add(lineWidth).equal()),
-        },
-        [`&${componentCls}-borderless${componentCls}-lg`]: {
-          paddingBlock: 0,
-          [varName('input-padding-block')]: unit(token.calc(paddingBlockLG).add(lineWidth).equal()),
-        },
-
         // ========================= RTL ==========================
         '&-rtl': {
           direction: 'rtl',

--- a/packages/antdv-next/src/input/style/variants.ts
+++ b/packages/antdv-next/src/input/style/variants.ts
@@ -203,10 +203,8 @@ export function genBorderlessStyle(token: InputToken, extraStyles?: CSSObject): 
   return {
     '&-borderless': {
       background: 'transparent',
-      // Keep the border box (same as Select) so variant switching only transitions colors.
-      borderWidth: token.lineWidth,
-      borderStyle: token.lineType,
-      borderColor: 'transparent',
+      // Reserve border space for consistent control heights and a stable transition origin.
+      border: `${unit(token.lineWidth)} ${token.lineType} transparent`,
 
       '&:focus, &:focus-within': {
         outline: 'none',

--- a/packages/antdv-next/src/input/style/variants.ts
+++ b/packages/antdv-next/src/input/style/variants.ts
@@ -203,19 +203,10 @@ export function genBorderlessStyle(token: InputToken, extraStyles?: CSSObject): 
   return {
     '&-borderless': {
       background: 'transparent',
-      border: 'none',
-
-      // Compensate for the removed border to maintain consistent height with other components
-      // (e.g. Select borderless) that keep a transparent border.
-      paddingBlock: token.calc(token.paddingBlock).add(token.lineWidth).equal(),
-
-      [`&${componentCls}-sm, &${componentCls}-affix-wrapper-sm`]: {
-        paddingBlock: token.calc(token.paddingBlockSM).add(token.lineWidth).equal(),
-      },
-
-      [`&${componentCls}-lg, &${componentCls}-affix-wrapper-lg`]: {
-        paddingBlock: token.calc(token.paddingBlockLG).add(token.lineWidth).equal(),
-      },
+      // Keep the border box (same as Select) so variant switching only transitions colors.
+      borderWidth: token.lineWidth,
+      borderStyle: token.lineType,
+      borderColor: 'transparent',
 
       '&:focus, &:focus-within': {
         outline: 'none',


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [x] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

参考 https://github.com/ant-design/ant-design/pull/59269

### 💡 背景与方案

Input 从 `borderless` 切换到其他 variant（`outlined` / `filled` / `underlined`）时，会出现短暂的边框闪现与内容位移。
<img width="1153" height="422" alt="form-variant-borderless" src="https://github.com/user-attachments/assets/e7d02076-417c-4833-bd57-db13a8870167" />

原因：

- borderless 原实现使用 `border: none` 移除边框盒，并以 `paddingBlock + lineWidth` 补偿高度；
- 基础样式为 `transition: all`，运行时切换 variant 时 border-width（0→1px）与 padding 同时参与过渡，导致边框"生长"和内容位置跳动。

解决方案：

对齐 Select borderless / Input filled 的稳定实现，borderless 保留 1px 边框盒、仅将 `borderColor` 设为 `transparent`。切换 variant 时几何尺寸恒定，只有颜色参与过渡；同步移除 borderless 自身的 paddingBlock 补偿及 InputNumber 中对应的内层补偿（修复后与其他 variant 结构完全一致，补偿不再需要）。

影响范围：`genBorderlessStyle` 为共享样式生成器，Input / TextArea / Search / Password 等共享样式及 InputNumber、Mentions、DatePicker 的 borderless 变体统一生效。borderless 最终视觉外观不变（仍无可见边框，与其他 variant 等高）。

<img width="1153" height="422" alt="form-variant-borderless2" src="https://github.com/user-attachments/assets/c213fd03-4212-4751-8273-206543f5f29e" />


### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | 🐞 Input: fix border flash when switching from the borderless variant at runtime. |
| 🇨🇳 中文 | 🐞 Input：修复运行时从 borderless 切换 variant 时边框闪现的问题。 |