### PR TITLE
fix(picker): render prefix slot correctly

### DIFF
--- a/docs/src/pages/components/date-picker/index.en-US.md
+++ b/docs/src/pages/components/date-picker/index.en-US.md
@@ -253,6 +253,7 @@ export type FormatType
 
 | Slot | Description | Type | Version |
 | --- | --- | --- | --- |
+| prefix | The custom prefix | () => any | - |
 | suffixIcon | The custom suffix icon | () => any | - |
 | renderExtraFooter | Render extra footer in panel | (mode: PickerMode) => any | - |
 | panelRender | Customize panel render | (originPanel: VueNode) => any | - |

--- a/docs/src/pages/components/date-picker/index.zh-CN.md
+++ b/docs/src/pages/components/date-picker/index.zh-CN.md
@@ -255,6 +255,7 @@ export type FormatType
 
 | 插槽 | 说明 | 类型 | 版本 |
 | --- | --- | --- | --- |
+| prefix | 自定义前缀 | () => any | - |
 | suffixIcon | 自定义的选择框后缀图标 | () => any | - |
 | renderExtraFooter | 在面板中添加额外的页脚 | (mode: PickerMode) => any | - |
 | panelRender | 自定义渲染面板 | (originPanel: VueNode) => any | - |

--- a/docs/src/pages/components/time-picker/index.en-US.md
+++ b/docs/src/pages/components/time-picker/index.en-US.md
@@ -43,6 +43,7 @@ Common props ref：[Common props](/docs/vue/common-props)
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | allowClear | Customize clear icon | boolean \| \{ clearIcon?: VueNode \} | true | 5.8.0: Support object type | ✓ |
+| ~~addon~~ | Called from time picker panel to render an addon to its bottom, please use `renderExtraFooter` instead | () => VueNode | - | - | × |
 | cellRender | Custom rendering function for picker cells | (current: number, info: \{ originNode: VueNode, today: dayjs, range?: 'start' \| 'end', subType: 'hour' \| 'minute' \| 'second' \| 'meridiem' \}) => VueNode | - | 5.4.0 | × |
 | changeOnScroll | Trigger selection when scroll the column | boolean | false | 5.14.0 | × |
 | classes | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: \{ props \})=> Record<[SemanticDOM](#semantic-dom), string> | - |  | ✓ |
@@ -94,12 +95,21 @@ type DisabledTime = (now: Dayjs) => {
 
 Note: `disabledMilliseconds` is added in `5.14.0`.
 
-## Methods
+#### Methods
 
 | Name    | Description  | Version |
 | ------- | ------------ | ------- |
 | blur()  | Remove focus |         |
 | focus() | Get focus    |         |
+
+#### Slots
+
+| Slot | Description | Type | Version |
+| --- | --- | --- | --- |
+| ~~addon~~ | Deprecated. Use `renderExtraFooter` instead | () => any | - |
+| renderExtraFooter | Called from time picker panel to render some addon to its bottom | (mode: PickerMode) => any | - |
+| suffixIcon | The custom suffix icon | () => any | - |
+| prefix | The custom prefix | () => any | - |
 
 ### RangePicker
 

--- a/docs/src/pages/components/time-picker/index.zh-CN.md
+++ b/docs/src/pages/components/time-picker/index.zh-CN.md
@@ -44,6 +44,7 @@ demo:
 | 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | allowClear | 自定义清除按钮 | boolean \| \{ clearIcon?: VueNode \} | true | 5.8.0: 支持对象类型 | ✓ |
+| ~~addon~~ | TimePicker 面板底部的附加内容渲染函数，请使用 `renderExtraFooter` 替代 | () => VueNode | - | - | × |
 | cellRender | 自定义单元格的内容 | (current: number, info: \{ originNode: VueNode, today: dayjs, range?: 'start' \| 'end', subType: 'hour' \| 'minute' \| 'second' \| 'meridiem' \}) => VueNode | - | 5.4.0 | × |
 | changeOnScroll | 在滚动时改变选择值 | boolean | false | 5.14.0 | × |
 | classes | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: \{ props \})=> Record<[SemanticDOM](#semantic-dom), string> | - |  | ✓ |
@@ -95,14 +96,23 @@ type DisabledTime = (now: Dayjs) => {
 
 注意：`disabledMilliseconds` 为 `5.14.0` 新增。
 
-## 方法 {#methods}
+#### 方法 {#methods}
 
 | 名称    | 描述     | 版本 |
 | ------- | -------- | ---- |
 | blur()  | 移除焦点 |      |
 | focus() | 获取焦点 |      |
 
-## RangePicker
+#### 插槽 {#slots}
+
+| 插槽 | 说明 | 类型 | 版本 |
+| --- | --- | --- | --- |
+| ~~addon~~ | 已弃用，请使用 `renderExtraFooter` | () => any | - |
+| renderExtraFooter | 在时间选择面板底部显示自定义内容 | (mode: PickerMode) => any | - |
+| suffixIcon | 自定义的选择框后缀图标 | () => any | - |
+| prefix | 自定义前缀 | () => any | - |
+
+### RangePicker
 
 属性与 DatePicker 的 [RangePicker](/components/date-picker-cn#rangepicker) 相同。还包含以下属性：
 

--- a/packages/antdv-next/src/components.ts
+++ b/packages/antdv-next/src/components.ts
@@ -215,6 +215,7 @@ export type {
   TimePickerSlots,
   TimeRangePickerEmits,
   TimeRangePickerProps,
+  TimeRangePickerSlots,
 } from './time-picker'
 export { default as Timeline, TimelineItem } from './timeline'
 export type { TimelineItemProps, TimelineItemSlots, TimelineItemType, TimelineProps } from './timeline'

--- a/packages/antdv-next/src/date-picker/generatePicker/generateRangePicker.tsx
+++ b/packages/antdv-next/src/date-picker/generatePicker/generateRangePicker.tsx
@@ -46,6 +46,7 @@ export interface RangePickerEmits<DateType = AnyObject> {
 
 export interface RangePickerSlots {
   suffixIcon?: () => any
+  prefix?: () => any
   renderExtraFooter?: (mode: PickerMode) => any
   panelRender?: (originPanel: VueNode) => any
   inputRender?: (props: Record<string, any>) => any
@@ -244,6 +245,7 @@ function generateRangePicker<DateType extends AnyObject = AnyObject>(generateCon
           components,
           placement,
           suffixIcon,
+          prefix,
           allowClear,
           popupClassName: _popupClassName,
           dropdownClassName: _dropdownClassName,
@@ -264,6 +266,7 @@ function generateRangePicker<DateType extends AnyObject = AnyObject>(generateCon
         const { className, style, restAttrs } = getAttrStyleAndClass(attrs, undefined, props)
 
         const mergedSuffixIcon = getSlotPropsFnRun(slots, { suffixIcon }, 'suffixIcon', false)
+        const mergedPrefix = getSlotPropsFnRun(slots, { prefix }, 'prefix', false)
 
         const [mergedAllowClear] = useIcons({ allowClear }, prefixCls.value)
 
@@ -348,6 +351,7 @@ function generateRangePicker<DateType extends AnyObject = AnyObject>(generateCon
               placement={placement}
               placeholder={getRangePlaceholder(locale.value, props.picker, placeholder)}
               suffix={suffixNode}
+              prefix={mergedPrefix}
               prevIcon={<span class={`${prefixCls.value}-prev-icon`} />}
               nextIcon={<span class={`${prefixCls.value}-next-icon`} />}
               superPrevIcon={<span class={`${prefixCls.value}-super-prev-icon`} />}

--- a/packages/antdv-next/src/date-picker/generatePicker/generateRangePicker.tsx
+++ b/packages/antdv-next/src/date-picker/generatePicker/generateRangePicker.tsx
@@ -44,13 +44,13 @@ export interface RangePickerEmits<DateType = AnyObject> {
   'keydown': (e: KeyboardEvent, preventDefault: VoidFunction) => void
 }
 
-export interface RangePickerSlots {
+export interface RangePickerSlots<CurrentType = AnyObject> {
   suffixIcon?: () => any
   prefix?: () => any
   renderExtraFooter?: (mode: PickerMode) => any
   panelRender?: (originPanel: VueNode) => any
   inputRender?: (props: Record<string, any>) => any
-  cellRender?: (ctx: { current: AnyObject, info: any }) => any
+  cellRender?: (ctx: { current: CurrentType, info: any }) => any
   dateRender?: (ctx: { date: AnyObject, today: AnyObject }) => any
   monthCellRender?: (ctx: { date: AnyObject, locale: any }) => any
   [key: string]: any

--- a/packages/antdv-next/src/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/packages/antdv-next/src/date-picker/generatePicker/generateSinglePicker.tsx
@@ -56,6 +56,7 @@ export interface DatePickerEmits<DateType = AnyObject> {
 
 export interface DatePickerSlots {
   suffixIcon?: () => any
+  prefix?: () => any
   renderExtraFooter?: (mode: PickerMode) => any
   panelRender?: (originPanel: VueNode) => any
   inputRender?: (props: Record<string, any>) => any
@@ -283,6 +284,7 @@ function generatePicker<DateType extends AnyObject = AnyObject>(generateConfig: 
             components,
             placement,
             suffixIcon,
+            prefix,
             allowClear,
             popupClassName: _popupClassName,
             dropdownClassName: _dropdownClassName,
@@ -303,6 +305,7 @@ function generatePicker<DateType extends AnyObject = AnyObject>(generateConfig: 
           const { className, style, restAttrs } = getAttrStyleAndClass(attrs, undefined, props)
 
           const mergedSuffixIcon = getSlotPropsFnRun(slots, { suffixIcon }, 'suffixIcon', false)
+          const mergedPrefix = getSlotPropsFnRun(slots, { prefix }, 'prefix', false)
 
           const [mergedAllowClear, removeIcon] = useIcons({
             allowClear,
@@ -377,6 +380,7 @@ function generatePicker<DateType extends AnyObject = AnyObject>(generateConfig: 
                 ref={innerRef}
                 placeholder={getPlaceholder(locale.value, mergedPicker.value, placeholder)}
                 suffix={suffixNode}
+                prefix={mergedPrefix}
                 placement={placement}
                 prevIcon={<span class={`${prefixCls.value}-prev-icon`} />}
                 nextIcon={<span class={`${prefixCls.value}-next-icon`} />}

--- a/packages/antdv-next/src/date-picker/tests/DatePicker.test.tsx
+++ b/packages/antdv-next/src/date-picker/tests/DatePicker.test.tsx
@@ -184,12 +184,18 @@ describe('date-picker', () => {
   })
 
   // ====================== Prefix ======================
-  it('should render prefix from slot and fall back to prop', () => {
+  it('should prefer prefix slot and fall back to prop', () => {
     const wrapper = mount({
-      render: () => <DatePicker v-slots={{ prefix: () => <SmileOutlined /> }} />,
+      render: () => (
+        <DatePicker
+          prefix={<span class="prop-prefix">P</span>}
+          v-slots={{ prefix: () => <SmileOutlined /> }}
+        />
+      ),
     })
     expect(wrapper.find('.ant-picker-prefix').exists()).toBe(true)
     expect(wrapper.find('.ant-picker-prefix .anticon-smile').exists()).toBe(true)
+    expect(wrapper.find('.ant-picker-prefix .prop-prefix').exists()).toBe(false)
     wrapper.unmount()
 
     const propWrapper = mount(DatePicker, {
@@ -201,10 +207,22 @@ describe('date-picker', () => {
 
   it('should render prefix for RangePicker from slot', () => {
     const wrapper = mount({
-      render: () => <DatePicker.RangePicker v-slots={{ prefix: () => <SmileOutlined /> }} />,
+      render: () => (
+        <DatePicker.RangePicker
+          prefix={<span class="prop-prefix">P</span>}
+          v-slots={{ prefix: () => <SmileOutlined /> }}
+        />
+      ),
     })
     expect(wrapper.find('.ant-picker-prefix').exists()).toBe(true)
     expect(wrapper.find('.ant-picker-prefix .anticon-smile').exists()).toBe(true)
+    expect(wrapper.find('.ant-picker-prefix .prop-prefix').exists()).toBe(false)
     wrapper.unmount()
+
+    const propWrapper = mount(DatePicker.RangePicker, {
+      props: { prefix: <span class="custom-prefix">P</span> },
+    })
+    expect(propWrapper.find('.ant-picker-prefix .custom-prefix').exists()).toBe(true)
+    propWrapper.unmount()
   })
 })

--- a/packages/antdv-next/src/date-picker/tests/DatePicker.test.tsx
+++ b/packages/antdv-next/src/date-picker/tests/DatePicker.test.tsx
@@ -1,3 +1,4 @@
+import { SmileOutlined } from '@antdv-next/icons'
 import dayjs from 'dayjs'
 import MockDate from 'mockdate'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -179,6 +180,31 @@ describe('date-picker', () => {
     errSpy.mockRestore()
     open.value = false
     await nextTick()
+    wrapper.unmount()
+  })
+
+  // ====================== Prefix ======================
+  it('should render prefix from slot and fall back to prop', () => {
+    const wrapper = mount({
+      render: () => <DatePicker v-slots={{ prefix: () => <SmileOutlined /> }} />,
+    })
+    expect(wrapper.find('.ant-picker-prefix').exists()).toBe(true)
+    expect(wrapper.find('.ant-picker-prefix .anticon-smile').exists()).toBe(true)
+    wrapper.unmount()
+
+    const propWrapper = mount(DatePicker, {
+      props: { prefix: <span class="custom-prefix">P</span> },
+    })
+    expect(propWrapper.find('.ant-picker-prefix .custom-prefix').exists()).toBe(true)
+    propWrapper.unmount()
+  })
+
+  it('should render prefix for RangePicker from slot', () => {
+    const wrapper = mount({
+      render: () => <DatePicker.RangePicker v-slots={{ prefix: () => <SmileOutlined /> }} />,
+    })
+    expect(wrapper.find('.ant-picker-prefix').exists()).toBe(true)
+    expect(wrapper.find('.ant-picker-prefix .anticon-smile').exists()).toBe(true)
     wrapper.unmount()
   })
 })

--- a/packages/antdv-next/src/date-picker/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/date-picker/tests/__snapshots__/demo.test.tsx.snap
@@ -64,7 +64,29 @@ exports[`date-picker demo > renders _semantic correctly 1`] = `
         <div
           class="ant-picker ant-picker-outlined css-var-v-0 ant-picker-css-var semantic-mark-root"
         >
-          <!---->
+          <div
+            class="ant-picker-prefix semantic-mark-prefix"
+          >
+            <span
+              aria-label="smile"
+              class="anticon anticon-smile"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="smile"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                />
+              </svg>
+            </span>
+          </div>
           <div
             class="ant-picker-input"
           >

--- a/packages/antdv-next/src/time-picker/index.tsx
+++ b/packages/antdv-next/src/time-picker/index.tsx
@@ -10,6 +10,7 @@ import type {
   PickerProps,
   RangePickerProps,
 } from '../date-picker/generatePicker'
+import type { RangePickerSlots } from '../date-picker/generatePicker/generateRangePicker'
 import { computed, defineComponent, shallowRef } from 'vue'
 import genPurePanel from '../_util/PurePanel.tsx'
 import { toPropsRefs } from '../_util/tools'
@@ -112,9 +113,13 @@ export interface TimeRangePickerEmits<DateType = AnyObject> {
   'keydown': (e: KeyboardEvent, preventDefault: VoidFunction) => void
 }
 
+export interface TimeRangePickerSlots extends RangePickerSlots<number> {}
+
 const RangePicker = defineComponent<
   TimeRangePickerProps,
-  TimeRangePickerEmits
+  TimeRangePickerEmits,
+  string,
+  SlotsType<TimeRangePickerSlots>
 >(
   (props, { slots, emit, expose, attrs }) => {
     const rangeRef = shallowRef<PickerRef>()
@@ -191,6 +196,7 @@ export interface TimePickerProps
   extends BaseTimePickerProps,
   /* @vue-ignore */
   Omit<TimePickerEmitsProps, keyof BaseTimePickerProps> {
+  /** @deprecated Please use `renderExtraFooter` instead */
   addon?: () => VueNode
   status?: InputStatus
   /** @deprecated Please use `classes.popup` instead */
@@ -204,6 +210,7 @@ export interface TimePickerProps
 }
 
 export interface TimePickerSlots {
+  /** @deprecated Please use `renderExtraFooter` instead */
   addon?: () => any
   renderExtraFooter?: (mode: PickerMode) => any
   suffixIcon?: () => any
@@ -274,7 +281,7 @@ const TimePicker = defineComponent<
 
     if (isDev) {
       const warning = devUseWarning('TimePicker')
-      warning.deprecated(!props.addon, 'addon', 'renderExtraFooter')
+      warning.deprecated(!props.addon && !slots.addon, 'addon', 'renderExtraFooter')
     }
 
     const [mergedVariant] = useVariants('timePicker', variant, bordered)

--- a/packages/antdv-next/src/time-picker/index.tsx
+++ b/packages/antdv-next/src/time-picker/index.tsx
@@ -207,6 +207,7 @@ export interface TimePickerSlots {
   addon?: () => any
   renderExtraFooter?: (mode: PickerMode) => any
   suffixIcon?: () => any
+  prefix?: () => any
   [key: string]: any
 }
 

--- a/packages/antdv-next/src/time-picker/tests/TimePicker.test.tsx
+++ b/packages/antdv-next/src/time-picker/tests/TimePicker.test.tsx
@@ -1,3 +1,4 @@
+import type { TimeRangePickerSlots } from '../../components'
 import { SmileOutlined } from '@antdv-next/icons'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
@@ -12,6 +13,10 @@ import { mount } from '/@tests/utils'
 dayjs.extend(customParseFormat)
 
 const { RangePicker } = TimePicker
+
+type IsExact<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+  ? true
+  : false
 
 describe('time-picker', () => {
   beforeEach(() => {
@@ -352,6 +357,11 @@ describe('time-picker', () => {
     await nextTick()
 
     expect(document.querySelector('.addon-slot')).toBeTruthy()
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Warning: [antd: TimePicker] `addon` is deprecated. Please use `renderExtraFooter` instead.',
+      ),
+    )
 
     errSpy.mockRestore()
     await wrapper.setProps({ open: false })
@@ -642,12 +652,18 @@ describe('time-picker', () => {
   })
 
   // ====================== Prefix ======================
-  it('should render prefix from slot and fall back to prop', () => {
+  it('should prefer prefix slot and fall back to prop', () => {
     const wrapper = mount({
-      render: () => <TimePicker v-slots={{ prefix: () => <SmileOutlined /> }} />,
+      render: () => (
+        <TimePicker
+          prefix={<span class="prop-prefix">P</span>}
+          v-slots={{ prefix: () => <SmileOutlined /> }}
+        />
+      ),
     })
     expect(wrapper.find('.ant-picker-prefix').exists()).toBe(true)
     expect(wrapper.find('.ant-picker-prefix .anticon-smile').exists()).toBe(true)
+    expect(wrapper.find('.ant-picker-prefix .prop-prefix').exists()).toBe(false)
     wrapper.unmount()
 
     const propWrapper = mount(TimePicker, {
@@ -659,10 +675,31 @@ describe('time-picker', () => {
 
   it('should render prefix for RangePicker from slot', () => {
     const wrapper = mount(RangePicker, {
+      props: { prefix: <span class="prop-prefix">P</span> },
       slots: { prefix: () => <SmileOutlined /> },
     })
     expect(wrapper.find('.ant-picker-prefix').exists()).toBe(true)
     expect(wrapper.find('.ant-picker-prefix .anticon-smile').exists()).toBe(true)
+    expect(wrapper.find('.ant-picker-prefix .prop-prefix').exists()).toBe(false)
+    wrapper.unmount()
+
+    const propWrapper = mount(RangePicker, {
+      props: { prefix: <span class="custom-prefix">P</span> },
+    })
+    expect(propWrapper.find('.ant-picker-prefix .custom-prefix').exists()).toBe(true)
+    propWrapper.unmount()
+  })
+
+  it('should expose typed RangePicker slots from the package entry', () => {
+    type CellRenderContext = Parameters<NonNullable<TimeRangePickerSlots['cellRender']>>[0]
+    const cellRenderCurrentTyped: IsExact<CellRenderContext['current'], number> = true
+    const slots: TimeRangePickerSlots = {
+      prefix: () => <span class="typed-prefix">P</span>,
+    }
+    const wrapper = mount(RangePicker, { slots })
+
+    expect(cellRenderCurrentTyped).toBe(true)
+    expect(wrapper.find('.typed-prefix').exists()).toBe(true)
     wrapper.unmount()
   })
 })

--- a/packages/antdv-next/src/time-picker/tests/TimePicker.test.tsx
+++ b/packages/antdv-next/src/time-picker/tests/TimePicker.test.tsx
@@ -1,3 +1,4 @@
+import { SmileOutlined } from '@antdv-next/icons'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 import MockDate from 'mockdate'
@@ -638,5 +639,30 @@ describe('time-picker', () => {
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
+  })
+
+  // ====================== Prefix ======================
+  it('should render prefix from slot and fall back to prop', () => {
+    const wrapper = mount({
+      render: () => <TimePicker v-slots={{ prefix: () => <SmileOutlined /> }} />,
+    })
+    expect(wrapper.find('.ant-picker-prefix').exists()).toBe(true)
+    expect(wrapper.find('.ant-picker-prefix .anticon-smile').exists()).toBe(true)
+    wrapper.unmount()
+
+    const propWrapper = mount(TimePicker, {
+      props: { prefix: <span class="custom-prefix">P</span> },
+    })
+    expect(propWrapper.find('.ant-picker-prefix .custom-prefix').exists()).toBe(true)
+    propWrapper.unmount()
+  })
+
+  it('should render prefix for RangePicker from slot', () => {
+    const wrapper = mount(RangePicker, {
+      slots: { prefix: () => <SmileOutlined /> },
+    })
+    expect(wrapper.find('.ant-picker-prefix').exists()).toBe(true)
+    expect(wrapper.find('.ant-picker-prefix .anticon-smile').exists()).toBe(true)
+    wrapper.unmount()
   })
 })

--- a/packages/antdv-next/src/time-picker/tests/__snapshots__/demo.test.tsx.snap
+++ b/packages/antdv-next/src/time-picker/tests/__snapshots__/demo.test.tsx.snap
@@ -64,7 +64,29 @@ exports[`time-picker demo > renders _semantic correctly 1`] = `
         <div
           class="ant-picker ant-picker-outlined css-var-v-0 ant-picker-css-var semantic-mark-root"
         >
-          <!---->
+          <div
+            class="ant-picker-prefix semantic-mark-prefix"
+          >
+            <span
+              aria-label="smile"
+              class="anticon anticon-smile"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="smile"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                />
+              </svg>
+            </span>
+          </div>
           <div
             class="ant-picker-input"
           >
@@ -2723,7 +2745,29 @@ exports[`time-picker demo > renders suffix correctly 1`] = `
     <div
       class="ant-picker ant-picker-outlined css-var-root ant-picker-css-var"
     >
-      <!---->
+      <div
+        class="ant-picker-prefix"
+      >
+        <span
+          aria-label="smile"
+          class="anticon anticon-smile"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="smile"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+            />
+          </svg>
+        </span>
+      </div>
       <div
         class="ant-picker-input"
       >
@@ -2774,7 +2818,29 @@ exports[`time-picker demo > renders suffix correctly 1`] = `
     <div
       class="ant-picker ant-picker-range ant-picker-outlined css-var-root ant-picker-css-var"
     >
-      <!---->
+      <div
+        class="ant-picker-prefix"
+      >
+        <span
+          aria-label="smile"
+          class="anticon anticon-smile"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="smile"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+            />
+          </svg>
+        </span>
+      </div>
       <div
         class="ant-picker-input ant-picker-input-start"
       >


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

None

### 💡 背景与方案

`#prefix` 插槽是组件已声明的 API，但封装层从未将 `slots.prefix` 解析为底层 `@v-c/picker` 所需的 `prefix` 属性，导致所有 `<template #prefix>` 用法（包括语义化 DOM 演示中的 smile 前缀）都无法渲染；`prefix` 属性此前也只是依赖 `restProps` 的意外透传才得以显示，并非显式实现。
<img width="2552" height="900" alt="image" src="https://github.com/user-attachments/assets/7a5447b1-5f6d-4ce0-802f-bd4bac63a299" />


本次变更：
- `generateSinglePicker` / `generateRangePicker` 通过 `getSlotPropsFnRun(slots, { prefix }, 'prefix', false)` 解析 `prefix`（插槽优先、prop 回退）并传给内部 picker。
- `RangePickerSlots` 泛型化为 `RangePickerSlots<CurrentType = AnyObject>`（默认值向后兼容）；新增 `TimeRangePickerSlots extends RangePickerSlots<number>`（`cellRender` 的 `current` 收紧为 `number`），补全 RangePicker 的 `SlotsType` 泛型并从包入口导出。
- TimePicker 的 `addon` 插槽用法现在与 `addon` 属性一样触发弃用警告（提示改用 `renderExtraFooter`），补充 `@deprecated` JSDoc。
- date-picker / time-picker 中英文 API 表补 `#prefix` 插槽；time-picker 补 `addon` 弃用说明与 Slots 小节；对齐中英文标题层级。
- 测试覆盖单选/范围 × date/time 的「插槽优先于 prop」及 prop 回退行为，断言 `addon` 插槽的弃用警告，更新语义化 DOM demo 快照。

修复后两种用法均可正常渲染：

```vue
<a-date-picker>
  <template #prefix>
    <SmileOutlined />
  </template>
</a-date-picker>

<!-- 或 -->
<a-date-picker :prefix="smileIcon" />
```
<img width="2555" height="840" alt="image" src="https://github.com/user-attachments/assets/b9472413-41b9-4a33-8374-2071fb6004fc" />

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Fixed an issue where the `#prefix` slot of DatePicker / TimePicker never rendered. |
| 🇨🇳 中文 | 修复 DatePicker / TimePicker 的 `#prefix` 插槽无法渲染的问题。 |