### PR TITLE
docs: show document date and author metadata

### DIFF
--- a/docs/src/components/docs/doc-meta.vue
+++ b/docs/src/components/docs/doc-meta.vue
@@ -1,0 +1,65 @@
+<script lang="ts" setup>
+import type { Frontmatter } from '@/composables/doc-page.ts'
+import { CalendarOutlined } from '@antdv-next/icons'
+import { computed, reactive } from 'vue'
+
+defineOptions({ name: 'DocMeta' })
+
+const props = defineProps<{
+  frontmatter?: Frontmatter
+}>()
+
+const avatarUrl = (name: string) => `https://github.com/${name}.png?size=24`
+
+const avatarStatus = reactive<Record<string, 'loading' | 'done' | 'error'>>({})
+
+function preloadAvatar(name: string) {
+  if (avatarStatus[name])
+    return
+  avatarStatus[name] = 'loading'
+  const img = new Image()
+  img.onload = () => {
+    avatarStatus[name] = 'done'
+  }
+  img.onerror = () => {
+    avatarStatus[name] = 'error'
+  }
+  img.src = avatarUrl(name)
+}
+
+const authors = computed(() => {
+  const author = props.frontmatter?.author
+  if (!author)
+    return []
+  const names = author.split(',').map(item => item.trim()).filter(Boolean)
+  names.forEach(preloadAvatar)
+  return names
+})
+</script>
+
+<template>
+  <div
+    v-if="frontmatter?.datetime || authors.length"
+    class="mt-8px flex flex-wrap items-center gap-8px text-14px"
+    style="color: var(--ant-color-text-tertiary)"
+  >
+    <span v-if="frontmatter?.datetime" class="inline-flex items-center gap-4px">
+      <CalendarOutlined />
+      {{ frontmatter.datetime.slice(0, 10) }}
+    </span>
+    <a
+      v-for="name in authors"
+      :key="name"
+      :href="`https://github.com/${name}`"
+      class="doc-heading-author inline-flex items-center gap-4px decoration-none transition-colors"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <a-skeleton-avatar v-if="avatarStatus[name] === 'loading'" active :size="24" />
+      <a-avatar v-else :alt="name" :size="24" :src="avatarStatus[name] === 'error' ? undefined : avatarUrl(name)">
+        {{ name.slice(0, 1).toUpperCase() }}
+      </a-avatar>
+      <span>@{{ name }}</span>
+    </a>
+  </div>
+</template>

--- a/docs/src/components/docs/heading.vue
+++ b/docs/src/components/docs/heading.vue
@@ -5,6 +5,7 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { usePageInfo } from '@/composables/doc-page.ts'
 import ComponentMeta from './component-meta.vue'
+import DocMeta from './doc-meta.vue'
 
 defineOptions({
   name: 'DocHeading',
@@ -51,5 +52,6 @@ const githubUrl = computed(() => {
     </a-space>
   </a-typography-title>
   {{ frontmatter?.description }}
+  <DocMeta :frontmatter="frontmatter" />
   <ComponentMeta :frontmatter="frontmatter" />
 </template>

--- a/docs/src/composables/doc-page.ts
+++ b/docs/src/composables/doc-page.ts
@@ -5,6 +5,8 @@ export interface Frontmatter {
   subtitle?: string
   description?: string
   tag?: string
+  author?: string
+  datetime?: string
   demo?: {
     cols?: number
     class?: string


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

None

### 💡 背景与方案

文档 frontmatter 已包含日期和作者信息，但标题区域此前没有统一展示这些元数据，对于博客这种内容，展示日期和作者有利于读者获取相关信息。比如官网当前这篇文章开头说“今天，我们终于发布了 Antdv Next 的第一个版本”，但是读者并不知道“今天”是哪天。
<img width="1256" height="307" alt="blog-no-datetime-avatar" src="https://github.com/user-attachments/assets/1c39fca7-dccc-49d5-b73f-42737864302d" />


本次新增 `DocMeta` 组件，样式参考 antd，负责：

- 展示文档日期，直接截取前 10 位，避免时区转换；
- 展示多个 GitHub 作者及头像；
- 头像加载期间显示 skeleton；
- 头像加载失败时显示作者首字母；
- 扩展 `Frontmatter` 类型以支持 `author` 和 `datetime`。

`DocHeading` 仅负责组合标题、文档元信息和组件元信息，降低组件内部复杂度。
<img width="1251" height="362" alt="blog-datetime-avatar" src="https://github.com/user-attachments/assets/d37b5164-14f8-470d-843a-fdc3b9b71953" />


### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |