### PR TITLE
fix(docs): add placeholder to cascader semantic preview

### DIFF
--- a/docs/src/pages/components/cascader/demo/_semantic.vue
+++ b/docs/src/pages/components/cascader/demo/_semantic.vue
@@ -69,6 +69,7 @@ const value = computed(() => {
         <div :style="{ display: 'flex', flexDirection: 'column', gap: '12px' }">
           <a-cascader
             prefix="prefix"
+            placeholder="Please select"
             :style="{ width: '300px' }"
             :options="options"
             :value="value"


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 📽️ Demo 改进

### 🔗 相关 Issue

None

### 💡 背景与方案

Cascader 语义化 DOM 预览(/components/cascader-cn#semantic-dom)的语义列表中包含 `placeholder` 条目,但 demo 未向组件传入 placeholder 文本,导致悬停/钉住该条目时无法在预览中定位并高亮 placeholder 元素。
<img width="2551" height="859" alt="image" src="https://github.com/user-attachments/assets/d4b50352-ac64-4343-9c87-23189dc6e98d" />

本次变更为 semantic 预览中的 `<a-cascader>` 显式添加 `placeholder="Please select"`,与 ant-design 官方 `SelectSemanticTemplate` 模板及仓库内 TreeSelect 等同类 semantic demo 的做法保持一致。不涉及组件 API 与行为变化。

<img width="2552" height="943" alt="image" src="https://github.com/user-attachments/assets/9b2b3d23-f9ca-4d33-95ab-b0854e8ac909" />

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |