### PR TITLE
fix(Skeleton): apply numeric element size in pixels

### DIFF
--- a/packages/antdv-next/src/skeleton/Element.tsx
+++ b/packages/antdv-next/src/skeleton/Element.tsx
@@ -49,8 +49,8 @@ const Element = defineComponent<SkeletonElementProps>(
       })
       const sizeStyle = typeof size === 'number'
         ? {
-            width: size,
-            height: size,
+            width: `${size}px`,
+            height: `${size}px`,
             lineHeight: `${size}px`,
           }
         : {}

--- a/packages/antdv-next/src/skeleton/tests/Skeleton.test.tsx
+++ b/packages/antdv-next/src/skeleton/tests/Skeleton.test.tsx
@@ -459,6 +459,8 @@ describe('skeleton', () => {
     it('should render numeric size as inline style', () => {
       const wrapper = mount(Skeleton.Avatar, { props: { size: 20 } })
       const el = wrapper.find('.ant-skeleton-avatar')
+      expect(el.attributes('style')).toContain('width: 20px')
+      expect(el.attributes('style')).toContain('height: 20px')
       expect(el.attributes('style')).toContain('line-height: 20px')
     })
 


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

None

### 💡 背景与方案

Skeleton 元素传入数值类型的 `size` 时，宽高以内联无单位数值传递。Vue DOM 不会像 React 一样自动补充 `px`，导致浏览器丢弃 `width` 和 `height`，最终使用默认的 32px 尺寸。

本次变更为数值类型的宽高显式添加 `px` 单位，并补充回归测试，确保 `width`、`height` 和 `line-height` 均正确生成。不涉及公开 API 变化。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Fix numeric sizes not being applied to Skeleton elements |
| 🇨🇳 中文 | 修复 Skeleton 元素无法正确应用数值尺寸的问题 |