### PR TITLE
docs(components-overview): show Not Found when search has no result

### DIFF
--- a/docs/src/components/component-overview/index.vue
+++ b/docs/src/components/component-overview/index.vue
@@ -90,39 +90,41 @@ onMounted(() => {
       </div>
     </a-affix>
     <a-divider />
-    <template v-for="group in searchMenus" :key="group.key">
-      <div class="component-overview">
-        <h2 class="component-overview-group-title">
-          <a-space>
-            {{ siderLocales?.[group.key]?.[locale] ?? group.label }}
-            <a-tag>{{ group.children.length }}</a-tag>
-          </a-space>
-        </h2>
-        <a-row :gutter="[24, 24]">
-          <template v-for="comp in group.children" :key="comp.key">
-            <a-col :xs="24" :sm="12" :lg="8" :xl="6">
-              <RouterLink :to="locale === 'zh-CN' ? `${comp.key}-cn` : comp.key" style="text-decoration: none; color: inherit;">
-                <a-border-beam :duration="6" :line-width="2">
-                  <a-card size="small" class="components-overview-card" :class="[getComponentName(comp.key) === 'BorderBeam' ? 'hasBorderBeam' : '']">
-                    <template #title>
-                      <div class="components-overview-title">
-                        {{ siderLocales?.[comp.key]?.[locale] ?? comp.label }}
+    <div class="components-overview-content">
+      <template v-for="group in searchMenus" :key="group.key">
+        <div class="component-overview">
+          <h2 class="component-overview-group-title">
+            <a-space>
+              {{ siderLocales?.[group.key]?.[locale] ?? group.label }}
+              <a-tag>{{ group.children.length }}</a-tag>
+            </a-space>
+          </h2>
+          <a-row :gutter="[24, 24]">
+            <template v-for="comp in group.children" :key="comp.key">
+              <a-col :xs="24" :sm="12" :lg="8" :xl="6">
+                <RouterLink :to="locale === 'zh-CN' ? `${comp.key}-cn` : comp.key" style="text-decoration: none; color: inherit;">
+                  <a-border-beam :duration="6" :line-width="2">
+                    <a-card size="small" class="components-overview-card" :class="[getComponentName(comp.key) === 'BorderBeam' ? 'hasBorderBeam' : '']">
+                      <template #title>
+                        <div class="components-overview-title">
+                          {{ siderLocales?.[comp.key]?.[locale] ?? comp.label }}
+                        </div>
+                      </template>
+                      <div class="components-overview-img">
+                        <img
+                          :src="darkMode ? covers?.[getComponentName(comp.key)]?.coverDark : covers?.[getComponentName(comp.key)]?.cover"
+                          :alt="siderLocales?.[comp.key]?.[locale] ?? comp.label"
+                        >
                       </div>
-                    </template>
-                    <div class="components-overview-img">
-                      <img
-                        :src="darkMode ? covers?.[getComponentName(comp.key)]?.coverDark : covers?.[getComponentName(comp.key)]?.cover"
-                        :alt="siderLocales?.[comp.key]?.[locale] ?? comp.label"
-                      >
-                    </div>
-                  </a-card>
-                </a-border-beam>
-              </RouterLink>
-            </a-col>
-          </template>
-        </a-row>
-      </div>
-    </template>
+                    </a-card>
+                  </a-border-beam>
+                </RouterLink>
+              </a-col>
+            </template>
+          </a-row>
+        </div>
+      </template>
+    </div>
   </section>
 </template>
 
@@ -170,6 +172,18 @@ onMounted(() => {
     border: 0 solid;
     background-color: var(--ant-color-bg-elevated);
     box-shadow: var(--ant-box-shadow-secondary);
+  }
+
+  // 搜索无匹配时容器为空，与 ant-design 一致地展示 Not Found 提示
+  &-content {
+    &:empty::after {
+      display: block;
+      padding: var(--ant-padding) 0 calc(var(--ant-padding-md) * 2);
+      color: var(--ant-color-text-disabled);
+      text-align: center;
+      border-bottom: 1px solid var(--ant-color-split);
+      content: 'Not Found';
+    }
   }
 }
 


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 📝 站点 / 文档改进

### 🔗 相关 Issue

None

### 💡 背景与方案

组件总览页面的搜索框在没有任何匹配结果时，页面直接空白，没有任何提示反馈；ant-design 官网在相同场景下会显示 "Not Found"。
<img width="2558" height="586" alt="image" src="https://github.com/user-attachments/assets/23d2241d-c616-4cd9-a778-08b7ab51a3b3" />


本变更对齐 ant-design 的实现：为分组列表外层增加 `.components-overview-content` 容器，当搜索过滤后无任何分组（容器为空）时，通过 `:empty::after` 伪元素渲染 "Not Found"。样式与官网一致：禁用文字色、居中、底部 `colorSplit` 分割线、`padding` 上 16px 下 40px，间距与颜色均取自 `--ant-*` token 变量，自动跟随明暗主题。

<img width="2556" height="707" alt="image" src="https://github.com/user-attachments/assets/75cf2eaf-49a4-434a-84bf-400f403195c3" />


### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |