### PR TITLE
fix(component-overview): show border beam effect on zh-CN overview

### DIFF
--- a/docs/src/components/component-overview/index.vue
+++ b/docs/src/components/component-overview/index.vue
@@ -103,7 +103,7 @@ onMounted(() => {
             <a-col :xs="24" :sm="12" :lg="8" :xl="6">
               <RouterLink :to="locale === 'zh-CN' ? `${comp.key}-cn` : comp.key" style="text-decoration: none; color: inherit;">
                 <a-border-beam :duration="6" :line-width="2">
-                  <a-card size="small" class="components-overview-card" :class="[siderLocales?.[comp.key]?.[locale] === 'BorderBeam' ? 'hasBorderBeam' : '']">
+                  <a-card size="small" class="components-overview-card" :class="[getComponentName(comp.key) === 'BorderBeam' ? 'hasBorderBeam' : '']">
                     <template #title>
                       <div class="components-overview-title">
                         {{ siderLocales?.[comp.key]?.[locale] ?? comp.label }}


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

None

### 💡 背景与方案

中文网站组件总览页（`/components/overview-cn`）中 BorderBeam 卡片未展示边框流光效果。
<img width="2544" height="945" alt="image" src="https://github.com/user-attachments/assets/852633a2-247a-4c15-9714-ace04f846842" />


原因：总览页给所有卡片都包了 `a-border-beam`，通过 `hasBorderBeam` 类控制流光显示，但判断条件是 locale 标签严格等于 `'BorderBeam'`；中文标签为 `'BorderBeam 边框流光'`，永远不匹配，导致中文总览页流光被 CSS（`opacity: 0`）一直隐藏。英文标签恰好是 `'BorderBeam'`，因此英文页表现正常。组件本身实现与 ant-design 一致，无问题。

方案：参考 ant-design 组件总览的判断方式（`component.title === 'BorderBeam'`），改用菜单 key 推导组件名判断：`getComponentName(comp.key) === 'BorderBeam'`，中英文均可正确触发流光显示。仅改动文档站一行代码，不影响组件库。

<img width="2534" height="1112" alt="image" src="https://github.com/user-attachments/assets/59dad1d0-4586-45d2-91c0-d76e0536e34a" />


### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |